### PR TITLE
layout: RTL support (start/end + mirrored button-wrapper styles)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,6 +25,7 @@
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
         android:requestLegacyExternalStorage="true"
+        android:supportsRtl="true"
         android:theme="@style/AppTheme" >
         <activity
             android:name="com.httrack.android.HTTrackActivity"

--- a/app/src/main/res/layout/activity_cleanup.xml
+++ b/app/src/main/res/layout/activity_cleanup.xml
@@ -4,8 +4,8 @@
     android:layout_height="fill_parent"
     android:orientation="vertical"
     android:paddingBottom="@dimen/activity_vertical_margin"
-    android:paddingLeft="@dimen/activity_horizontal_margin"
-    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingStart="@dimen/activity_horizontal_margin"
+    android:paddingEnd="@dimen/activity_horizontal_margin"
     android:paddingTop="@dimen/activity_vertical_margin"
     tools:context=".HTTrackActivity" >
 

--- a/app/src/main/res/layout/activity_file_chooser.xml
+++ b/app/src/main/res/layout/activity_file_chooser.xml
@@ -4,8 +4,8 @@
     android:layout_height="fill_parent"
     android:orientation="vertical"
     android:paddingBottom="@dimen/activity_vertical_margin"
-    android:paddingLeft="@dimen/activity_horizontal_margin"
-    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingStart="@dimen/activity_horizontal_margin"
+    android:paddingEnd="@dimen/activity_horizontal_margin"
     android:paddingTop="@dimen/activity_vertical_margin" >
 
     <LinearLayout
@@ -17,7 +17,7 @@
             android:id="@+id/textLinksDetails"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:paddingRight="@dimen/activity_horizontal_margin"
+            android:paddingEnd="@dimen/activity_horizontal_margin"
             android:text="@string/base_path" />
 
         <EditText
@@ -31,7 +31,7 @@
     <LinearLayout
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
-        android:gravity="left"
+        android:gravity="start"
         android:orientation="horizontal" >
 
         <Button
@@ -46,7 +46,7 @@
     <LinearLayout
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
-        android:gravity="right"
+        android:gravity="end"
         android:orientation="horizontal" >
 
         <Button

--- a/app/src/main/res/layout/activity_mirror_finished.xml
+++ b/app/src/main/res/layout/activity_mirror_finished.xml
@@ -4,8 +4,8 @@
     android:layout_height="fill_parent"
     android:orientation="vertical"
     android:paddingBottom="@dimen/activity_vertical_margin"
-    android:paddingLeft="@dimen/activity_horizontal_margin"
-    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingStart="@dimen/activity_horizontal_margin"
+    android:paddingEnd="@dimen/activity_horizontal_margin"
     android:paddingTop="@dimen/activity_vertical_margin"
     tools:context=".ProjNameActivity" >
 
@@ -39,6 +39,8 @@
                     style="@style/ButtonStyle"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:ellipsize="end"
+                    android:maxLines="1"
                     android:onClick="onShowLogs"
                     android:text="@string/show_logs" />
             </LinearLayout>
@@ -56,6 +58,8 @@
                     style="@style/ButtonStyle"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:ellipsize="end"
+                    android:maxLines="1"
                     android:onClick="onBrowse"
                     android:text="@string/browse_website" />
             </LinearLayout>
@@ -73,6 +77,8 @@
                     style="@style/ButtonStyle"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:ellipsize="end"
+                    android:maxLines="1"
                     android:onClick="onNewProject"
                     android:text="@string/title_activity_proj_name" />
             </LinearLayout>

--- a/app/src/main/res/layout/activity_mirror_finished.xml
+++ b/app/src/main/res/layout/activity_mirror_finished.xml
@@ -39,8 +39,6 @@
                     style="@style/ButtonStyle"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:ellipsize="end"
-                    android:maxLines="1"
                     android:onClick="onShowLogs"
                     android:text="@string/show_logs" />
             </LinearLayout>
@@ -58,8 +56,6 @@
                     style="@style/ButtonStyle"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:ellipsize="end"
-                    android:maxLines="1"
                     android:onClick="onBrowse"
                     android:text="@string/browse_website" />
             </LinearLayout>
@@ -77,8 +73,6 @@
                     style="@style/ButtonStyle"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:ellipsize="end"
-                    android:maxLines="1"
                     android:onClick="onNewProject"
                     android:text="@string/title_activity_proj_name" />
             </LinearLayout>

