### PR TITLE
Route back through the AndroidX dispatcher (predictive back silently kills both overrides at 36)

### DIFF
--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -89,6 +89,7 @@ import android.widget.RadioGroup;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.core.app.ActivityCompat;
 import androidx.core.app.NotificationCompat;
 import androidx.core.content.ContextCompat;
@@ -496,6 +497,8 @@ public class HTTrackActivity extends FragmentActivity {
   protected void onCreate(final Bundle savedInstanceState) {
     Log.d(getClass().getSimpleName(), "onCreate");
     super.onCreate(savedInstanceState);
+
+    getOnBackPressedDispatcher().addCallback(this, stayAliveWhileMirroring);
 
     // Attempt to load the native library.
     // Fetch httrack engine version
@@ -2159,6 +2162,7 @@ public class HTTrackActivity extends FragmentActivity {
 
       // Switch pane
       pane_id = position;
+      stayAliveWhileMirroring.setEnabled(pane_id == LAYOUT_MIRROR_PROGRESS);
       setContentView(layouts[pane_id]);
 
       // Entering a new pane: restore data
@@ -2827,14 +2831,14 @@ public class HTTrackActivity extends FragmentActivity {
     startActivity(intent);
   }
 
-  @Override
-  public void onBackPressed() {
-    // Downloading data
-    if (pane_id == LAYOUT_MIRROR_PROGRESS) {
-      // Do not go home, or our fragment will die.
+  /*
+   * Enabled only on the progress pane, where finishing would take the retained fragment, and
+   * the crawl with it, down. Everywhere else it stays disabled so back does its usual thing.
+   */
+  private final OnBackPressedCallback stayAliveWhileMirroring = new OnBackPressedCallback(false) {
+    @Override
+    public void handleOnBackPressed() {
       goToHome();
-    } else {
-      super.onBackPressed();
     }
-  }
+  };
 }

--- a/app/src/main/java/com/httrack/android/OptionsActivity.java
+++ b/app/src/main/java/com/httrack/android/OptionsActivity.java
@@ -44,10 +44,16 @@ import android.widget.Button;
 import android.widget.EditText;
 import android.widget.LinearLayout;
 
+import androidx.activity.OnBackPressedCallback;
+import androidx.fragment.app.FragmentActivity;
+
 /**
  * The options activity.
+ *
+ * FragmentActivity rather than Activity: predictive back is dispatched through the AndroidX
+ * OnBackPressedDispatcher, which a plain Activity does not have.
  */
-public class OptionsActivity extends Activity implements View.OnClickListener {
+public class OptionsActivity extends FragmentActivity implements View.OnClickListener {
   /* List of all tabs. */
   @SuppressWarnings("unchecked")
   protected static Class<? extends Tab>[] tabClasses = new Class[] {
@@ -335,6 +341,8 @@ public class OptionsActivity extends Activity implements View.OnClickListener {
   protected void onCreate(final Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
 
+    getOnBackPressedDispatcher().addCallback(this, backCallback);
+
     // Large screen ? Enable special tablet features in such case...
     // "xlarge screens are at least 960dp x 720dp"
     isTabletMode = getResources().getBoolean(R.bool.isTablet)
@@ -388,27 +396,28 @@ public class OptionsActivity extends Activity implements View.OnClickListener {
   }
 
   /**
-   * Override back to propagate settings. <br />
-   * FIXME: we should probably do better than that!
+   * Back propagates the settings, and on a sub-tab returns to the menu rather than leaving.
+   * Always enabled: neither branch wants the default, which would finish without saving.
    */
-  @Override
-  public void onBackPressed() {
-    // Back from activity
-    if (isTabletMode || activityClass == null) {
-      if (isTabletMode && activityClass != null) {
-        save();
+  private final OnBackPressedCallback backCallback = new OnBackPressedCallback(true) {
+    @Override
+    public void handleOnBackPressed() {
+      // Back from activity. finish() is overridden above to carry the settings back.
+      if (isTabletMode || activityClass == null) {
+        if (isTabletMode && activityClass != null) {
+          save();
+        }
+        finish();
       }
-      super.onBackPressed();
-      finish();
+      // Leave sub-activity (activityClass != null)
+      else {
+        notifyHideTab();
+        save();
+        activityClass = null;
+        setViewMenu();
+      }
     }
-    // Leave sub-activity (activityClass != null)
-    else {
-      notifyHideTab();
-      save();
-      activityClass = null;
-      setViewMenu();
-    }
-  }
+  };
 
   /*
    * Return current field ID's for the activity view.


### PR DESCRIPTION
At targetSdk 36 `enableOnBackInvokedCallback` defaults to true and the system stops calling `onBackPressed()`, so both of the app's overrides quietly stop running. No crash, no log, nothing a build or lint check can see. Landing it now, while the target is still 25 and the AndroidX dispatcher is already the path back takes, keeps the eventual bump a one-variable change.

`OptionsActivity` loses the most. Its override calls `save()`, and its `else` branch is the entire "leave a sub-tab" navigation, so bypassed it would both drop the settings and walk out of the options screen instead of returning to the menu. It extended the framework `Activity`, which has no `OnBackPressedDispatcher` at all, so it moves to `FragmentActivity`; it uses no fragments, and nothing else about it changes. The branch that called `super.onBackPressed()` and then `finish()` now simply finishes, which is what that pair amounted to, and `finish()` is overridden there to carry the settings back.

`HTTrackActivity` is a `FragmentActivity` already, but that does not save it: the dispatcher does not re-enter a subclass override either, so its guard against finishing mid-crawl (the retained fragment holds the runner) was equally dead. Rather than intercept every back and re-dispatch the ones it does not want, its callback is enabled only on the progress pane, which is the condition the old `if` was really expressing.

The result is one path for both eras: with no override left, `ComponentActivity` routes today's back through the same dispatcher that `OnBackInvokedCallback` reaches at 36.

Verified: no `onBackPressed` override remains, and lint is unchanged against master (2 errors, 10 fatal `Instantiatable`, all pre-existing). Behaviour needs a device, which is not available yet.
