### PR TITLE
manifest: drop the dead OptionsActivity$*Tab activity entries

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -45,46 +45,6 @@
             android:label="@string/title_activity_options" >
         </activity>
         <activity
-            android:name="com.httrack.android.OptionsActivity$ScanRulesTab"
-            android:label="@string/title_activity_options" >
-        </activity>
-        <activity
-            android:name="com.httrack.android.OptionsActivity$LimitsTab"
-            android:label="@string/title_activity_options" >
-        </activity>
-        <activity
-            android:name="com.httrack.android.OptionsActivity$FlowControlTab"
-            android:label="@string/title_activity_options" >
-        </activity>
-        <activity
-            android:name="com.httrack.android.OptionsActivity$LinksTab"
-            android:label="@string/title_activity_options" >
-        </activity>
-        <activity
-            android:name="com.httrack.android.OptionsActivity$BuildTab"
-            android:label="@string/title_activity_options" >
-        </activity>
-        <activity
-            android:name="com.httrack.android.OptionsActivity$BrowserId"
-            android:label="@string/title_activity_options" >
-        </activity>
-        <activity
-            android:name="com.httrack.android.OptionsActivity$Spider"
-            android:label="@string/title_activity_options" >
-        </activity>
-        <activity
-            android:name="com.httrack.android.OptionsActivity$Proxy"
-            android:label="@string/title_activity_options" >
-        </activity>
-        <activity
-            android:name="com.httrack.android.OptionsActivity$LogIndexCache"
-            android:label="@string/title_activity_options" >
-        </activity>
-        <activity
-            android:name="com.httrack.android.OptionsActivity$ExpertsOnly"
-            android:label="@string/title_activity_options" >
-        </activity>
-        <activity
             android:name="com.httrack.android.FileChooserActivity"
             android:label="@string/title_activity_file_chooser" >
         </activity>


### PR DESCRIPTION
Removes the ten `OptionsActivity$*Tab` `<activity>` entries from the manifest. Those inner classes extend a plain data-holder (`Tab`), not `Activity`, and nothing launches them (they render as in-activity tabs via reflection), so the entries only trip Instantiatable/Fatal lint (hidden today by `lint{abortOnError false}`). No runtime change; from the phase-4 audit LOW findings.