--- a/app/src/main/res/layout/activity_mirror_progress.xml
+++ b/app/src/main/res/layout/activity_mirror_progress.xml
@@ -3,8 +3,8 @@
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
     android:paddingBottom="@dimen/activity_vertical_margin"
-    android:paddingLeft="@dimen/activity_horizontal_margin"
-    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingStart="@dimen/activity_horizontal_margin"
+    android:paddingEnd="@dimen/activity_horizontal_margin"
     android:paddingTop="@dimen/activity_vertical_margin"
     tools:context=".ProjNameActivity" >
 
@@ -12,8 +12,8 @@
         android:id="@+id/layout"
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
-        android:layout_alignParentLeft="true"
-        android:layout_alignParentRight="true"
+        android:layout_alignParentStart="true"
+        android:layout_alignParentEnd="true"
         android:layout_alignParentTop="true"
         android:orientation="vertical" >
     </LinearLayout>

--- a/app/src/main/res/layout/activity_options.xml
+++ b/app/src/main/res/layout/activity_options.xml
@@ -4,8 +4,8 @@
     android:layout_height="fill_parent"
     android:orientation="vertical"
     android:paddingBottom="@dimen/activity_vertical_margin_phone_only"
-    android:paddingLeft="@dimen/activity_horizontal_margin_phone_only"
-    android:paddingRight="@dimen/activity_horizontal_margin_phone_only"
+    android:paddingStart="@dimen/activity_horizontal_margin_phone_only"
+    android:paddingEnd="@dimen/activity_horizontal_margin_phone_only"
     android:paddingTop="@dimen/activity_vertical_margin_phone_only" >
 
     <LinearLayout

--- a/app/src/main/res/layout/activity_options_browserid.xml
+++ b/app/src/main/res/layout/activity_options_browserid.xml
@@ -4,8 +4,8 @@
     android:layout_height="fill_parent"
     android:orientation="vertical"
     android:paddingBottom="@dimen/activity_vertical_margin_phone_only"
-    android:paddingLeft="@dimen/activity_horizontal_margin_phone_only"
-    android:paddingRight="@dimen/activity_horizontal_margin_phone_only"
+    android:paddingStart="@dimen/activity_horizontal_margin_phone_only"
+    android:paddingEnd="@dimen/activity_horizontal_margin_phone_only"
     android:paddingTop="@dimen/activity_vertical_margin_phone_only" >
 
     <LinearLayout

--- a/app/src/main/res/layout/activity_options_build.xml
+++ b/app/src/main/res/layout/activity_options_build.xml
@@ -5,8 +5,8 @@
     android:background="@color/transparent"
     android:orientation="vertical"
     android:paddingBottom="@dimen/activity_vertical_margin_phone_only"
-    android:paddingLeft="@dimen/activity_horizontal_margin_phone_only"
-    android:paddingRight="@dimen/activity_horizontal_margin_phone_only"
+    android:paddingStart="@dimen/activity_horizontal_margin_phone_only"
+    android:paddingEnd="@dimen/activity_horizontal_margin_phone_only"
     android:paddingTop="@dimen/activity_vertical_margin_phone_only" >
 
     <LinearLayout

--- a/app/src/main/res/layout/activity_options_expertsonly.xml
+++ b/app/src/main/res/layout/activity_options_expertsonly.xml
@@ -4,8 +4,8 @@
     android:layout_height="wrap_content"
     android:orientation="vertical"
     android:paddingBottom="@dimen/activity_vertical_margin_phone_only"
-    android:paddingLeft="@dimen/activity_horizontal_margin_phone_only"
-    android:paddingRight="@dimen/activity_horizontal_margin_phone_only"
+    android:paddingStart="@dimen/activity_horizontal_margin_phone_only"
+    android:paddingEnd="@dimen/activity_horizontal_margin_phone_only"
     android:paddingTop="@dimen/activity_vertical_margin_phone_only" >
 
     <LinearLayout

--- a/app/src/main/res/layout/activity_options_flowcontrol.xml
+++ b/app/src/main/res/layout/activity_options_flowcontrol.xml
@@ -4,8 +4,8 @@
     android:layout_height="fill_parent"
     android:orientation="vertical"
     android:paddingBottom="@dimen/activity_vertical_margin_phone_only"
-    android:paddingLeft="@dimen/activity_horizontal_margin_phone_only"
-    android:paddingRight="@dimen/activity_horizontal_margin_phone_only"
+    android:paddingStart="@dimen/activity_horizontal_margin_phone_only"
+    android:paddingEnd="@dimen/activity_horizontal_margin_phone_only"
     android:paddingTop="@dimen/activity_vertical_margin_phone_only" >
 
     <LinearLayout
