### PR TITLE
Fix notifications before the targetSdk bump (channel, PendingIntent mutability, POST_NOTIFICATIONS)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,6 +8,9 @@
     <!-- We need to connect to the Internet. -->
     <uses-permission android:name="android.permission.INTERNET" />
 
+    <!-- We tell the user when a mirror ends while the app sits in the background. -->
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+
     <!-- We need to check the Internet connection (IPv6 enabled ?). -->
     <!-- NetworkInterface.getNetworkInterfaces() does not need that apparently, so let's remove the permission. -->
     <!-- uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" -->

--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -120,6 +120,9 @@ public class HTTrackActivity extends FragmentActivity {
   // Preferences
   protected static final String PREFS_NAME = "HTTrackPreferences";
   protected static final String BASE_NAME = "BasePath";
+  // Whether POST_NOTIFICATIONS was ever asked for. Has to outlive the activity: pane_id is
+  // restored on rotation, and a second refusal is the one that sticks for good.
+  protected static final String NOTIFY_ASKED_NAME = "NotificationPermissionAsked";
 
   // <br /> Pattern
   protected static final Pattern brHtmlPattern = Pattern.compile(Pattern
@@ -442,16 +445,22 @@ public class HTTrackActivity extends FragmentActivity {
     if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.TIRAMISU) {
       return;
     }
-    final boolean hasPermissionNotify = (ContextCompat.checkSelfPermission(this,
-            Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED);
-    if (!hasPermissionNotify) {
-      Log.d("httrack", "Requesting permission to post notifications");
-      ActivityCompat.requestPermissions(this,
-              new String[]{Manifest.permission.POST_NOTIFICATIONS},
-              REQUEST_POST_NOTIFICATIONS);
-    } else {
+    if (ContextCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS)
+            == PackageManager.PERMISSION_GRANTED) {
       Log.d("httrack", "Posting notifications is allowed");
+      return;
     }
+    // Once only: the user's refusal stands until they revisit it in the system settings.
+    final SharedPreferences settings = getSharedPreferences(PREFS_NAME, 0);
+    if (settings.getBoolean(NOTIFY_ASKED_NAME, false)) {
+      Log.d("httrack", "Permission to post notifications was already declined");
+      return;
+    }
+    settings.edit().putBoolean(NOTIFY_ASKED_NAME, true).apply();
+    Log.d("httrack", "Requesting permission to post notifications");
+    ActivityCompat.requestPermissions(this,
+            new String[]{Manifest.permission.POST_NOTIFICATIONS},
+            REQUEST_POST_NOTIFICATIONS);
   }
 
   /*
@@ -549,9 +558,6 @@ public class HTTrackActivity extends FragmentActivity {
     } catch (final NameNotFoundException e) {
       throw new RuntimeException(e);
     }
-
-    // Register before anything can post: a notification sent to an unknown channel is dropped.
-    createNotificationChannel();
 
     // Compute target directory on external storage
     ensureExternalStorage();
@@ -2710,8 +2716,10 @@ public class HTTrackActivity extends FragmentActivity {
   }
 
   /**
-   * Register the channel every notification below is posted to. Mandatory from API 26 on,
+   * Register the channel the notifications below are posted to. Mandatory from API 26 on,
    * where a channel-less notification is dropped with nothing but a log line; a no-op before.
+   * Idempotent, and called at post time rather than at startup: creating a channel is what
+   * makes the system prompt an app targeting 32 or lower, and launch is too early to ask.
    */
   protected void createNotificationChannel() {
     final NotificationChannelCompat channel = new NotificationChannelCompat.Builder(
@@ -2741,6 +2749,8 @@ public class HTTrackActivity extends FragmentActivity {
   /** Send a notification with a specific Intent. **/
   protected void sendSystemNotification(final Intent intent,
       final CharSequence title, final CharSequence text) {
+
+    createNotificationChannel();
 
     // Create notification
     final long when = System.currentTimeMillis();

--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -90,7 +90,9 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.core.app.ActivityCompat;
+import androidx.core.app.NotificationChannelCompat;
 import androidx.core.app.NotificationCompat;
+import androidx.core.app.NotificationManagerCompat;
 import androidx.core.content.ContextCompat;
 import androidx.core.content.FileProvider;
 import androidx.fragment.app.Fragment;
@@ -125,6 +127,10 @@ public class HTTrackActivity extends FragmentActivity {
   
   // ".nomedia" ; prevents media scanner from reading media files
   public static final String NOMEDIA_FILE = ".nomedia";
+
+  // Channel carrying every notification we post. Never rename: the user's sound/importance
+  // choices are keyed on it, and a new id silently resets them.
+  protected static final String NOTIFICATION_CHANNEL_ID = "mirror";
 
   // Running instances of HTTrack (based on winprofile.ini path)
   protected static final HashSet<String> runningInstances = new HashSet<String>();
@@ -413,6 +419,7 @@ public class HTTrackActivity extends FragmentActivity {
   */
   private static final int REQUEST_WRITE_STORAGE = 1;
   private static final int REQUEST_INTERNET = 2;
+  private static final int REQUEST_POST_NOTIFICATIONS = 3;
 
   protected void ensureMediaIsAllowedHardPermissions() {
     final boolean hasPermissionStorage = (ContextCompat.checkSelfPermission(this,
@@ -424,6 +431,26 @@ public class HTTrackActivity extends FragmentActivity {
               REQUEST_WRITE_STORAGE);
     } else {
       Log.d("httrack", "Access to storage is allowed");
+    }
+  }
+
+  /*
+   * Only a runtime permission from Android 13 on; below that the manifest entry is enough.
+   * Targeting 33+ also drops the automatic prompt, so without this the app posts nothing.
+   */
+  protected void ensureNotificationsAreAllowed() {
+    if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.TIRAMISU) {
+      return;
+    }
+    final boolean hasPermissionNotify = (ContextCompat.checkSelfPermission(this,
+            Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED);
+    if (!hasPermissionNotify) {
+      Log.d("httrack", "Requesting permission to post notifications");
+      ActivityCompat.requestPermissions(this,
+              new String[]{Manifest.permission.POST_NOTIFICATIONS},
+              REQUEST_POST_NOTIFICATIONS);
+    } else {
+      Log.d("httrack", "Posting notifications is allowed");
     }
   }
 
@@ -448,6 +475,14 @@ public class HTTrackActivity extends FragmentActivity {
         } else {
           Log.d("httrack", "Permission to access Internet is granted");
         }
+      }
+      break;
+      // No Toast unlike the two above: a refusal costs only the end-of-mirror notice.
+      case REQUEST_POST_NOTIFICATIONS: {
+        final boolean granted = grantResults.length != 0
+                && grantResults[0] == PackageManager.PERMISSION_GRANTED;
+        Log.d("httrack", "Permission to post notifications is "
+                + (granted ? "granted" : "denied"));
       }
       break;
     }
@@ -514,6 +549,9 @@ public class HTTrackActivity extends FragmentActivity {
     } catch (final NameNotFoundException e) {
       throw new RuntimeException(e);
     }
+
+    // Register before anything can post: a notification sent to an unknown channel is dropped.
+    createNotificationChannel();
 
     // Compute target directory on external storage
     ensureExternalStorage();
@@ -1849,6 +1887,8 @@ public class HTTrackActivity extends FragmentActivity {
       break;
     case R.layout.activity_mirror_progress:
       setProgressLinesInternal(new String[] { getString(R.string.starting_worker_thread) });
+      // Asked at crawl start, not at launch: a refusal is permanent after two of them.
+      ensureNotificationsAreAllowed();
       startRunner();
       if (runner != null) {
         ProgressBar.class.cast(findViewById(R.id.progressMirror))
@@ -2669,6 +2709,17 @@ public class HTTrackActivity extends FragmentActivity {
     return intent;
   }
 
+  /**
+   * Register the channel every notification below is posted to. Mandatory from API 26 on,
+   * where a channel-less notification is dropped with nothing but a log line; a no-op before.
+   */
+  protected void createNotificationChannel() {
+    final NotificationChannelCompat channel = new NotificationChannelCompat.Builder(
+        NOTIFICATION_CHANNEL_ID, NotificationManagerCompat.IMPORTANCE_DEFAULT)
+        .setName(getString(R.string.app_name)).build();
+    NotificationManagerCompat.from(this).createNotificationChannel(channel);
+  }
+
   /** Send a notification. **/
   protected void sendAbortNotification() {
     final String title = getString(R.string.mirror_xxx_stopped).replace("%s",
@@ -2693,12 +2744,13 @@ public class HTTrackActivity extends FragmentActivity {
 
     // Create notification
     final long when = System.currentTimeMillis();
-    final PendingIntent pintent = PendingIntent.getActivity(this, 0, intent, 0);
-    final Notification notification = new NotificationCompat.Builder(this)
-        .setContentTitle(title).setContentText(text).setTicker(title)
-        .setSmallIcon(R.drawable.ic_launcher).setWhen(when)
-        .setContentInfo(getString(R.string.start)).setContentIntent(pintent)
-        .setAutoCancel(true).build();
+    // FLAG_IMMUTABLE: mandatory from API 31 on, and the extras are only ever read back by us.
+    final PendingIntent pintent = PendingIntent.getActivity(this, 0, intent,
+        PendingIntent.FLAG_IMMUTABLE);
+    final Notification notification = new NotificationCompat.Builder(this,
+        NOTIFICATION_CHANNEL_ID).setContentTitle(title).setContentText(text)
+        .setTicker(title).setSmallIcon(R.drawable.ic_launcher).setWhen(when)
+        .setContentIntent(pintent).setAutoCancel(true).build();
 
     // Send
     final NotificationManager manager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);

--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -450,13 +450,13 @@ public class HTTrackActivity extends FragmentActivity {
       Log.d("httrack", "Posting notifications is allowed");
       return;
     }
-    // Once only: the user's refusal stands until they revisit it in the system settings.
-    final SharedPreferences settings = getSharedPreferences(PREFS_NAME, 0);
-    if (settings.getBoolean(NOTIFY_ASKED_NAME, false)) {
-      Log.d("httrack", "Permission to post notifications was already declined");
+    // Ask once: a refusal stands until the user revisits it in the system settings. The latch
+    // is set from the result below, not here, so dismissing the dialog (which Android does not
+    // count as a refusal) leaves it to be offered again rather than silently lost.
+    if (getSharedPreferences(PREFS_NAME, 0).getBoolean(NOTIFY_ASKED_NAME, false)) {
+      Log.d("httrack", "Permission to post notifications was already answered");
       return;
     }
-    settings.edit().putBoolean(NOTIFY_ASKED_NAME, true).apply();
     Log.d("httrack", "Requesting permission to post notifications");
     ActivityCompat.requestPermissions(this,
             new String[]{Manifest.permission.POST_NOTIFICATIONS},
@@ -488,10 +488,12 @@ public class HTTrackActivity extends FragmentActivity {
       break;
       // No Toast unlike the two above: a refusal costs only the end-of-mirror notice.
       case REQUEST_POST_NOTIFICATIONS: {
-        final boolean granted = grantResults.length != 0
-                && grantResults[0] == PackageManager.PERMISSION_GRANTED;
-        Log.d("httrack", "Permission to post notifications is "
-                + (granted ? "granted" : "denied"));
+        // An empty result is a dismissal, not an answer, so leave the latch clear and re-offer.
+        if (grantResults.length != 0) {
+          getSharedPreferences(PREFS_NAME, 0).edit().putBoolean(NOTIFY_ASKED_NAME, true).apply();
+          Log.d("httrack", "Permission to post notifications is "
+                  + (grantResults[0] == PackageManager.PERMISSION_GRANTED ? "granted" : "denied"));
+        }
       }
       break;
     }


### PR DESCRIPTION
Three things that break notifications at targetSdk 36, landing ahead of the bump so that the bump itself stays a one-variable change.

The `PendingIntent` is the one that matters: a bare `0` flag throws from API 31 on, and one of the three callers is `RunnerFragment.onDestroy`, so this is a crash on every aborted crawl rather than a lost notification. Lint has been flagging it as `UnspecifiedImmutableFlag` all along, unnoticed because `abortOnError` is false. The other two are silent by nature: a channel-less notification is dropped from API 26 with only a log line, and `POST_NOTIFICATIONS` needs an explicit request, since targeting 33+ removes the automatic prompt.

Everything lands in `sendSystemNotification()`, the single sink for every notification the app posts. (`showNotification()` is a Toast despite the name, so its call sites are untouched.) The permission is requested at crawl start rather than at launch, once per install and latched in preferences: the activity has no `configChanges`, so a rotation would otherwise re-enter the progress pane and re-ask, and the second refusal is the one that sticks for good. The channel is registered at post time for the same reason, since creating a channel is what makes the system prompt an app targeting 32 or lower, and because the save-failure notification can fire without any crawl having run.

This is **not** inert on current devices, contrary to what the first commit assumed: androidx branches on the device `SDK_INT` and never on targetSdk, so on any API 26+ device the notifications now carry a real channel and the app gains an entry in the system notification settings. Master is in fact silently broken on Android 13 today, creating no channel and therefore never getting the system's own permission dialog, so a fresh install posts nothing at all. This PR is what fixes that.

Verified by differential: lint reports `UnspecifiedImmutableFlag` once on master and zero here, and `POST_NOTIFICATIONS` appears in the merged manifest of the built APK with `targetSdkVersion` still 25. The channel and the prompt cannot be exercised without a device, so they rest on the API contract rather than on observation.

Left alone deliberately, each wanting its own PR: the abort `PendingIntent` reuses request code `0` without `FLAG_UPDATE_CURRENT`, so a second abort notification carries the first one's extras and tapping it restores the wrong project (pre-existing, master behaves identically), and the mirror-finished intent carries no extras at all, which is what its `FIXME` says.