### PR TITLE
build: bump NDK to r27 LTS (27.3.13750724)

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -20,7 +20,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  NDK_VERSION: r26d
+  NDK_VERSION: r27
   OPENSSL_VERSION: "3.0.15"
 
 jobs:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -20,7 +20,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  NDK_VERSION: r27
+  NDK_VERSION: r27d
   OPENSSL_VERSION: "3.0.15"
 
 jobs:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,7 +22,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  NDK_VERSION: r26d
+  NDK_VERSION: r27
   OPENSSL_VERSION: "3.0.15"
 
 jobs:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,7 +22,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  NDK_VERSION: r27
+  NDK_VERSION: r27d
   OPENSSL_VERSION: "3.0.15"
 
 jobs:

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,7 +7,7 @@ android {
     compileSdk 35
     // Pinned to what the toolchain image installs, so no build-tools are fetched at build time.
     buildToolsVersion "35.0.0"
-    ndkVersion "26.3.11579264"
+    ndkVersion "27.3.13750724"
 
     defaultConfig {
         applicationId "com.httrack.android"

--- a/app/src/main/jni/Application.mk
+++ b/app/src/main/jni/Application.mk
@@ -8,5 +8,5 @@
 APP_ABI := arm64-v8a x86_64
 APP_PLATFORM := android-24
 
-# Play requires 16 KB-aligned LOAD segments at targetSdk 35+; r26d's lld still defaults to 4 KB.
+# Play requires 16 KB-aligned LOAD segments at targetSdk 35+; kept explicit though r27's lld defaults to 16 KB.
 APP_LDFLAGS := -Wl,-z,max-page-size=16384

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@
 #
 #   - JDK 17            (required by AGP 8.x)
 #   - Android cmdline-tools + platform 35 + build-tools 35
-#   - NDK r26d          (Clang, unified toolchain — replaces the r14/GCC hack)
+#   - NDK r27           (Clang, unified toolchain — replaces the r14/GCC hack)
 #   - OpenSSL 3.x static libs cross-compiled for arm64-v8a/x86_64
 #
 # Build:  docker build -t httrack-android-build docker/
@@ -16,7 +16,7 @@ FROM eclipse-temurin:17-jdk-jammy
 ARG ANDROID_CMDLINE_VERSION=11076708
 ARG ANDROID_PLATFORM=android-35
 ARG ANDROID_BUILD_TOOLS=35.0.0
-ARG NDK_VERSION=26.3.11579264
+ARG NDK_VERSION=27.3.13750724
 ARG OPENSSL_VERSION=3.0.15
 ARG OPENSSL_SHA256=23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533
 


### PR DESCRIPTION
Moves off r26d to the current LTS NDK (r27, supported until r29), across `build.gradle`, the toolchain `Dockerfile`, and the setup-ndk workflow versions. r27 defaults LOAD segments to 16 KB alignment, so the explicit `-Wl,-z,max-page-size=16384` is now belt-and-suspenders (kept; the alignment gate still enforces it). coffeecatch needs no change (its arm64/x86_64 paths use bionic ucontext with no compile-time gates).

**CI sequencing (important):** the `assemble` job builds inside the prebuilt GHCR toolchain image, which still ships r26d, so this PRs assemble check will fail until the image is rebuilt from the bumped Dockerfile and republished via `docker-image.yml`. The image rebuild must be sequenced with the merge (see the PR discussion).