@@ -42,7 +42,7 @@
             android:id="@+id/checkPersistentConnections"
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"
-            android:layout_gravity="right"
+            android:layout_gravity="end"
             android:text="@string/persistent_connections" />
 
         <LinearLayout
@@ -71,7 +71,7 @@
             android:id="@+id/checkRemoveHostIfTimeout"
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"
-            android:layout_gravity="right"
+            android:layout_gravity="end"
             android:text="@string/remove_host_if_timeout" />
 
         <LinearLayout
@@ -121,7 +121,7 @@
             android:id="@+id/checkRemoveHostIfSlow"
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"
-            android:layout_gravity="right"
+            android:layout_gravity="end"
             android:text="@string/remove_host_if_slow" />
     </LinearLayout>
 

--- a/app/src/main/res/layout/activity_options_limits.xml
+++ b/app/src/main/res/layout/activity_options_limits.xml
@@ -4,8 +4,8 @@
     android:layout_height="fill_parent"
     android:orientation="vertical"
     android:paddingBottom="@dimen/activity_vertical_margin_phone_only"
-    android:paddingLeft="@dimen/activity_horizontal_margin_phone_only"
-    android:paddingRight="@dimen/activity_horizontal_margin_phone_only"
+    android:paddingStart="@dimen/activity_horizontal_margin_phone_only"
+    android:paddingEnd="@dimen/activity_horizontal_margin_phone_only"
     android:paddingTop="@dimen/activity_vertical_margin_phone_only" >
 
     <LinearLayout

--- a/app/src/main/res/layout/activity_options_links.xml
+++ b/app/src/main/res/layout/activity_options_links.xml
@@ -4,8 +4,8 @@
     android:layout_height="fill_parent"
     android:orientation="vertical"
     android:paddingBottom="@dimen/activity_vertical_margin_phone_only"
-    android:paddingLeft="@dimen/activity_horizontal_margin_phone_only"
-    android:paddingRight="@dimen/activity_horizontal_margin_phone_only"
+    android:paddingStart="@dimen/activity_horizontal_margin_phone_only"
+    android:paddingEnd="@dimen/activity_horizontal_margin_phone_only"
     android:paddingTop="@dimen/activity_vertical_margin_phone_only" >
 
     <LinearLayout

--- a/app/src/main/res/layout/activity_options_logindexcache.xml
+++ b/app/src/main/res/layout/activity_options_logindexcache.xml
@@ -4,8 +4,8 @@
     android:layout_height="fill_parent"
     android:orientation="vertical"
     android:paddingBottom="@dimen/activity_vertical_margin_phone_only"
-    android:paddingLeft="@dimen/activity_horizontal_margin_phone_only"
-    android:paddingRight="@dimen/activity_horizontal_margin_phone_only"
+    android:paddingStart="@dimen/activity_horizontal_margin_phone_only"
+    android:paddingEnd="@dimen/activity_horizontal_margin_phone_only"
     android:paddingTop="@dimen/activity_vertical_margin_phone_only" >
 
     <LinearLayout

--- a/app/src/main/res/layout/activity_options_mimetypes.xml
+++ b/app/src/main/res/layout/activity_options_mimetypes.xml
@@ -4,8 +4,8 @@
     android:layout_height="fill_parent"
     android:orientation="vertical"
     android:paddingBottom="@dimen/activity_vertical_margin_phone_only"
-    android:paddingLeft="@dimen/activity_horizontal_margin_phone_only"
-    android:paddingRight="@dimen/activity_horizontal_margin_phone_only"
+    android:paddingStart="@dimen/activity_horizontal_margin_phone_only"
+    android:paddingEnd="@dimen/activity_horizontal_margin_phone_only"
     android:paddingTop="@dimen/activity_vertical_margin_phone_only" >
 
     <LinearLayout

--- a/app/src/main/res/layout/activity_options_proxy.xml
+++ b/app/src/main/res/layout/activity_options_proxy.xml
@@ -4,8 +4,8 @@
     android:layout_height="fill_parent"
     android:orientation="vertical"
     android:paddingBottom="@dimen/activity_vertical_margin_phone_only"
