### PR TITLE
Harden two hostile-input paths reaching the crawl (project name, UTF-8)

### DIFF
--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -801,6 +801,11 @@ public class HTTrackActivity extends FragmentActivity {
   protected File getTargetFile() {
     final String name = mapper.getProjectName();
     if (name != null && name.length() != 0) {
+      // Backstop: a name that is not a single in-root segment must never become an -O path.
+      if (!StoragePaths.isValidProjectName(name)) {
+        Log.w(getClass().getSimpleName(), "rejecting unsafe project name: " + name);
+        return null;
+      }
       return new File(getProjectRootFile(), name);
     } else {
       return null;
@@ -2139,6 +2144,11 @@ public class HTTrackActivity extends FragmentActivity {
           } finally {
             dirtyNamePane = false;
           }
+        }
+        // A crafted winprofile.ini can overwrite the name with a path that escapes the root.
+        if (!StoragePaths.isValidProjectName(mapper.getProjectName())) {
+          showNotification(getString(R.string.invalid_project_name), true);
+          return false;
         }
         return true;
       }

--- a/app/src/main/java/com/httrack/android/StoragePaths.java
+++ b/app/src/main/java/com/httrack/android/StoragePaths.java
@@ -40,4 +40,26 @@ final class StoragePaths {
     }
     return external != null ? Boolean.FALSE : null;
   }
+
+  /**
+   * Whether {@code name} is safe to append to a root as one directory. File does not fold "..", so
+   * a crafted winprofile.ini name like "../../sdcard/evil" would otherwise steer the engine's -O
+   * outside the Websites tree. Rejects empty, ".", ".." and anything carrying a path separator.
+   *
+   * @param name
+   *          the project name, already whitespace-collapsed
+   * @return true if it denotes a single, in-root directory segment
+   */
+  static boolean isValidProjectName(final String name) {
+    if (name == null || name.isEmpty() || name.equals(".") || name.equals("..")) {
+      return false;
+    }
+    for (int i = 0; i < name.length(); i++) {
+      final char c = name.charAt(i);
+      if (c == '/' || c == '\\' || c == '\0') {
+        return false;
+      }
+    }
+    return true;
+  }
 }

