### PR TITLE
native: fix leaks, 0600, and a crash-path UAF in initRootPath

### DIFF
--- a/app/src/main/jni/htslibjni.c
+++ b/app/src/main/jni/htslibjni.c
@@ -371,10 +371,8 @@ Java_com_httrack_android_jni_HTTrackLib_initRootPath(JNIEnv* env,
       char *const buffer = malloc(buffer_size);
       if (buffer != NULL) {
         snprintf(buffer, buffer_size, "%s/error.txt", path);
-        if (emergencyLog != NULL) {
-          free(emergencyLog);
-          emergencyLog = NULL;
-        }
+        /* Publish without freeing the old pointer: the crash handler may read it on
+           another thread (use-after-free). One small buffer leaks per rare re-init. */
         emergencyLog = buffer;
       }
     }
@@ -384,17 +382,23 @@ Java_com_httrack_android_jni_HTTrackLib_initRootPath(JNIEnv* env,
     {
       const size_t buffer_size = strlen(path) + 256;
       char *const buffer = malloc(buffer_size);
-      snprintf(buffer, buffer_size, "%s/log.txt", path);
-      FILE * const log = fopen(buffer, "wb");
-      if (log != NULL) {
-        const int fd = dup(fileno(log));
-        if (dup2(fd, 1) == -1 || dup2(fd, 2) == -1) {
-          ASSERT_THROWS(!"could not redirect stdin/stdout");
+      if (buffer != NULL) {
+        snprintf(buffer, buffer_size, "%s/log.txt", path);
+        /* Owner-only (0600) for symmetry with the crash log: no-op on sdcardfs, correct on the internal fallback. */
+        const int fd = open(buffer, O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR);
+        FILE *const log = fd != -1 ? fdopen(fd, "wb") : NULL;
+        if (log != NULL) {
+          if (dup2(fileno(log), 1) != -1 && dup2(fileno(log), 2) != -1) {
+            fprintf(stderr, "started stdio logging in file\n");
+          } else {
+            error("could not redirect stdout/stderr to log file");
+          }
+          fclose(log); /* fds 1 and 2 keep the redirected file open */
+        } else if (fd != -1) {
+          close(fd);
         }
-        fclose(log);
-        fprintf(stderr, "started stdio logging in file\n");
+        free(buffer);
       }
-      free(buffer);
     }
 #endif
 


### PR DESCRIPTION
initRootPath's stdout/stderr log redirect leaked on every call: the malloc was never null-checked, the intermediate `dup(fileno(log))` fd leaked, and the dup2-failure path threw and returned early, dropping the buffer and FILE. This reworks it to `dup2` the log fd directly (no third descriptor), free and close on every path (malloc-null, open-fail, fdopen-fail, dup2-fail, success), and open the log 0600 like the crash log instead of fopen's 0666. A failed redirect now degrades to a logcat line rather than throwing, since the stdio redirect is best-effort.

It also drops the free of the previous `emergencyLog` pointer, which raced the native crash handler reading it on another thread: a use-after-free on the crash path. The new pointer is published without freeing the old one; a re-init is rare, so leaking one small path buffer is the right trade for crash-path safety.

From the phase-4 audit's emergency-log LOW findings. The native build is CI-gated (NDK + OpenSSL statics).