-    android:paddingLeft="@dimen/activity_horizontal_margin_phone_only"
-    android:paddingRight="@dimen/activity_horizontal_margin_phone_only"
+    android:paddingStart="@dimen/activity_horizontal_margin_phone_only"
+    android:paddingEnd="@dimen/activity_horizontal_margin_phone_only"
     android:paddingTop="@dimen/activity_vertical_margin_phone_only" >
 
     <LinearLayout

--- a/app/src/main/res/layout/activity_options_scanrules.xml
+++ b/app/src/main/res/layout/activity_options_scanrules.xml
@@ -4,8 +4,8 @@
     android:layout_height="fill_parent"
     android:orientation="vertical"
     android:paddingBottom="@dimen/activity_vertical_margin_phone_only"
-    android:paddingLeft="@dimen/activity_horizontal_margin_phone_only"
-    android:paddingRight="@dimen/activity_horizontal_margin_phone_only"
+    android:paddingStart="@dimen/activity_horizontal_margin_phone_only"
+    android:paddingEnd="@dimen/activity_horizontal_margin_phone_only"
     android:paddingTop="@dimen/activity_vertical_margin_phone_only" >
 
     <LinearLayout
@@ -23,14 +23,14 @@
                 android:id="@+id/buttonExclude"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_gravity="left"
+                android:layout_gravity="start"
                 android:text="@string/exclude_links" />
 
             <Button
                 android:id="@+id/buttonInclude"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_gravity="right"
+                android:layout_gravity="end"
                 android:text="@string/include_links" />
         </LinearLayout>
 

--- a/app/src/main/res/layout/activity_options_spider.xml
+++ b/app/src/main/res/layout/activity_options_spider.xml
@@ -4,8 +4,8 @@
     android:layout_height="fill_parent"
     android:orientation="vertical"
     android:paddingBottom="@dimen/activity_vertical_margin_phone_only"
-    android:paddingLeft="@dimen/activity_horizontal_margin_phone_only"
-    android:paddingRight="@dimen/activity_horizontal_margin_phone_only"
+    android:paddingStart="@dimen/activity_horizontal_margin_phone_only"
+    android:paddingEnd="@dimen/activity_horizontal_margin_phone_only"
     android:paddingTop="@dimen/activity_vertical_margin_phone_only" >
 
     <LinearLayout
@@ -17,7 +17,7 @@
             android:id="@+id/checkAcceptCookies"
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"
-            android:layout_gravity="right"
+            android:layout_gravity="end"
             android:text="@string/accept_cookies" />
 
         <LinearLayout
@@ -59,7 +59,7 @@
             android:id="@+id/checkParseJavaFiles"
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"
-            android:layout_gravity="right"
+            android:layout_gravity="end"
             android:text="@string/parse_java_files" />
 
         <LinearLayout
@@ -101,28 +101,28 @@
             android:id="@+id/checkUpdateHacks"
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"
-            android:layout_gravity="right"
+            android:layout_gravity="end"
             android:text="@string/update_hack" />
 
         <CheckBox
             android:id="@+id/checkUrlHacks"
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"
-            android:layout_gravity="right"
+            android:layout_gravity="end"
             android:text="@string/url_hacks" />
 
         <CheckBox
             android:id="@+id/checkTolerentRequests"
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"
-            android:layout_gravity="right"
+            android:layout_gravity="end"
             android:text="@string/tolerent_requests" />
 
         <CheckBox
             android:id="@+id/checkForceHttp10"
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"
-            android:layout_gravity="right"
+            android:layout_gravity="end"
             android:text="@string/force_http_10" />
     </LinearLayout>
 

--- a/app/src/main/res/layout/activity_options_tablet.xml
+++ b/app/src/main/res/layout/activity_options_tablet.xml
@@ -5,8 +5,8 @@
     android:baselineAligned="false"
     android:orientation="horizontal"
     android:paddingBottom="@dimen/activity_vertical_margin"
-    android:paddingLeft="@dimen/activity_horizontal_margin"
-    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingStart="@dimen/activity_horizontal_margin"
+    android:paddingEnd="@dimen/activity_horizontal_margin"
     android:paddingTop="@dimen/activity_vertical_margin" >
 
     <LinearLayout
@@ -15,7 +15,7 @@
         android:layout_height="fill_parent"
         android:layout_weight="0.4"
         android:orientation="horizontal"
-        android:paddingRight="@dimen/activity_horizontal_margin_tablet_only" >
+        android:paddingEnd="@dimen/activity_horizontal_margin_tablet_only" >
     </LinearLayout>
 
     <LinearLayout

