### PR TITLE
ci: fix Play publish alignment step failing under dash

### DIFF
--- a/.github/workflows/play-publish.yml
+++ b/.github/workflows/play-publish.yml
@@ -59,7 +59,7 @@ jobs:
         run: ./gradlew --no-daemon bundleRelease
       - name: Assert 16 KB .so alignment in the AAB
         run: |
-          set -euo pipefail
+          set -eu    # steps run under dash here; no pipefail (a readelf failure yields a="" -> $((a))=0, still trips the guard)
           aab=app/build/outputs/bundle/release/app-release.aab
           readelf="$(command -v llvm-readelf || command -v readelf || true)"
           [ -n "$readelf" ] || readelf="$(ls "${ANDROID_NDK_ROOT:-/nonexistent}"/toolchains/llvm/prebuilt/*/bin/llvm-readelf 2>/dev/null | head -1)"


### PR DESCRIPTION
The SDK container runs workflow `run:` steps under `/bin/sh` (dash), which rejects `set -o pipefail`. The 16 KB alignment assert exited 2, so the first tag build (v3.49.02.64) never uploaded the AAB. Dropping pipefail is safe: the step already fails closed on a readelf error, since empty output makes `$((a))` evaluate to 0, below the 16384 guard.

Verified the remaining constructs (hex arithmetic, `command -v`, the find loop) run under dash.