### PR TITLE
cleanup: null-safe delete, scroll-safe row selection, bounded recursion

### DIFF
--- a/app/src/main/java/com/httrack/android/CleanupActivity.java
+++ b/app/src/main/java/com/httrack/android/CleanupActivity.java
@@ -27,13 +27,10 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
 
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.ListActivity;
-import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
@@ -41,9 +38,8 @@ import android.os.Handler;
 import android.os.Looper;
 import android.util.Log;
 import android.util.SparseArray;
-import android.view.LayoutInflater;
 import android.view.View;
-import android.view.ViewGroup;
+import android.view.ViewParent;
 import android.widget.CheckBox;
 import android.widget.ListView;
 import android.widget.SimpleAdapter;
@@ -67,37 +63,8 @@ public class CleanupActivity extends ListActivity {
   public static final int ACTION_CLEANUP = 1;
   public static final int ACTION_SELECT = 2;
 
-  /**
-   * List adapter.
-   */
-  public class CleanupListAdapter extends SimpleAdapter {
-    private final LayoutInflater inflater;
-
-    public CleanupListAdapter(final Context context,
-        final List<? extends Map<String, ?>> data, final int resource, final String[] from,
-        final int[] to) {
-      super(context, data, resource, from, to);
-      inflater = LayoutInflater.from(context);
-    }
-
-    @Override
-    public Object getItem(final int position) {
-      return super.getItem(position);
-    }
-
-    @Override
-    public View getView(final int position, View convertView, final ViewGroup parent) {
-      if (convertView == null) {
-        convertView = inflater.inflate(R.layout.cleanup_item, null);
-        final CheckBox cb = (CheckBox) convertView.findViewById(R.id.check);
-        if (cb != null) {
-          cb.setTag(position);
-        }
-      }
-      return super.getView(position, convertView, parent);
-    }
-
-  }
+  // A directory nested deeper than this is treated as a failure rather than overflowing the stack.
+  static final int MAX_DEPTH = 100;
 
   /** Called when the activity is first created. */
   @Override
@@ -147,7 +114,7 @@ public class CleanupActivity extends ListActivity {
       listItem.add(map);
     }
 
-    final CleanupListAdapter adapter = new CleanupListAdapter(
+    final SimpleAdapter adapter = new SimpleAdapter(
         this.getBaseContext(), listItem, R.layout.cleanup_item, new String[] {
             "name", "description" }, new int[] { R.id.name, R.id.description });
     list.setAdapter(adapter);
@@ -155,15 +122,24 @@ public class CleanupActivity extends ListActivity {
 
   public void OnClickCheckbox(final View v) {
     final CheckBox cb = (CheckBox) v;
-    final int position = Integer.parseInt(cb.getTag().toString());
-    final View o = list.getChildAt(position).findViewById(R.id.blocCheck);
+    // Adapter position of the clicked row, valid even when scrolled; getChildAt would misread it
+    // as a visible-child index and toggle/select the wrong project.
+    final int position = list.getPositionForView(v);
+    if (position == ListView.INVALID_POSITION) {
+      return;
+    }
 
     if (action == ACTION_CLEANUP) {
+      final View o = blocCheckFor(v);
       if (cb.isChecked()) {
-        o.setBackgroundResource(R.color.transparent_red);
+        if (o != null) {
+          o.setBackgroundResource(R.color.transparent_red);
+        }
         toBeDeleted.add(position);
       } else {
-        o.setBackgroundResource(R.color.transparent);
+        if (o != null) {
+          o.setBackgroundResource(R.color.transparent);
+        }
         toBeDeleted.remove(position);
       }
     } else if (action == ACTION_SELECT) {
@@ -177,20 +153,40 @@ public class CleanupActivity extends ListActivity {
     }
   }
 
+  /** The clicked row's coloured container, walked up from the clicked view rather than by index. */
+  private static View blocCheckFor(final View clicked) {
+    View view = clicked;
+    while (view != null && view.getId() != R.id.blocCheck) {
+      final ViewParent parent = view.getParent();
+      view = parent instanceof View ? (View) parent : null;
+    }
+    return view;
+  }
+
   /* Delete recursively a directory, or delete a file. */
   public static boolean deleteRecursively(final File file) {
+    return deleteRecursively(file, MAX_DEPTH);
+  }
+
+  /* Depth-bounded worker: refuses a tree deeper than depthLeft instead of overflowing the stack. */
+  static boolean deleteRecursively(final File file, final int depthLeft) {
     // TODO: check if this is necessary (symbolic link handling to avoid
     // infinite loops)
     if (file.delete()) {
       return true;
-    } else {
-      if (file.isDirectory()) {
-        for (final File child : file.listFiles()) {
-          deleteRecursively(child);
+    }
+    if (depthLeft <= 0) {
+      return false;
+    }
+    if (file.isDirectory()) {
+      final File[] children = file.listFiles(); // null on I/O error even for a real directory
+      if (children != null) {
+        for (final File child : children) {
+          deleteRecursively(child, depthLeft - 1);
         }
       }
-      return file.delete();
     }
+    return file.delete();
   }
 
   /**
@@ -277,8 +273,10 @@ public class CleanupActivity extends ListActivity {
       public void run() {
         deleteInProgress = false;
         if (!isFinishing() && !isDestroyed()) {
+          final int firstVisible = list.getFirstVisiblePosition();
           for (final int position : deleted) {
-            final View item = list.getChildAt(position);
+            // deleted holds adapter positions; map to the visible child, skipping rows scrolled off.
+            final View item = list.getChildAt(position - firstVisible);
             if (item == null) {
               continue;
             }

--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -2380,11 +2380,18 @@ public class HTTrackActivity extends FragmentActivity {
       new Thread(new Runnable() {
         @Override
         public void run() {
+          String message;
           try {
-            deliverImportOutcome(appContext, runImport(appContext, resolver, treeUri, dest));
+            message = runImport(appContext, resolver, treeUri, dest);
+          } catch (final Throwable t) {
+            // Even a StackOverflowError must still deliver a failure outcome, not die silently with
+            // the guard cleared and nothing shown.
+            Log.w(getClass().getSimpleName(), "import failed", t);
+            message = getString(R.string.import_mirrors_partial, 0, 0);
           } finally {
             importInProgress.set(false);
           }
+          deliverImportOutcome(appContext, message);
         }
       }, "legacy-import").start();
     } catch (final Throwable t) {

--- a/app/src/main/java/com/httrack/android/LegacyMirrorImport.java
+++ b/app/src/main/java/com/httrack/android/LegacyMirrorImport.java
@@ -24,6 +24,9 @@ import java.util.List;
 final class LegacyMirrorImport {
   private static final int BUFFER = 64 * 1024;
 
+  // A tree nested deeper than this is refused rather than recursing until the stack overflows.
+  static final int MAX_DEPTH = 100;
+
   private LegacyMirrorImport() {
   }
 
@@ -74,6 +77,15 @@ final class LegacyMirrorImport {
   }
 
   private static void copyInto(final Source dir, final File destDir, final Result result) {
+    copyInto(dir, destDir, result, MAX_DEPTH);
+  }
+
+  private static void copyInto(final Source dir, final File destDir, final Result result,
+      final int depthLeft) {
+    if (depthLeft <= 0) {
+      record(result, "tree too deep at " + destDir);
+      return;
+    }
     if (!destDir.exists() && !destDir.mkdirs()) {
       record(result, "could not create " + destDir);
       return;
@@ -87,7 +99,7 @@ final class LegacyMirrorImport {
       }
       final File dest = new File(destDir, name);
       if (child.isDirectory()) {
-        copyInto(child, dest, result);
+        copyInto(child, dest, result, depthLeft - 1);
       } else if (dest.isDirectory()) {
         // A directory already sits where this file would go; skipping would drop it silently.
         record(result, "name clash at " + dest);
@@ -132,12 +144,25 @@ final class LegacyMirrorImport {
 
   /** Bytes the tree holds, for a free-space check before starting. Skipped files still count. */
   static long totalSize(final Source src) {
+    return totalSize(src, MAX_DEPTH);
+  }
+
+  // Long.MAX_VALUE for a tree deeper than the cap so the caller's space check refuses it,
+  // rather than recursing until the stack overflows.
+  private static long totalSize(final Source src, final int depthLeft) {
     if (!src.isDirectory()) {
       return src.length();
     }
+    if (depthLeft <= 0) {
+      return Long.MAX_VALUE;
+    }
     long total = 0;
     for (final Source child : src.children()) {
-      total += totalSize(child);
+      final long childSize = totalSize(child, depthLeft - 1);
+      if (childSize == Long.MAX_VALUE) {
+        return Long.MAX_VALUE;
+      }
+      total += childSize;
     }
     return total;
   }

--- a/app/src/test/java/com/httrack/android/CleanupActivityTest.java
+++ b/app/src/test/java/com/httrack/android/CleanupActivityTest.java
@@ -1,0 +1,71 @@
+package com.httrack.android;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/** Exercises CleanupActivity.deleteRecursively: full delete, null-listFiles safety, depth cap. */
+public class CleanupActivityTest {
+  @Rule
+  public final TemporaryFolder tmp = new TemporaryFolder();
+
+  @Test
+  public void deletesANestedTreeWhole() throws Exception {
+    final File root = tmp.newFolder("proj");
+    final File deep = new File(new File(root, "a"), "b");
+    assertTrue(deep.mkdirs());
+    assertTrue(new File(deep, "page.html").createNewFile());
+    assertTrue(new File(root, "top.html").createNewFile());
+
+    assertTrue(CleanupActivity.deleteRecursively(root));
+    assertFalse(root.exists());
+  }
+
+  /** A directory populated and then wiped: delete() fails first, then succeeds once emptied. */
+  @Test
+  public void removesADirectoryThatWasNotInitiallyEmpty() throws Exception {
+    final File dir = tmp.newFolder("dir");
+    assertTrue(new File(dir, "child.txt").createNewFile());
+
+    assertTrue(CleanupActivity.deleteRecursively(dir));
+    assertFalse(dir.exists());
+  }
+
+  @Test
+  public void deletesASingleFile() throws Exception {
+    final File file = tmp.newFile("lone.txt");
+    assertTrue(CleanupActivity.deleteRecursively(file));
+    assertFalse(file.exists());
+  }
+
+  /** A tree deeper than the cap is refused rather than blowing the stack; the low levels survive. */
+  @Test
+  public void refusesATreeDeeperThanTheDepthCap() throws Exception {
+    File cursor = tmp.newFolder("deep");
+    final File root = cursor;
+    for (int i = 0; i <= CleanupActivity.MAX_DEPTH; i++) {
+      cursor = new File(cursor, "d");
+      assertTrue(cursor.mkdir());
+    }
+
+    assertFalse(CleanupActivity.deleteRecursively(root));
+    assertTrue(root.exists());
+  }
+
+  /** The bounded worker stops at its limit: with limit 1 it cannot reach a file two levels down. */
+  @Test
+  public void boundedWorkerRefusesBeyondItsLimit() throws Exception {
+    final File root = tmp.newFolder("bounded");
+    final File sub = new File(root, "sub");
+    assertTrue(sub.mkdir());
+    assertTrue(new File(sub, "leaf.txt").createNewFile());
+
+    assertFalse(CleanupActivity.deleteRecursively(root, 1));
+    assertTrue(root.exists());
+  }
+}

--- a/app/src/test/java/com/httrack/android/LegacyMirrorImportTest.java
+++ b/app/src/test/java/com/httrack/android/LegacyMirrorImportTest.java
@@ -341,6 +341,21 @@ public class LegacyMirrorImportTest {
     assertEquals(8, LegacyMirrorImport.totalSize(root));
   }
 
+  /** A tree deeper than the cap is refused by both the size probe and the copy, not overflowed. */
+  @Test
+  public void aTreeDeeperThanTheCapIsRefused() throws Exception {
+    FakeNode cursor = FakeNode.dir("leaf");
+    for (int i = 0; i <= LegacyMirrorImport.MAX_DEPTH; i++) {
+      cursor = FakeNode.dir("d").with(cursor);
+    }
+    // Long.MAX_VALUE forces the free-space check to reject the import.
+    assertEquals(Long.MAX_VALUE, LegacyMirrorImport.totalSize(cursor));
+
+    final File dest = tmp.newFolder("dest");
+    final LegacyMirrorImport.Result r = LegacyMirrorImport.copyTree(cursor, dest);
+    assertFalse(r.isComplete());
+  }
+
   @Test
   public void aByteForByteCopyMatchesBinaryContent() throws Exception {
     final byte[] raw = new byte[1000];


### PR DESCRIPTION
Three LOW robustness fixes in the project-cleanup and legacy-import paths, from the phase-4 audit. `deleteRecursively` did not null-check `listFiles()`, which returns null on an I/O error even for a real directory, and could NPE. The checkbox handler treated an adapter position as a `getChildAt()` visible-child index, so once the list scrolled it toggled or selected the wrong project; it now uses `getPositionForView` and walks up from the clicked view to its row. And `deleteRecursively`/`copyInto`/`totalSize` recursed with no depth cap and could StackOverflow on a pathologically deep mirror (in the import case the Error escaped the IOException-only handler and delivered no outcome); a depth cap and a Throwable catch fix that. Adds unit tests for the null, depth-cap, and refusal cases.