### PR TITLE
Write the emergency dump somewhere it can actually land

### DIFF
--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -891,18 +891,25 @@ public class HTTrackActivity extends FragmentActivity {
   }
 
   /**
-   * Emergency dump.
+   * Emergency dump, into storage of our own: this runs on a crash path, so it must not depend
+   * on a permission, nor on a volume being mounted.
+   *
+   * @param context
+   *          null while the activity is being torn down, in which case nothing is written
+   * @param e
+   *          the throwable to record
    */
-  protected static void emergencyDump(final Throwable e) {
-    try {
-      final File dumpFile = new File(new File(
-          Environment.getExternalStorageState(), "HTTrack"), "error.txt");
-      final FileWriter writer = new FileWriter(dumpFile);
-      final PrintWriter print = new PrintWriter(writer);
+  protected static void emergencyDump(final Context context, final Throwable e) {
+    if (context == null) {
+      return;
+    }
+    final File external = context.getExternalFilesDir(null);
+    final File dumpFile = new File(
+        external != null ? external : context.getFilesDir(), "error.txt");
+    try (final PrintWriter print = new PrintWriter(new FileWriter(dumpFile))) {
       e.printStackTrace(print);
-      writer.close();
-      HTTrackActivity.setFileReadWrite(dumpFile);
     } catch (final IOException io) {
+      Log.w(HTTrackActivity.class.getSimpleName(), "could not write " + dumpFile, io);
     }
   }
 
@@ -1106,7 +1113,7 @@ public class HTTrackActivity extends FragmentActivity {
       try {
         runInternal();
       } catch (final RuntimeException e) {
-        HTTrackActivity.emergencyDump(e);
+        HTTrackActivity.emergencyDump(parent, e);
         throw e;
       } finally {
         ended = true;

--- a/app/src/main/jni/htslibjni.c
+++ b/app/src/main/jni/htslibjni.c
@@ -29,6 +29,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
 
 #include <android/log.h>
 
@@ -64,10 +66,16 @@ static void log_assert_failure(const char* exp, const char* file, int line) {
   __android_log_print(ANDROID_LOG_VERBOSE, "httrack", "assertion '%s' failed at %s:%d", exp, file, line);
   /* Nothing is writable before initRootPath(); logcat above carries it either way. */
   if (emergencyLog != NULL) {
-    FILE *const dumpFile = fopen(emergencyLog, "wb");
-    if (dumpFile != NULL) {
-      fprintf(dumpFile, "assertion '%s' failed at %s:%d\n", exp, file, line);
-      fclose(dumpFile);
+    /* Owner-only (0600): a crash log created with fopen's default 0666 is world-writable. */
+    const int fd = open(emergencyLog, O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR);
+    if (fd != -1) {
+      FILE *const dumpFile = fdopen(fd, "wb");
+      if (dumpFile != NULL) {
+        fprintf(dumpFile, "assertion '%s' failed at %s:%d\n", exp, file, line);
+        fclose(dumpFile);
+      } else {
+        close(fd);
+      }
     }
   }
 }

--- a/app/src/main/jni/htslibjni.c
+++ b/app/src/main/jni/htslibjni.c
@@ -62,15 +62,13 @@ static char *rootPath = NULL;
 /* log assertion failure. */
 static void log_assert_failure(const char* exp, const char* file, int line) {
   __android_log_print(ANDROID_LOG_VERBOSE, "httrack", "assertion '%s' failed at %s:%d", exp, file, line);
-#define MKDIR_MODE (S_IRUSR|S_IWUSR|S_IXUSR|S_IRGRP|S_IXGRP|S_IROTH|S_IXOTH)
-  /* FIXME TODO: pass the getExternalStorageDirectory() in init. */
-  FILE *dumpFile;
-  const char *const filename = emergencyLog != NULL ? emergencyLog
-    : "/mnt/sdcard/Download/HTTrack/error.txt";
-  dumpFile = fopen(filename, "wb");
-  if (dumpFile != NULL) {
-    fprintf(dumpFile, "assertion '%s' failed at %s:%d\n", exp, file, line);
-    fclose(dumpFile);
+  /* Nothing is writable before initRootPath(); logcat above carries it either way. */
+  if (emergencyLog != NULL) {
+    FILE *const dumpFile = fopen(emergencyLog, "wb");
+    if (dumpFile != NULL) {
+      fprintf(dumpFile, "assertion '%s' failed at %s:%d\n", exp, file, line);
+      fclose(dumpFile);
+    }
   }
 }
 


### PR DESCRIPTION
`emergencyDump()` passed `Environment.getExternalStorageState()` into `new File()`. That returns the status string, `"mounted"`, so the dump aimed at the relative path `mounted/HTTrack/error.txt`, resolved against the process working directory of `/`, where `FileWriter` threw straight into an empty `catch`. It has never written a file, on any release. The catch now logs, since the silence is what hid it for nine years.

Being `static`, it had no `Context` to ask for a directory, which is plausibly how it drifted there in the first place. It now takes the `Runner`'s parent activity and writes into our own external directory, falling back to the internal one. A crash path should not depend on a permission or on a volume being mounted, and this one no longer does.

The JNI glue had the same hole from the other side: assertion failures fell back to a hardcoded `/mnt/sdcard/Download/HTTrack/error.txt`, a storage layout gone since KitKat, whose `fopen` has failed quietly ever since. Once `initRootPath()` has run, `emergencyLog` already points into the mirror root; before it, there is nowhere we may legally write, and logcat carries the assertion either way. `MKDIR_MODE` went with it, having had no users.

Demonstrated rather than argued, since the failure is invisible by construction:

```
old target      : mounted/HTTrack/error.txt
  isAbsolute    : false
  resolves to   : <cwd>/mounted/HTTrack/error.txt
  FileWriter    : throws FileNotFoundException -> swallowed by the empty catch
```

No tracker issue matches these symptoms in either repo, so there is nothing to close. Independent of the storage PRs, and compatible with either root. The new path needs a device to confirm end to end, which is not available yet.
