### PR TITLE
release: bump to 3.49.02.68 (versionCode 68)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,8 +17,8 @@ android {
         // edge-to-edge (35) is opted out in values-v35 until the layouts handle window insets.
         targetSdk 35
         // Must exceed the versionCode currently live on the Play listing before uploading.
-        versionCode 67
-        versionName "3.49.02.67"
+        versionCode 68
+        versionName "3.49.02.68"
 
         ndk {
             abiFilters "arm64-v8a", "x86_64"


### PR DESCRIPTION
Version bump for an internal-testing build with the polish pass: dark mode (#32), RTL support (#33), and NDK r27 LTS (#34).