--- a/app/src/main/jni/htslibjni-private.h
+++ b/app/src/main/jni/htslibjni-private.h
@@ -181,9 +181,12 @@ static char *sanitizeModifiedUtf8(const char *s) {
 static jobject newStringSafe(JNIEnv *env, const char *s) {
   if (s != NULL) {
     char *const safe = sanitizeModifiedUtf8(s);
-    jobject str = (*env)->NewStringUTF(env, safe != NULL ? safe : s);
-    free(safe);
-    return str;
+    /* On OOM, a null field beats feeding raw (possibly hostile) bytes to NewStringUTF. */
+    if (safe != NULL) {
+      jobject str = (*env)->NewStringUTF(env, safe);
+      free(safe);
+      return str;
+    }
   }
   return NULL;
 }

--- a/app/src/main/jni/htslibjni-private.h
+++ b/app/src/main/jni/htslibjni-private.h
@@ -137,15 +137,52 @@ typedef struct hts_state_t {
   const char *message;
 } hts_state_t;
 
-/* NewStringUTF, but ignore invalid UTF-8 or NULL input. */
+/* Sanitize server-controlled bytes to well-formed modified UTF-8 (invalid sequences, including
+   4-byte forms, become '?'), so hostile input cannot reach NewStringUTF, which aborts under
+   CheckJNI. Caller frees the result. */
+static char *sanitizeModifiedUtf8(const char *s) {
+  const size_t len = strlen(s);
+  char *const out = malloc(len + 1);
+  if (out != NULL) {
+    const unsigned char *const in = (const unsigned char *) s;
+    size_t i = 0, j = 0;
+    while (i < len) {
+      const unsigned char c = in[i];
+      unsigned int seq = 0;
+      if (c <= 0x7F) {
+        seq = 1;
+      } else if (c >= 0xC2 && c <= 0xDF) {
+        if (i + 1 < len && (in[i + 1] & 0xC0) == 0x80) {
+          seq = 2;
+        }
+      } else if (c >= 0xE0 && c <= 0xEF) {
+        /* Reject overlong E0 80..9F; surrogate halves (ED A0..BF) stay, they are valid here. */
+        const unsigned char lo = (c == 0xE0) ? 0xA0 : 0x80;
+        if (i + 2 < len && in[i + 1] >= lo && (in[i + 1] & 0xC0) == 0x80
+            && (in[i + 2] & 0xC0) == 0x80) {
+          seq = 3;
+        }
+      }
+      if (seq != 0) {
+        for (unsigned int k = 0; k < seq; k++) {
+          out[j++] = (char) in[i++];
+        }
+      } else {
+        out[j++] = '?';
+        i++;
+      }
+    }
+    out[j] = '\0';
+  }
+  return out;
+}
+
+/* NewStringUTF over sanitized bytes, so hostile input cannot reach it; NULL input yields NULL. */
 static jobject newStringSafe(JNIEnv *env, const char *s) {
   if (s != NULL) {
-    const int ne = ! (*env)->ExceptionOccurred(env);
-    jobject str = (*env)->NewStringUTF(env, s);
-    /* Silently ignore UTF-8 exception. */
-    if (str == NULL && (*env)->ExceptionOccurred(env) && ne) {
-      (*env)->ExceptionClear(env);
-    }
+    char *const safe = sanitizeModifiedUtf8(s);
+    jobject str = (*env)->NewStringUTF(env, safe != NULL ? safe : s);
+    free(safe);
     return str;
   }
   return NULL;

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -184,6 +184,7 @@
     <string name="could_not_write_to">Could not write to:</string>
     <string name="read_only_storage_media">Read-only media (SDCARD)</string>
     <string name="no_storage_media">No storage media (SDCARD)</string>
+    <string name="invalid_project_name">Invalid project name: it must not contain \'/\', \'\\\' or \'..\'</string>
     <string name="may_not_download_until_problem_fixed">HTTrack may not be able to download websites until this problem is fixed</string>
     <string name="mirror_xxx_stopped">HTTrack: mirror \'%s\' stopped!</string>
     <string name="click_on_notification_to_restart">Click on this notification to restart the interrupted mirror</string>

--- a/app/src/test/java/com/httrack/android/ProjectNameTest.java
+++ b/app/src/test/java/com/httrack/android/ProjectNameTest.java
@@ -1,0 +1,38 @@
+package com.httrack.android;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/** Attacks StoragePaths.isValidProjectName: a name is one in-root directory segment, nothing more. */
+public class ProjectNameTest {
+  @Test
+  public void acceptsAPlainName() {
+    assertTrue(StoragePaths.isValidProjectName("My Website"));
+    assertTrue(StoragePaths.isValidProjectName("..dotdot..name"));
+    assertTrue(StoragePaths.isValidProjectName("a.b.c"));
+  }
+
+  @Test
+  public void refusesEmptyOrDotSegments() {
+    assertFalse(StoragePaths.isValidProjectName(null));
+    assertFalse(StoragePaths.isValidProjectName(""));
+    assertFalse(StoragePaths.isValidProjectName("."));
+    assertFalse(StoragePaths.isValidProjectName(".."));
+  }
+
+  /** The discriminating case: no separator, yet still a traversal a naive '/'-only check would miss. */
+  @Test
+  public void refusesABareParentSegment() {
+    assertFalse(StoragePaths.isValidProjectName(".."));
+  }
+
+  @Test
+  public void refusesAnyPathSeparator() {
+    assertFalse(StoragePaths.isValidProjectName("../../../../sdcard/Android/data/evil"));
+    assertFalse(StoragePaths.isValidProjectName("a/b"));
+    assertFalse(StoragePaths.isValidProjectName("a\\b"));
+    assertFalse(StoragePaths.isValidProjectName("evil\0hidden"));
+  }
+}

--- a/app/src/test/java/com/httrack/android/ProjectNameTest.java
+++ b/app/src/test/java/com/httrack/android/ProjectNameTest.java
@@ -22,12 +22,6 @@ public class ProjectNameTest {
     assertFalse(StoragePaths.isValidProjectName(".."));
   }
 
-  /** The discriminating case: no separator, yet still a traversal a naive '/'-only check would miss. */
-  @Test
-  public void refusesABareParentSegment() {
-    assertFalse(StoragePaths.isValidProjectName(".."));
-  }
-
   @Test
   public void refusesAnyPathSeparator() {
     assertFalse(StoragePaths.isValidProjectName("../../../../sdcard/Android/data/evil"));


### PR DESCRIPTION
Two hostile-input paths that a crawled server can drive.

The project name becomes the engine's `-O` destination with no validation, and `File` does not fold `..`, so a name like `../../sdcard/evil` writes outside the Websites tree. It is typeable, and a crafted `winprofile.ini` supplies it without the user typing anything, since the profile load overwrites the name in the map. A pure `StoragePaths.isValidProjectName` now rejects empty, `.`, `..`, and any path separator. It is enforced when advancing past the name pane (with a message) and as a backstop in `getTargetFile`, where the crawl aborts cleanly rather than escaping. A unit test covers it, and it is mutation-checked: a naive `/`-only validator fails the bare-`..` case.

`newStringSafe` relied on `NewStringUTF` raising a Java exception on malformed modified UTF-8, which it does not, so its guard was dead code and its "ignore invalid UTF-8" contract was false. `build_stats()` feeds it server-controlled bytes (Content-Type, charset, HTTP status, URLs). It now sanitizes to well-formed modified UTF-8 first (invalid sequences become `?`), so hostile bytes cannot reach `NewStringUTF` and trip a CheckJNI abort.

From the pre-KVM audit (findings #7, #8, medium). The real abort-vs-clean-String behavior and the profile-import rejection need a device to confirm; the validator and the sanitizer are covered by the `-Werror` native build and the JUnit test.
