### PR TITLE
storage: write mirrors to public storage so other apps can use them

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,8 +17,8 @@ android {
         // edge-to-edge (35) is opted out in values-v35 until the layouts handle window insets.
         targetSdk 35
         // Must exceed the versionCode currently live on the Play listing before uploading.
-        versionCode 64
-        versionName "3.49.02.64"
+        versionCode 65
+        versionName "3.49.02.65"
 
         ndk {
             abiFilters "arm64-v8a", "x86_64"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,6 +8,13 @@
     <!-- We tell the user when a mirror ends while the app sits in the background. -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
+    <!-- Mirrors live in public storage so other apps (browsers, file managers) can use them.
+         Below API 30 the legacy write permission suffices; from API 30 on it needs all-files
+         access, granted from a settings screen. -->
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="29" />
+    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
+
     <!-- We need to check the Internet connection (IPv6 enabled ?). -->
     <!-- NetworkInterface.getNetworkInterfaces() does not need that apparently, so let's remove the permission. -->
     <!-- uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" -->
@@ -17,6 +24,7 @@
         android:description="@string/app_description"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
+        android:requestLegacyExternalStorage="true"
         android:theme="@style/AppTheme" >
         <activity
             android:name="com.httrack.android.HTTrackActivity"

--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -71,6 +71,7 @@ import android.os.Handler;
 import android.os.Looper;
 import android.os.Parcelable;
 import android.os.StrictMode;
+import android.provider.Settings;
 import android.text.Editable;
 import android.text.Html;
 import android.text.TextUtils;
@@ -130,6 +131,8 @@ public class HTTrackActivity extends FragmentActivity {
   protected static final String NOTIFY_ASKED_NAME = "NotificationPermissionAsked";
   // Whether the one-time "import your old mirrors" offer has been shown and dismissed for good.
   protected static final String IMPORT_OFFERED_NAME = "LegacyImportOffered";
+  // Whether all-files storage access was ever offered; a refusal keeps mirrors in private storage.
+  protected static final String STORAGE_ASKED_NAME = "StorageAccessAsked";
 
   // <br /> Pattern
   protected static final Pattern brHtmlPattern = Pattern.compile(Pattern
@@ -235,12 +238,19 @@ public class HTTrackActivity extends FragmentActivity {
   }
 
   /*
-   * The only place mirrors may live under scoped storage: our own external directory, which
-   * needs no permission at any target. The engine takes a POSIX path either way.
+   * Default mirror root. With all-files access, the classic public HTTrack/Websites, so other apps
+   * can use the mirrors and upgraders find their old crawls. Without it (or while the volume is
+   * unmounted), our own private external dir, which needs no permission. The engine takes a POSIX
+   * path either way.
    */
   private File getDefaultHTTrackPath() {
+    if (hasAllFilesAccess()) {
+      final File shared = Environment.getExternalStorageDirectory();
+      if (shared != null) {
+        return new File(new File(shared, "HTTrack"), "Websites");
+      }
+    }
     final File external = getExternalFilesDir(null);
-    // Null while the volume is unmounted; internal storage keeps the engine writable.
     return new File(external != null ? external : getFilesDir(), "Websites");
   }
 
@@ -250,7 +260,8 @@ public class HTTrackActivity extends FragmentActivity {
    * never refused; see StoragePaths.isWritable.
    */
   private Boolean isWritableProjectPath(final File path) {
-    return StoragePaths.isWritable(path, getExternalFilesDir(null), getFilesDir());
+    final File shared = hasAllFilesAccess() ? Environment.getExternalStorageDirectory() : null;
+    return StoragePaths.isWritable(path, getExternalFilesDir(null), getFilesDir(), shared);
   }
 
   /*
@@ -416,6 +427,59 @@ public class HTTrackActivity extends FragmentActivity {
 
   private static final int REQUEST_INTERNET = 2;
   private static final int REQUEST_POST_NOTIFICATIONS = 3;
+  private static final int REQUEST_WRITE_STORAGE = 4;
+
+  /*
+   * Whether the app may write anywhere in shared storage: all-files access from Android 11 on,
+   * or the legacy WRITE_EXTERNAL_STORAGE permission below it.
+   */
+  private boolean hasAllFilesAccess() {
+    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
+      return Environment.isExternalStorageManager();
+    }
+    return ContextCompat.checkSelfPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE)
+            == PackageManager.PERMISSION_GRANTED;
+  }
+
+  /*
+   * Ask for the access that lets mirrors live in the public HTTrack/ folder, reachable by other
+   * apps. Android 11+ grants all-files access from a system settings screen; below it, the runtime
+   * WRITE permission. Offered once per install; a refusal simply keeps mirrors in private storage.
+   */
+  protected void ensureStorageAccess() {
+    if (hasAllFilesAccess()) {
+      return;
+    }
+    if (getSharedPreferences(PREFS_NAME, 0).getBoolean(STORAGE_ASKED_NAME, false)) {
+      return;
+    }
+    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
+      new AlertDialog.Builder(this)
+          .setMessage("Allow HTTrack all-files access so your mirrors are saved in a public "
+              + "HTTrack folder other apps can open. Without it, mirrors stay private to HTTrack.")
+          .setPositiveButton(android.R.string.ok, (dialog, which) -> {
+            getSharedPreferences(PREFS_NAME, 0).edit()
+                .putBoolean(STORAGE_ASKED_NAME, true).apply();
+            try {
+              startActivity(new Intent(
+                  Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION,
+                  Uri.parse("package:" + getPackageName())));
+            } catch (final Exception e) {
+              // Some OEMs lack the per-app screen; fall back to the global list.
+              try {
+                startActivity(new Intent(Settings.ACTION_MANAGE_ALL_FILES_ACCESS_PERMISSION));
+              } catch (final Exception e2) {
+                Log.d(getClass().getSimpleName(), "no all-files-access settings screen", e2);
+              }
+            }
+          })
+          .setNegativeButton(R.string.import_mirrors_offer_later, null)
+          .show();
+    } else {
+      ActivityCompat.requestPermissions(this,
+              new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE}, REQUEST_WRITE_STORAGE);
+    }
+  }
 
   /*
    * Only a runtime permission from Android 13 on; below that the manifest entry is enough.
@@ -468,6 +532,16 @@ public class HTTrackActivity extends FragmentActivity {
         }
       }
       break;
+      // Legacy write (API <= 29). A refusal keeps mirrors private; on a grant, re-point to public.
+      case REQUEST_WRITE_STORAGE: {
+        if (grantResults.length != 0) {
+          getSharedPreferences(PREFS_NAME, 0).edit().putBoolean(STORAGE_ASKED_NAME, true).apply();
+          if (grantResults[0] == PackageManager.PERMISSION_GRANTED && runner == null) {
+            computeStorageTarget();
+          }
+        }
+      }
+      break;
     }
   }
 
@@ -478,7 +552,8 @@ public class HTTrackActivity extends FragmentActivity {
    */
   protected boolean ensureExternalStorage() {
     Log.d("httrack", "called ensureExternalStorage");
-    
+
+    ensureStorageAccess();
     computeStorageTarget();
     ensureInternetIsAvailable();
 
@@ -3017,6 +3092,13 @@ public class HTTrackActivity extends FragmentActivity {
     Log.d(getClass().getSimpleName(), "onResume");
     super.onResume();
     paused = false;
+    // Returning from the all-files-access settings screen may have granted access: re-point the
+    // default to public storage. Never while a crawl runs, and only if the resolved default moved.
+    if (runner == null && projectPath != null
+        && !getDefaultHTTrackPath().getAbsolutePath().equals(projectPath.getAbsolutePath())
+        && getSharedPreferences(PREFS_NAME, 0).getString(BASE_NAME, null) == null) {
+      computeStorageTarget();
+    }
   }
 
   @Override

--- a/app/src/main/java/com/httrack/android/StoragePaths.java
+++ b/app/src/main/java/com/httrack/android/StoragePaths.java
@@ -26,10 +26,24 @@ final class StoragePaths {
    *         a caller that reads that as a refusal would discard a setting it cannot vet.
    */
   static Boolean isWritable(final File path, final File external, final File internal) {
+    return isWritable(path, external, internal, null);
+  }
+
+  /**
+   * As {@link #isWritable(File, File, File)}, plus {@code shared}: a public storage root the app
+   * may write only when it holds all-files access. Kept a distinct root because a public path is
+   * writable exactly when that access is held, which only the Context layer knows.
+   *
+   * @param shared
+   *          the public root (e.g. getExternalStorageDirectory()) when access is held, else null.
+   *          Does not affect the null-vs-false verdict, which stays keyed on external.
+   */
+  static Boolean isWritable(final File path, final File external, final File internal,
+      final File shared) {
     try {
       // The separator on both sides is what keeps a sibling like "files2" from matching "files".
       final String target = path.getCanonicalPath() + File.separator;
-      for (final File root : new File[] { external, internal }) {
+      for (final File root : new File[] { external, internal, shared }) {
         if (root != null
             && target.startsWith(root.getCanonicalPath() + File.separator)) {
           return true;

--- a/app/src/test/java/com/httrack/android/StoragePathsTest.java
+++ b/app/src/test/java/com/httrack/android/StoragePathsTest.java
@@ -37,11 +37,24 @@ public class StoragePathsTest {
     assertEquals(Boolean.TRUE, StoragePaths.isWritable(external, external, internal));
   }
 
+  /** Without all-files access (no shared root), a public path is not ours to write. */
   @Test
-  public void refusesTheOldPublicRoot() {
+  public void refusesThePublicRootWithoutAllFilesAccess() {
     final File old = new File(tmp.getRoot(), "ext/HTTrack/Websites");
     assertEquals(Boolean.FALSE, StoragePaths.isWritable(old, external, internal));
     assertEquals(Boolean.FALSE, StoragePaths.isWritable(new File("/"), external, internal));
+    assertEquals(Boolean.FALSE, StoragePaths.isWritable(old, external, internal, null));
+  }
+
+  /** With all-files access, the public HTTrack root passed as {@code shared} is writable. */
+  @Test
+  public void acceptsThePublicRootWithAllFilesAccess() throws Exception {
+    final File shared = tmp.newFolder("shared"); // stands in for /storage/emulated/0
+    final File mirror = new File(new File(shared, "HTTrack"), "Websites");
+    assertEquals(Boolean.TRUE, StoragePaths.isWritable(mirror, external, internal, shared));
+    // A sibling of the shared root is still outside it.
+    assertEquals(Boolean.FALSE,
+        StoragePaths.isWritable(new File(tmp.getRoot(), "elsewhere"), external, internal, shared));
   }
 
   /** "files2" shares the string prefix of "files" without being inside it. */


### PR DESCRIPTION
Mirrors save to the public /storage/emulated/0/HTTrack folder again, so other apps (browsers, file managers) can open and share them, and upgraders see their old crawls. PR #11 had moved them to app-private storage for scoped-storage compliance, which left a mirror unusable outside HTTrack. For a website copier, that's a release blocker.

At targetSdk 35 a POSIX write into public storage requires all-files access, so this re-declares `MANAGE_EXTERNAL_STORAGE` (legacy `WRITE` below API 30) and adds a one-time grant prompt following the existing `ensure*` pattern. Refusing it just keeps mirrors private, and the engine always has a writable path. `StoragePaths.isWritable` gains an optional public root honoured only when access is held, so the existing security assertions are untouched and new tests cover both cases. Engine and JNI are unchanged.

This needs the All-files-access declaration in the Play Console; without it the Play build risks rejection, so the all-files variant may suit F-Droid/sideload better. On-device verification still owed.