### PR TITLE
security: block option injection from a tampered winprofile.ini URL field

### DIFF
--- a/app/src/main/java/com/httrack/android/CommandlineTokens.java
+++ b/app/src/main/java/com/httrack/android/CommandlineTokens.java
@@ -1,0 +1,17 @@
+package com.httrack.android;
+
+/** Classifies engine commandline tokens; pure, Android-free, so it is unit-testable. */
+public final class CommandlineTokens {
+  private CommandlineTokens() {
+  }
+
+  /**
+   * True if the token would be read by the engine as an option or scan-filter
+   * rule ("-...", "+...") rather than a URL. Only a tampered profile puts one in
+   * the URL field, since no legitimate URL begins with those characters.
+   */
+  public static boolean isOptionLike(final String token) {
+    return token.length() != 0
+        && (token.charAt(0) == '-' || token.charAt(0) == '+');
+  }
+}

--- a/app/src/main/java/com/httrack/android/CommandlineTokens.java
+++ b/app/src/main/java/com/httrack/android/CommandlineTokens.java
@@ -1,5 +1,8 @@
 package com.httrack.android;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /** Classifies engine commandline tokens; pure, Android-free, so it is unit-testable. */
 public final class CommandlineTokens {
   private CommandlineTokens() {
@@ -13,5 +16,26 @@ public final class CommandlineTokens {
   public static boolean isOptionLike(final String token) {
     return token.length() != 0
         && (token.charAt(0) == '-' || token.charAt(0) == '+');
+  }
+
+  /**
+   * Split a URL-field value into argv tokens, dropping empty ones and any that an
+   * engine would read as an option. This is the enforcement point for the
+   * winprofile.ini URL-field hardening, kept here so it is unit-testable without
+   * loading OptionsMapper (whose static init needs Android).
+   */
+  public static List<String> urlTokens(final String value) {
+    final List<String> out = new ArrayList<String>();
+    if (value == null) {
+      return out;
+    }
+    // Collapse whitespace (as OptionsMapper.cleanupString does) then split on it.
+    for (String token : value.replaceAll("\\s+", " ").trim().split("\\s+")) {
+      token = token.trim();
+      if (token.length() != 0 && !isOptionLike(token)) {
+        out.add(token);
+      }
+    }
+    return out;
   }
 }

--- a/app/src/main/java/com/httrack/android/OptionsMapper.java
+++ b/app/src/main/java/com/httrack/android/OptionsMapper.java
@@ -238,7 +238,7 @@ public class OptionsMapper {
   protected final Pair<String, OptionMapper> fieldsMapper[] = new Pair[] {
       new Pair<String, OptionMapper>("ProjectName", NoOpOption.INSTANCE),
       new Pair<String, OptionMapper>("Category", NoOpOption.INSTANCE),
-      new Pair<String, OptionMapper>("CurrentUrl", StringSplit.INSTANCE),
+      new Pair<String, OptionMapper>("CurrentUrl", UrlSplit.INSTANCE),
       new Pair<String, OptionMapper>("CurrentAction",
           new MultipleChoicesOption(new String[] { "iC1", "iC2" }, true)),
       new Pair<String, OptionMapper>("WildCardFilters", StringSplit.INSTANCE),
@@ -508,6 +508,28 @@ public class OptionsMapper {
           if (option != null) {
             commandline.add(option);
           }
+          commandline.add(s);
+        }
+      }
+    }
+  }
+
+  /**
+   * URL field split: like StringSplit but drops option-looking tokens so a
+   * crafted winprofile.ini can't inject engine options (e.g. -O) through URLs.
+   */
+  public static class UrlSplit extends StringSplit {
+    /**
+     * An instance of the UrlSplit class.
+     */
+    public static final UrlSplit INSTANCE = new UrlSplit();
+
+    @Override
+    public void emit(final StringBuilder flags, final List<String> commandline,
+        final String value) {
+      for (String s : cleanupString(value).trim().split(split)) {
+        s = s.trim();
+        if (s.length() != 0 && !CommandlineTokens.isOptionLike(s)) {
           commandline.add(s);
         }
       }

--- a/app/src/main/java/com/httrack/android/OptionsMapper.java
+++ b/app/src/main/java/com/httrack/android/OptionsMapper.java
@@ -527,12 +527,7 @@ public class OptionsMapper {
     @Override
     public void emit(final StringBuilder flags, final List<String> commandline,
         final String value) {
-      for (String s : cleanupString(value).trim().split(split)) {
-        s = s.trim();
-        if (s.length() != 0 && !CommandlineTokens.isOptionLike(s)) {
-          commandline.add(s);
-        }
-      }
+      commandline.addAll(CommandlineTokens.urlTokens(value));
     }
   }
 

--- a/app/src/test/java/com/httrack/android/ImportProfileHardeningTest.java
+++ b/app/src/test/java/com/httrack/android/ImportProfileHardeningTest.java
@@ -1,0 +1,33 @@
+package com.httrack.android;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/**
+ * A tampered winprofile.ini must not inject engine options through the URL
+ * field: OptionsMapper.UrlSplit drops tokens flagged here, while the filter
+ * field keeps plain StringSplit so +/- rules still pass.
+ */
+public class ImportProfileHardeningTest {
+  @Test
+  public void dropsInjectedOptionTokens() {
+    assertTrue(CommandlineTokens.isOptionLike("-O"));
+    assertTrue(CommandlineTokens.isOptionLike("-%O"));
+  }
+
+  @Test
+  public void passesNormalUrls() {
+    assertFalse(CommandlineTokens.isOptionLike("http://example.com/"));
+    assertFalse(CommandlineTokens.isOptionLike("www.foo.org"));
+    assertFalse(CommandlineTokens.isOptionLike("example.com/path?a=b"));
+  }
+
+  // +/- filter tokens read as option-like: why the filter field must NOT apply this.
+  @Test
+  public void filterTokensAreOptionLike() {
+    assertTrue(CommandlineTokens.isOptionLike("+*.png"));
+    assertTrue(CommandlineTokens.isOptionLike("-*.gif"));
+  }
+}

--- a/app/src/test/java/com/httrack/android/ImportProfileHardeningTest.java
+++ b/app/src/test/java/com/httrack/android/ImportProfileHardeningTest.java
@@ -1,33 +1,45 @@
 package com.httrack.android;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+
+import java.util.List;
 
 import org.junit.Test;
 
 /**
- * A tampered winprofile.ini must not inject engine options through the URL
- * field: OptionsMapper.UrlSplit drops tokens flagged here, while the filter
- * field keeps plain StringSplit so +/- rules still pass.
+ * A tampered winprofile.ini must not inject engine options through the URL field.
+ * These exercise the actual token-production (urlTokens), which UrlSplit.emit
+ * delegates to, not just the isOptionLike predicate.
  */
 public class ImportProfileHardeningTest {
   @Test
-  public void dropsInjectedOptionTokens() {
-    assertTrue(CommandlineTokens.isOptionLike("-O"));
-    assertTrue(CommandlineTokens.isOptionLike("-%O"));
+  public void dropsInjectedOptionTokensButKeepsTheUrl() {
+    // A CurrentUrl tampered to inject -O: the flag is dropped, the real URL survives.
+    final List<String> tokens = CommandlineTokens.urlTokens("-O /evil http://real.example/");
+    assertFalse(tokens.contains("-O"));
+    assertTrue(tokens.contains("http://real.example/"));
   }
 
   @Test
-  public void passesNormalUrls() {
-    assertFalse(CommandlineTokens.isOptionLike("http://example.com/"));
-    assertFalse(CommandlineTokens.isOptionLike("www.foo.org"));
-    assertFalse(CommandlineTokens.isOptionLike("example.com/path?a=b"));
+  public void keepsNormalUrls() {
+    final List<String> tokens =
+        CommandlineTokens.urlTokens("http://example.com/ www.foo.org example.com/path?a=b");
+    assertEquals(3, tokens.size());
+    assertTrue(tokens.contains("www.foo.org"));
   }
 
-  // +/- filter tokens read as option-like: why the filter field must NOT apply this.
+  @Test
+  public void dropsAllOptionAndPlusTokens() {
+    assertTrue(CommandlineTokens.urlTokens("-%O +x").isEmpty());
+  }
+
+  /** Filter tokens read as option-like: why WildCardFilters must keep the plain split. */
   @Test
   public void filterTokensAreOptionLike() {
     assertTrue(CommandlineTokens.isOptionLike("+*.png"));
     assertTrue(CommandlineTokens.isOptionLike("-*.gif"));
+    assertFalse(CommandlineTokens.isOptionLike("http://x/"));
   }
 }


### PR DESCRIPTION
The app loads a project's `hts-cache/winprofile.ini` into its options map, and the URL field emitted each whitespace-split token bare into the crawl argv. After #24 moved mirrors to shared storage, another app can plant or edit that profile, so a URL value like `-O /sdcard/evil` landed `-O` as a standalone engine option (for example, redirecting the output directory).

The URL field now goes through a `UrlSplit` emitter that drops tokens starting with `-` or `+`. No legitimate URL starts with those, so real URLs are untouched, and the `WildCardFilters` field keeps the plain split since its `+`/`-` filter tokens are intended. The guard (`CommandlineTokens.isOptionLike`) is a pure, unit-tested class.

Follows up audit finding #11, more pressing now that mirrors live on shared storage. Note: this closes the app-side emission path; if the native engine also re-reads winprofile.ini on resume, that is a separate engine-side concern.