### PR TITLE
Make the legacy-import re-entry guard survive activity recreation

### DIFF
--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -2270,17 +2270,24 @@ public class HTTrackActivity extends FragmentActivity {
       showNotification(getString(R.string.import_mirrors_running));
       return;
     }
-    showNotification(getString(R.string.import_mirrors_running));
-    new Thread(new Runnable() {
-      @Override
-      public void run() {
-        try {
-          deliverImportOutcome(appContext, runImport(appContext, resolver, treeUri, dest));
-        } finally {
-          importInProgress.set(false);
+    // Release the process-wide guard if the worker never starts (e.g. OOM at thread creation);
+    // otherwise a failed launch would wedge it true for the rest of the process.
+    try {
+      showNotification(getString(R.string.import_mirrors_running));
+      new Thread(new Runnable() {
+        @Override
+        public void run() {
+          try {
+            deliverImportOutcome(appContext, runImport(appContext, resolver, treeUri, dest));
+          } finally {
+            importInProgress.set(false);
+          }
         }
-      }
-    }, "legacy-import").start();
+      }, "legacy-import").start();
+    } catch (final Throwable t) {
+      importInProgress.set(false);
+      throw t;
+    }
   }
 
   /** The copy itself, on the worker thread; returns the message to show. **/

--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -42,6 +42,7 @@ import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
@@ -2250,7 +2251,8 @@ public class HTTrackActivity extends FragmentActivity {
     }
   }
 
-  private volatile boolean importInProgress;
+  // Process-wide: a rotation recreates the activity, but the detached worker keeps copying.
+  private static final AtomicBoolean importInProgress = new AtomicBoolean();
 
   /**
    * Copy the picked tree into our Websites directory, entirely off the UI thread: even walking
@@ -2259,26 +2261,24 @@ public class HTTrackActivity extends FragmentActivity {
    * threads would race on the same temp files.
    */
   private void importMirrorsFrom(final Uri treeUri) {
-    if (importInProgress) {
-      showNotification(getString(R.string.import_mirrors_running));
-      return;
-    }
     final ContentResolver resolver = getContentResolver();
     resolver.takePersistableUriPermission(treeUri, Intent.FLAG_GRANT_READ_URI_PERMISSION);
     final Context appContext = getApplicationContext();
     final File dest = getProjectRootFile();
-    importInProgress = true;
+    // Claim the guard last, so a synchronous throw above cannot wedge it.
+    if (!importInProgress.compareAndSet(false, true)) {
+      showNotification(getString(R.string.import_mirrors_running));
+      return;
+    }
     showNotification(getString(R.string.import_mirrors_running));
     new Thread(new Runnable() {
       @Override
       public void run() {
-        String outcome;
         try {
-          outcome = runImport(appContext, resolver, treeUri, dest);
+          deliverImportOutcome(appContext, runImport(appContext, resolver, treeUri, dest));
         } finally {
-          importInProgress = false;
+          importInProgress.set(false);
         }
-        deliverImportOutcome(appContext, outcome);
       }
     }, "legacy-import").start();
   }


### PR DESCRIPTION
`importInProgress` was a per-instance field. Since the activity declares no `configChanges`, a rotation during a long import recreated it with the flag reset while the detached worker kept copying, and the always-live Import menu then let a second worker start and race the first onto the same `.part` file. The loser leaves a short file behind that `dest.exists()` treats as complete on every future run.

It is now a `static AtomicBoolean`, claimed with `compareAndSet` and cleared in the worker's `finally`, so a recreated activity sees the in-flight import and a failed import cannot wedge the guard. The claim moved after the idempotent SAF setup so a throw there cannot wedge it either.

From the pre-KVM audit (finding #5, medium). The rotate-mid-import scenario needs a device to confirm end to end; the repo has no instrumentation suite.