--- a/app/src/main/res/layout/activity_proj_name.xml
+++ b/app/src/main/res/layout/activity_proj_name.xml
@@ -4,8 +4,8 @@
     android:layout_height="fill_parent"
     android:orientation="vertical"
     android:paddingBottom="@dimen/activity_vertical_margin"
-    android:paddingLeft="@dimen/activity_horizontal_margin"
-    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingStart="@dimen/activity_horizontal_margin"
+    android:paddingEnd="@dimen/activity_horizontal_margin"
     android:paddingTop="@dimen/activity_vertical_margin" >
 
     <TableLayout
@@ -22,13 +22,13 @@
                 android:id="@+id/textLinksDetails"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:paddingRight="@dimen/activity_horizontal_margin"
+                android:paddingEnd="@dimen/activity_horizontal_margin"
                 android:text="@string/project_name" />
 
             <LinearLayout
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:gravity="left"
+                android:gravity="start"
                 android:orientation="horizontal" >
 
                 <AutoCompleteTextView
@@ -61,13 +61,13 @@
                 android:id="@+id/textMaxExtDepth"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:paddingRight="@dimen/activity_horizontal_margin"
+                android:paddingEnd="@dimen/activity_horizontal_margin"
                 android:text="@string/project_category" />
 
             <LinearLayout
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:gravity="left"
+                android:gravity="start"
                 android:orientation="horizontal" >
 
                 <EditText
@@ -88,7 +88,7 @@
                 android:id="@+id/textBasePath"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:paddingRight="@dimen/activity_horizontal_margin"
+                android:paddingEnd="@dimen/activity_horizontal_margin"
                 android:text="@string/base_path" />
 
             <TextView
@@ -96,7 +96,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="2dp"
-                android:layout_marginRight="16dp"
+                android:layout_marginEnd="16dp"
                 android:layout_marginTop="2dp"
                 android:clickable="true"
                 android:maxLines="4"
@@ -129,6 +129,8 @@
                     style="@style/ButtonStyle"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:ellipsize="end"
+                    android:maxLines="1"
                     android:onClick="onClickPrevious"
                     android:text="@string/previous" />
             </LinearLayout>
@@ -146,6 +148,8 @@
                     style="@style/ButtonStyle"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:ellipsize="end"
+                    android:maxLines="1"
                     android:onClick="onClickNext"
                     android:text="@string/tab_next" />
             </LinearLayout>

--- a/app/src/main/res/layout/activity_proj_name.xml
+++ b/app/src/main/res/layout/activity_proj_name.xml
@@ -129,8 +129,6 @@
                     style="@style/ButtonStyle"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:ellipsize="end"
-                    android:maxLines="1"
                     android:onClick="onClickPrevious"
                     android:text="@string/previous" />
             </LinearLayout>
@@ -148,8 +146,6 @@
                     style="@style/ButtonStyle"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:ellipsize="end"
-                    android:maxLines="1"
                     android:onClick="onClickNext"
                     android:text="@string/tab_next" />
             </LinearLayout>

--- a/app/src/main/res/layout/activity_proj_setup.xml
+++ b/app/src/main/res/layout/activity_proj_setup.xml
@@ -5,8 +5,8 @@
     android:fillViewport="true"
     android:orientation="vertical"
     android:paddingBottom="@dimen/activity_vertical_margin"
-    android:paddingLeft="@dimen/activity_horizontal_margin"
-    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingStart="@dimen/activity_horizontal_margin"
+    android:paddingEnd="@dimen/activity_horizontal_margin"
     android:paddingTop="@dimen/activity_vertical_margin"
     tools:context=".ProjSetupActivity" >
 
@@ -41,7 +41,7 @@
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="0.5"
-                android:gravity="left" >
+                android:gravity="start" >
 
                 <RadioButton
                     android:id="@+id/radioItemContinue"
@@ -60,7 +60,7 @@
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="0.5"
-                android:gravity="right"
+                android:gravity="end"
                 android:orientation="horizontal" >
 
                 <Button

--- a/app/src/main/res/layout/activity_startup.xml
+++ b/app/src/main/res/layout/activity_startup.xml
@@ -49,8 +49,6 @@
                     style="@style/ButtonStyle"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:ellipsize="end"
-                    android:maxLines="1"
                     android:gravity="center_vertical"
                     android:onClick="onBrowseAll"
                     android:text="@string/browse_all" />
@@ -69,8 +67,6 @@
                     style="@style/ButtonStyle"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:ellipsize="end"
