### PR TITLE
theme: respond to system dark mode

### DIFF
--- a/app/src/main/res/layout/activity_proj_name.xml
+++ b/app/src/main/res/layout/activity_proj_name.xml
@@ -36,7 +36,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:hint="@string/projname_hint"
-                    android:textColor="@android:color/primary_text_light" >
+                    android:textColor="?android:attr/textColorPrimary" >
 
                     <requestFocus android:layout_width="fill_parent" />
                 </AutoCompleteTextView>

--- a/app/src/main/res/values-night/color.xml
+++ b/app/src/main/res/values-night/color.xml
@@ -4,4 +4,6 @@
     <color name="black">#808080</color>
     <!-- Brighten the app-name/debug text so it stays legible on dark. -->
     <color name="blue">#9090D0</color>
+    <!-- 50% white shows as a grey box on a dark window; use 50% black so the row/scroll overlay blends. -->
+    <color name="transparent">#80000000</color>
 </resources>

--- a/app/src/main/res/values-night/color.xml
+++ b/app/src/main/res/values-night/color.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Only used for divider lines; pure black is invisible on a dark window. -->
+    <color name="black">#808080</color>
+    <!-- Brighten the app-name/debug text so it stays legible on dark. -->
+    <color name="blue">#9090D0</color>
+</resources>

--- a/app/src/main/res/values-night/styles.xml
+++ b/app/src/main/res/values-night/styles.xml
@@ -1,0 +1,7 @@
+<resources>
+
+    <!-- Night variant: dark Holo base. The night qualifier outranks the version
+         qualifier, so this wins over the Theme.Holo.Light in values-v11. -->
+    <style name="AppBaseTheme" parent="@android:style/Theme.Holo" />
+
+</resources>


### PR DESCRIPTION
The app ran a fixed Holo.Light theme and ignored the system dark setting. This adds a `values-night` overlay re-parenting the base theme to dark Holo (the `night` qualifier outranks the `version` qualifier, so it wins in dark and is inert in light), and fixes the only elements that would break on a dark window: the divider black becomes grey in night, the app-name blue is brightened, and the project-name field's hardcoded light text becomes `?android:attr/textColorPrimary` (same in light, legible in dark). `values/` is untouched, so light mode is unchanged. Dark appearance is device-verified. From the phase-4 audit LOW findings.