### PR TITLE
Align native .so LOAD segments to 16 KB (blocks any targetSdk 35+ upload)

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -84,6 +84,11 @@ jobs:
         run: tools/ci/fetch-openssl-statics.sh    # picks up $OPENSSL_ANDROID_ROOT from the image
       - name: Gradle assemble + lint
         run: ./gradlew --no-daemon assembleDebug assembleRelease lint
+      - name: Check 16 KB .so alignment
+        run: |
+          for apk in app/build/outputs/apk/*/*.apk; do
+            tools/ci/check-so-alignment.sh "$apk"
+          done
       - uses: actions/upload-artifact@v4
         with:
           name: apk

--- a/app/src/main/jni/Application.mk
+++ b/app/src/main/jni/Application.mk
@@ -7,3 +7,6 @@
 # at API 24+.
 APP_ABI := arm64-v8a x86_64
 APP_PLATFORM := android-24
+
+# Play requires 16 KB-aligned LOAD segments at targetSdk 35+; r26d's lld still defaults to 4 KB.
+APP_LDFLAGS := -Wl,-z,max-page-size=16384

--- a/tools/ci/check-so-alignment.sh
+++ b/tools/ci/check-so-alignment.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+#
+# Fail if any packaged .so has a LOAD segment aligned below 16 KB. Play rejects those
+# at targetSdk 35+, and nothing in a normal build says so — the regression is silent.
+set -euo pipefail
+
+APK="${1:?usage: $0 <apk>}"
+WANT=16384
+
+# The toolchain image carries the NDK but no binutils, so fall back to its llvm-readelf.
+READELF="$(command -v llvm-readelf || command -v readelf || true)"
+if [ -z "$READELF" ]; then
+    for cand in "${ANDROID_NDK_ROOT:-${ANDROID_NDK_HOME:-/nonexistent}}"/toolchains/llvm/prebuilt/*/bin/llvm-readelf; do
+        [ -x "$cand" ] && READELF="$cand" && break
+    done
+fi
+[ -n "$READELF" ] || {
+    echo "check-so-alignment: no readelf/llvm-readelf found" >&2
+    exit 1
+}
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+unzip -q -o "$APK" 'lib/*' -d "$tmp"
+
+mapfile -t sos < <(find "$tmp/lib" -name '*.so' | sort)
+# An empty list would otherwise "pass" every check below.
+[ "${#sos[@]}" -gt 0 ] || {
+    echo "check-so-alignment: no .so inside $APK" >&2
+    exit 1
+}
+
+rc=0
+for so in "${sos[@]}"; do
+    name="${so#"$tmp"/}"
+    aligns="$("$READELF" -lW "$so" | awk '$1 == "LOAD" { print $NF }')"
+    [ -n "$aligns" ] || {
+        echo "check-so-alignment: no LOAD segments in $name" >&2
+        exit 1
+    }
+    for a in $aligns; do
+        if [ "$((a))" -lt "$WANT" ]; then
+            echo "FAIL $name: LOAD p_align $a < $WANT"
+            rc=1
+        fi
+    done
+done
+
+[ "$rc" -eq 0 ] && echo "16 KB aligned: ${#sos[@]} .so in $(basename "$APK")"
+exit "$rc"

--- a/tools/ci/check-so-alignment.sh
+++ b/tools/ci/check-so-alignment.sh
@@ -23,12 +23,19 @@ tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 unzip -q -o "$APK" 'lib/*' -d "$tmp"
 
+# Cross-check the walk against the archive listing. find's exit status is invisible to set -e
+# from inside a process substitution, so a truncated walk would silently check a subset and
+# still report success; comparing counts asserts completeness, not merely non-emptiness.
+listed="$(unzip -Z1 "$APK" 'lib/*.so' | wc -l)" ||
+    {
+        echo "check-so-alignment: cannot list $APK" >&2
+        exit 1
+    }
 mapfile -t sos < <(find "$tmp/lib" -name '*.so' | sort)
-# An empty list would otherwise "pass" every check below.
-[ "${#sos[@]}" -gt 0 ] || {
-    echo "check-so-alignment: no .so inside $APK" >&2
+if [ "$listed" -le 0 ] || [ "${#sos[@]}" -ne "$listed" ]; then
+    echo "check-so-alignment: $APK lists $listed .so, walked ${#sos[@]}" >&2
     exit 1
-}
+fi
 
 rc=0
 for so in "${sos[@]}"; do

--- a/tools/ci/check-so-alignment.sh
+++ b/tools/ci/check-so-alignment.sh
@@ -21,18 +21,26 @@ fi
 
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
-unzip -q -o "$APK" 'lib/*' -d "$tmp"
+mkdir -p "$tmp/lib"
+# 11 is "nothing matched", which the count check below reports in its own words.
+rc=0
+unzip -q -o "$APK" 'lib/*' -d "$tmp" || rc=$?
+if [ "$rc" -ne 0 ] && [ "$rc" -ne 11 ]; then
+    echo "check-so-alignment: cannot extract $APK (unzip rc=$rc)" >&2
+    exit 1
+fi
 
 # Cross-check the walk against the archive listing. find's exit status is invisible to set -e
 # from inside a process substitution, so a truncated walk would silently check a subset and
 # still report success; comparing counts asserts completeness, not merely non-emptiness.
-listed="$(unzip -Z1 "$APK" 'lib/*.so' | wc -l)" ||
-    {
-        echo "check-so-alignment: cannot list $APK" >&2
-        exit 1
-    }
-mapfile -t sos < <(find "$tmp/lib" -name '*.so' | sort)
-if [ "$listed" -le 0 ] || [ "${#sos[@]}" -ne "$listed" ]; then
+# unzip -Z1 exits 11 when the pattern matches nothing, which is the likely regression here
+# (a build shipping no native libs at all), so name that case rather than blame the archive.
+listed="$(unzip -Z1 "$APK" 'lib/*.so' | wc -l)" || {
+    echo "check-so-alignment: no lib/*.so in $APK, or it is unreadable" >&2
+    exit 1
+}
+mapfile -t sos < <(find "$tmp/lib" -type f -name '*.so' | sort)
+if [ "${#sos[@]}" -ne "$listed" ]; then
     echo "check-so-alignment: $APK lists $listed .so, walked ${#sos[@]}" >&2
     exit 1
 fi


### PR DESCRIPTION
Every `.so` we ship links its LOAD segments at 4 KB, which Play rejects at targetSdk 35+. Play checks ZIP-entry alignment and ELF segment alignment separately, and the first already passed, so the problem was invisible to the checks we had.

The fix is one linker flag on the current NDK r26d. The release APK comes out the same size either way, because lld shifts vaddr rather than file offsets. The `.so` are not byte-identical, since `p_align`, the RW segment `p_vaddr` and the relocations tracking it all move, but nothing is padded or reordered. NDK r28 only makes 16 KB the default, so that bump stays separate.

The CI guard matters as much as the flag, since alignment regresses with no build error. It fails on a 4 KB build and passes on a 16 KB one, and it compares its walk against the archive listing so a partial enumeration cannot pass on a subset.

Known gaps, deliberately out of scope: the guard asserts ELF `p_align` only, while Play also wants ZIP-entry alignment and RELRO. ZIP alignment currently passes on AGP 8.6 defaults rather than on anything we set, so an AGP downgrade or a hand-set packaging option would produce an APK that Play rejects and this guard passes green. Nothing builds or checks an AAB either, and that is the artifact Play actually takes. None of it bites while targetSdk is 25, but all of it wants a tracker note before we upload.