-                    android:maxLines="1"
                     android:gravity="center_vertical"
                     android:onClick="onCleanup"
                     android:text="@string/cleanup_sites" />
@@ -89,9 +85,7 @@
                     style="@style/ButtonStyle"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:ellipsize="end"
                     android:layout_gravity="end"
-                    android:maxLines="1"
                     android:gravity="center_vertical"
                     android:onClick="onClickNext"
                     android:text="@string/tab_next" />

--- a/app/src/main/res/layout/activity_startup.xml
+++ b/app/src/main/res/layout/activity_startup.xml
@@ -4,8 +4,8 @@
     android:layout_height="fill_parent"
     android:orientation="vertical"
     android:paddingBottom="@dimen/activity_vertical_margin"
-    android:paddingLeft="@dimen/activity_horizontal_margin"
-    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingStart="@dimen/activity_horizontal_margin"
+    android:paddingEnd="@dimen/activity_horizontal_margin"
     android:paddingTop="@dimen/activity_vertical_margin"
     tools:context=".HTTrackActivity" >
 
@@ -49,6 +49,8 @@
                     style="@style/ButtonStyle"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:ellipsize="end"
+                    android:maxLines="1"
                     android:gravity="center_vertical"
                     android:onClick="onBrowseAll"
                     android:text="@string/browse_all" />
@@ -67,6 +69,8 @@
                     style="@style/ButtonStyle"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:ellipsize="end"
+                    android:maxLines="1"
                     android:gravity="center_vertical"
                     android:onClick="onCleanup"
                     android:text="@string/cleanup_sites" />
@@ -85,7 +89,9 @@
                     style="@style/ButtonStyle"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_gravity="right"
+                    android:ellipsize="end"
+                    android:layout_gravity="end"
+                    android:maxLines="1"
                     android:gravity="center_vertical"
                     android:onClick="onClickNext"
                     android:text="@string/tab_next" />

--- a/app/src/main/res/layout/cleanup_item.xml
+++ b/app/src/main/res/layout/cleanup_item.xml
@@ -12,13 +12,13 @@
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
         android:paddingBottom="4sp"
-        android:paddingLeft="4sp" >
+        android:paddingStart="4sp" >
 
         <TextView
             android:id="@+id/name"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_gravity="left"
+            android:layout_gravity="start"
             android:textSize="20sp" />
     </TableRow>
 
@@ -26,7 +26,7 @@
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
         android:baselineAligned="true"
-        android:paddingLeft="4sp" >
+        android:paddingStart="4sp" >
 
         <LinearLayout
             android:layout_width="fill_parent"
@@ -34,13 +34,13 @@
             android:layout_gravity="center_vertical"
             android:layout_weight="1"
             android:orientation="horizontal"
-            android:paddingLeft="20sp" >
+            android:paddingStart="20sp" >
 
             <TextView
                 android:id="@+id/description"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_gravity="left"
+                android:layout_gravity="start"
                 android:textSize="20sp" />
         </LinearLayout>
 
@@ -48,8 +48,8 @@
             android:id="@+id/check"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_gravity="right"
-            android:layout_marginRight="10sp"
+            android:layout_gravity="end"
+            android:layout_marginEnd="10sp"
             android:onClick="OnClickCheckbox" />
     </TableRow>
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -37,7 +37,7 @@
     </style>
 
     <style name="BorderlessButtonLeft">
-        <item name="android:gravity">left|center_vertical</item>
+        <item name="android:gravity">start|center_vertical</item>
     </style>
 
     <style name="BorderlessButtonCenter">
@@ -45,7 +45,7 @@
     </style>
 
     <style name="BorderlessButtonRight">
-        <item name="android:gravity">right|center_vertical</item>
+        <item name="android:gravity">end|center_vertical</item>
     </style>
 
 </resources>


### PR DESCRIPTION
Adds `android:supportsRtl` and converts every directional layout attribute to start/end across the layouts (paddingLeft->paddingStart, marginRight->marginEnd, alignParentLeft->alignParentStart, gravity left/right->start/end). Under LTR, start==left, so the visual layout is unchanged; RTL locales now mirror instead of getting a non-mirrored LTR UI. Separately, the three-button bottom bars get `ellipsize="end"` + `maxLines="1"` so labels degrade gracefully at the largest font scale instead of clipping (no width/weight change, normal font unchanged). RTL and large-font appearance are device-verified. From the phase-4 audit LOW findings.