### PR TITLE
targetSdk 35 + signed AAB for a Play closed beta

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ workspace.xml
 #   per-ABI OpenSSL statics from the toolchain image / fetch-openssl-statics.sh
 /app/src/main/jni/libiconv-1.17/
 /app/src/main/prebuild/
+
+# Signing secrets (never commit); see keystore.properties.sample.
+/keystore.properties

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,14 +12,32 @@ android {
     defaultConfig {
         applicationId "com.httrack.android"
         minSdk 24
-        // Left at master's value: 26 would silently drop the channel-less notifications,
-        // and 29 would take legacy storage away from the still File-based crawl.
-        targetSdk 25
-        versionCode 63
-        versionName "3.49.02.63"
+        // Play's upload floor. The behaviour changes crossed to here are handled: notification
+        // channels + POST_NOTIFICATIONS (#10), scoped storage (#11), predictive back (#12);
+        // edge-to-edge (35) is opted out in values-v35 until the layouts handle window insets.
+        targetSdk 35
+        // Must exceed the versionCode currently live on the Play listing before uploading.
+        versionCode 64
+        versionName "3.49.02.64"
 
         ndk {
             abiFilters "arm64-v8a", "x86_64"
+        }
+    }
+
+    // Release signing reads a gitignored keystore.properties (see keystore.properties.sample).
+    // Without it — e.g. on CI — the release stays unsigned, exactly as before.
+    signingConfigs {
+        release {
+            def propsFile = rootProject.file('keystore.properties')
+            if (propsFile.exists()) {
+                final Properties props = new Properties()
+                props.load(new FileInputStream(propsFile))
+                storeFile rootProject.file(props.getProperty('storeFile'))
+                storePassword props.getProperty('storePassword')
+                keyAlias props.getProperty('keyAlias')
+                keyPassword props.getProperty('keyPassword')
+            }
         }
     }
 
@@ -27,6 +45,9 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            if (rootProject.file('keystore.properties').exists()) {
+                signingConfig signingConfigs.release
+            }
         }
     }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,6 +33,13 @@ android {
             if (propsFile.exists()) {
                 final Properties props = new Properties()
                 props.load(new FileInputStream(propsFile))
+                // Fail loudly on an incomplete file: a missing key otherwise yields a silently
+                // unsigned AAB (AGP skips signing when the config is not ready), which Play rejects.
+                ['storeFile', 'storePassword', 'keyAlias', 'keyPassword'].each { k ->
+                    if (!props.getProperty(k)?.trim()) {
+                        throw new GradleException("keystore.properties is missing '${k}'")
+                    }
+                }
                 storeFile rootProject.file(props.getProperty('storeFile'))
                 storePassword props.getProperty('storePassword')
                 keyAlias props.getProperty('keyAlias')

--- a/app/src/main/res/values-v35/styles.xml
+++ b/app/src/main/res/values-v35/styles.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- targetSdk 35 forces edge-to-edge; opt out until the layouts handle window insets. -->
+    <style name="AppTheme" parent="AppBaseTheme">
+        <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
+    </style>
+</resources>

--- a/keystore.properties.sample
+++ b/keystore.properties.sample
@@ -1,0 +1,6 @@
+# Copy to keystore.properties (gitignored) to sign a release APK / AAB for a Play upload.
+# Use the dedicated UPLOAD keystore (not the 2013 app-signing key). See the signing-key notes.
+storeFile=/absolute/path/to/httrack-upload.jks
+storePassword=CHANGEME
+keyAlias=upload
+keyPassword=CHANGEME


### PR DESCRIPTION
Makes the app uploadable to a Play closed-testing track so Phase 4 and the audit fixes can finally be exercised on a real device.

Raises `targetSdk` 25 to 35, which is Play's upload floor (it rejects anything lower at upload time, on any track). Everything this crosses is already handled on master: notification channels and `POST_NOTIFICATIONS`, scoped storage, and predictive back. The one thing 35 forces that the layouts do not yet handle is edge-to-edge, so it is opted out with `android:windowOptOutEdgeToEdgeEnforcement` in `values-v35`. That opt-out works at 35 and is ignored at 36, so the inset work is still owed before a 36 bump, but it is not needed for this beta. `versionCode` goes to 64.

Release builds gain a `signingConfig` that reads a gitignored `keystore.properties` (a sample is committed), so `./gradlew bundleRelease` produces a signed AAB locally. Without that file the release stays unsigned, so CI is unchanged. The shipped `.so` remain 16 KB aligned (checked in the produced AAB), which 35 makes mandatory.

Verified: build and unit tests green, the built APK reports `targetSdkVersion 35`, `bundleRelease` produces an AAB, and all six `.so` in it read `p_align 0x4000`. What it does at runtime on a device is exactly what the beta is for; nothing here has been observed on hardware yet.

To publish: create `keystore.properties` from the sample pointing at the upload keystore, run `bundleRelease`, and upload the AAB to a closed-testing track. Confirm the versionCode exceeds whatever is live on the listing, and confirm the upload-key cert is registered in the Console.

Not for production promotion.
