### PR TITLE
status: escape the crawled URL before it reaches Html.fromHtml

### DIFF
--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -1531,10 +1531,10 @@ public class HTTrackActivity extends FragmentActivity {
             break;
           }
 
-          // URL
+          // URL (server-controlled: escape so markup/entities stay literal)
           str.append("<i>");
-          str.append(element.address);
-          str.append(element.path);
+          str.append(TextUtils.htmlEncode(element.address));
+          str.append(TextUtils.htmlEncode(element.path));
           str.append("</i>");
           str.append(" → ");
 


### PR DESCRIPTION
The per-item crawl status interpolated the crawled URL's host and path raw into an HTML string that is rendered with `Html.fromHtml`, so markup or entities in a URL (or a literal `<br />`) corrupted the status display and could inject styled markup. Both are now escaped with `TextUtils.htmlEncode`; the app's own static markup is unchanged.

This deliberately does not touch the whitespace-split argv finding (#11): splitting is intended for the filter/URL list fields, so there is no safe in-place fix. Its risk rose now that #24 puts mirrors in shared storage where another app can plant a `winprofile.ini`, so it belongs in a dedicated import-profile validation change (extending `StoragePaths.isValidProjectName`), not here.

From the phase-4 audit LOW findings.