### PR TITLE
options: expose SOCKS5, cookies-file, pause, strip-query, keep-* and a modern User-Agent

### DIFF
--- a/app/src/main/java/com/httrack/android/OptionsActivity.java
+++ b/app/src/main/java/com/httrack/android/OptionsActivity.java
@@ -154,14 +154,15 @@ public class OptionsActivity extends FragmentActivity implements View.OnClickLis
   @ActivityId(R.layout.activity_options_flowcontrol)
   @Fields({ R.id.editNumberOfConnections, R.id.checkPersistentConnections,
       R.id.editTimeout, R.id.checkRemoveHostIfTimeout, R.id.editRetries,
-      R.id.editMinTransferRate, R.id.checkRemoveHostIfSlow })
+      R.id.editMinTransferRate, R.id.checkRemoveHostIfSlow, R.id.editPause })
   public static class FlowControlTab extends Tab {
   }
 
   @Title(R.string.links)
   @ActivityId(R.layout.activity_options_links)
   @Fields({ R.id.checkDetectAllLinks, R.id.checkGetNonHtmlNear,
-      R.id.checkTestAllLinks, R.id.checkGetHtmlFirst })
+      R.id.checkTestAllLinks, R.id.checkGetHtmlFirst, R.id.checkKeepWwwPrefix,
+      R.id.checkKeepDoubleSlashes, R.id.checkKeepQueryOrder })
   public static class LinksTab extends Tab {
   }
 
@@ -183,15 +184,17 @@ public class OptionsActivity extends FragmentActivity implements View.OnClickLis
 
   @Title(R.string.spider)
   @ActivityId(R.layout.activity_options_spider)
-  @Fields({ R.id.checkAcceptCookies, R.id.radioCheckDocumentType,
-      R.id.checkParseJavaFiles, R.id.radioSpider, R.id.checkUpdateHacks,
-      R.id.checkUrlHacks, R.id.checkTolerentRequests, R.id.checkForceHttp10 })
+  @Fields({ R.id.checkAcceptCookies, R.id.editCookiesFile,
+      R.id.radioCheckDocumentType, R.id.checkParseJavaFiles, R.id.radioSpider,
+      R.id.checkUpdateHacks, R.id.checkUrlHacks, R.id.checkTolerentRequests,
+      R.id.checkForceHttp10 })
   public static class Spider extends Tab {
   }
 
   @Title(R.string.proxy)
   @ActivityId(R.layout.activity_options_proxy)
-  @Fields({ R.id.editProxy, R.id.editProxyPort, R.id.checkUseProxyForFtp })
+  @Fields({ R.id.radioProxyProtocol, R.id.editProxy, R.id.editProxyPort,
+      R.id.checkUseProxyForFtp })
   public static class Proxy extends Tab {
   }
 
@@ -218,7 +221,7 @@ public class OptionsActivity extends FragmentActivity implements View.OnClickLis
   @ActivityId(R.layout.activity_options_expertsonly)
   @Fields({ R.id.checkUseCacheForUpdates, R.id.radioPrimaryScanRule,
       R.id.textTravelMode, R.id.radioTravelMode, R.id.radioGlobalTravelMode,
-      R.id.radioRewriteLinks, R.id.checkActivateDebugging })
+      R.id.radioRewriteLinks, R.id.editStripQuery, R.id.checkActivateDebugging })
   public static class ExpertsOnly extends Tab {
   }
 

--- a/app/src/main/java/com/httrack/android/OptionsMapper.java
+++ b/app/src/main/java/com/httrack/android/OptionsMapper.java
@@ -84,12 +84,16 @@ public class OptionsMapper {
       new Pair<Integer, String>(R.id.editRetries, "Retry"),
       new Pair<Integer, String>(R.id.editMinTransferRate, "RateOut"),
       new Pair<Integer, String>(R.id.checkRemoveHostIfSlow, "RemoveRateout"),
+      new Pair<Integer, String>(R.id.editPause, "Pause"),
 
       /* Links */
       new Pair<Integer, String>(R.id.checkDetectAllLinks, "ParseAll"),
       new Pair<Integer, String>(R.id.checkGetNonHtmlNear, "Near"),
       new Pair<Integer, String>(R.id.checkTestAllLinks, "Test"),
       new Pair<Integer, String>(R.id.checkGetHtmlFirst, "HTMLFirst"),
+      new Pair<Integer, String>(R.id.checkKeepWwwPrefix, "KeepWwwPrefix"),
+      new Pair<Integer, String>(R.id.checkKeepDoubleSlashes, "KeepDoubleSlashes"),
+      new Pair<Integer, String>(R.id.checkKeepQueryOrder, "KeepQueryOrder"),
 
       /* Build */
       new Pair<Integer, String>(R.id.checkDosNames, "Dos"),
@@ -111,6 +115,7 @@ public class OptionsMapper {
 
       /* Spider */
       new Pair<Integer, String>(R.id.checkAcceptCookies, "Cookies"),
+      new Pair<Integer, String>(R.id.editCookiesFile, "CookiesFile"),
       new Pair<Integer, String>(R.id.radioCheckDocumentType, "CheckType"),
       new Pair<Integer, String>(R.id.checkParseJavaFiles, "ParseJava"),
       new Pair<Integer, String>(R.id.radioSpider, "FollowRobotsTxt"),
@@ -120,6 +125,7 @@ public class OptionsMapper {
       new Pair<Integer, String>(R.id.checkForceHttp10, "HTTP10"),
 
       /* Proxy */
+      new Pair<Integer, String>(R.id.radioProxyProtocol, "ProxyProtocol"),
       new Pair<Integer, String>(R.id.editProxy, "Proxy"),
       new Pair<Integer, String>(R.id.editProxyPort, "Port"),
       new Pair<Integer, String>(R.id.checkUseProxyForFtp, "UseHTTPProxyForFTP"),
@@ -163,6 +169,7 @@ public class OptionsMapper {
       new Pair<Integer, String>(R.id.radioTravelMode, "Travel"),
       new Pair<Integer, String>(R.id.radioGlobalTravelMode, "GlobalTravel"),
       new Pair<Integer, String>(R.id.radioRewriteLinks, "RewriteLinks"),
+      new Pair<Integer, String>(R.id.editStripQuery, "StripQuery"),
       new Pair<Integer, String>(R.id.checkActivateDebugging, "Debugging"), /* FIXME */
 
   };
@@ -206,8 +213,12 @@ public class OptionsMapper {
       new Pair<String, String>("GlobalTravel", "0"),
       new Pair<String, String>("RewriteLinks", "0"),
       new Pair<String, String>("BuildString", "%h%p/%n%q.%t"),
-      new Pair<String, String>("UserID",
-          "Mozilla/4.5 (compatible; HTTrack 3.0x; Windows 98)"),
+      // Empty: no -F, so the engine supplies its own current versioned User-Agent.
+      new Pair<String, String>("UserID", ""),
+      new Pair<String, String>("ProxyProtocol", "0"),
+      new Pair<String, String>("KeepWwwPrefix", "0"),
+      new Pair<String, String>("KeepDoubleSlashes", "0"),
+      new Pair<String, String>("KeepQueryOrder", "0"),
       new Pair<String, String>("Footer",
           "<!-- Mirrored from %s%s by HTTrack Website Copier/3.x [XR&CO'2017], %s -->"),
       new Pair<String, String>("AcceptLanguage", "en,*"),
@@ -297,8 +308,17 @@ public class OptionsMapper {
       new Pair<String, OptionMapper>("TolerantRequests", new SimpleOptionFlag(
           "%B")),
       new Pair<String, OptionMapper>("HTTP10", new SimpleOptionFlag("%h")),
+      new Pair<String, OptionMapper>("ProxyProtocol",
+          proxyHandler.getProtocolMapper()),
       new Pair<String, OptionMapper>("Proxy", proxyHandler.getAddressMapper()),
       new Pair<String, OptionMapper>("Port", proxyHandler.getPortMapper()),
+      new Pair<String, OptionMapper>("CookiesFile", new ArgumentOption("-%K")),
+      new Pair<String, OptionMapper>("Pause", new ArgumentOption("-%G")),
+      new Pair<String, OptionMapper>("StripQuery", new ArgumentOption("-%g")),
+      new Pair<String, OptionMapper>("KeepWwwPrefix", new SimpleOptionFlag("%j")),
+      new Pair<String, OptionMapper>("KeepDoubleSlashes", new SimpleOptionFlag(
+          "%o")),
+      new Pair<String, OptionMapper>("KeepQueryOrder", new SimpleOptionFlag("%y")),
       new Pair<String, OptionMapper>("UseHTTPProxyForFTP", new SimpleOption0(
           "%f")),
       new Pair<String, OptionMapper>("StoreAllInCache", new SimpleOptionFlag(
@@ -789,6 +809,7 @@ public class OptionsMapper {
     protected boolean finished = false;
     protected String address;
     protected String port;
+    protected String protocol; // radio index: "1" == SOCKS5, else HTTP
 
     /*
      * Build type.
@@ -839,7 +860,7 @@ public class OptionsMapper {
 
     /**
      * Get the port mapper
-     * 
+     *
      * @return the port build mapper
      */
     public OptionMapper getPortMapper() {
@@ -847,16 +868,48 @@ public class OptionsMapper {
     }
 
     /*
-     * Where we really emit the option
+     * Proxy protocol selector (HTTP vs SOCKS5).
+     */
+    private class Protocol implements OptionMapper, OptionMapper.FinishMapper {
+      @Override
+      public void emit(final StringBuilder flags,
+          final List<String> commandline, final String value) {
+        if (value != null && value.length() != 0) {
+          ProxyHandler.this.protocol = value;
+        }
+      }
+
+      @Override
+      public void finish(final StringBuilder flags,
+          final List<String> commandline) {
+        ProxyHandler.this.finish(flags, commandline);
+      }
+    }
+
+    /**
+     * Get the protocol mapper
+     *
+     * @return the proxy protocol mapper
+     */
+    public OptionMapper getProtocolMapper() {
+      return new Protocol();
+    }
+
+    /*
+     * Where we really emit the option; SOCKS5 prepends the scheme and defaults
+     * to the SOCKS port 1080 instead of 8080.
      */
     private void finish(final StringBuilder flags,
         final List<String> commandline) {
       if (!finished) {
         finished = true;
         if (address != null) {
+          final boolean socks5 = "1".equals(protocol);
+          final String scheme = socks5 ? "socks5://" : "";
+          final String defaultPort = socks5 ? "1080" : "8080";
           commandline.add("-P");
-          commandline.add(address + ":"
-              + (port != null && port.length() != 0 ? port : "8080"));
+          commandline.add(scheme + address + ":"
+              + (port != null && port.length() != 0 ? port : defaultPort));
         }
       }
     }

--- a/app/src/main/res/layout/activity_options_expertsonly.xml
+++ b/app/src/main/res/layout/activity_options_expertsonly.xml
@@ -184,6 +184,27 @@
             </RadioGroup>
         </LinearLayout>
 
+        <LinearLayout
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal" >
+
+            <TextView
+                android:id="@+id/textStripQuery"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight=".30"
+                android:text="@string/strip_query" />
+
+            <EditText
+                android:id="@+id/editStripQuery"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight=".70"
+                android:hint="@string/hint_strip_query"
+                android:inputType="textNoSuggestions" />
+        </LinearLayout>
+
         <CheckBox
             android:id="@+id/checkActivateDebugging"
             android:layout_width="fill_parent"

--- a/app/src/main/res/layout/activity_options_flowcontrol.xml
+++ b/app/src/main/res/layout/activity_options_flowcontrol.xml
@@ -123,6 +123,27 @@
             android:layout_height="wrap_content"
             android:layout_gravity="end"
             android:text="@string/remove_host_if_slow" />
+
+        <LinearLayout
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal" >
+
+            <TextView
+                android:id="@+id/textPause"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight=".70"
+                android:text="@string/pause_between_downloads" />
+
+            <EditText
+                android:id="@+id/editPause"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight=".30"
+                android:hint="@string/hint_pause"
+                android:inputType="textNoSuggestions" />
+        </LinearLayout>
     </LinearLayout>
 
 </ScrollView>

--- a/app/src/main/res/layout/activity_options_links.xml
+++ b/app/src/main/res/layout/activity_options_links.xml
@@ -36,6 +36,24 @@
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"
             android:text="@string/get_html_first" />
+
+        <CheckBox
+            android:id="@+id/checkKeepWwwPrefix"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/keep_www_prefix" />
+
+        <CheckBox
+            android:id="@+id/checkKeepDoubleSlashes"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/keep_double_slashes" />
+
+        <CheckBox
+            android:id="@+id/checkKeepQueryOrder"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/keep_query_order" />
     </LinearLayout>
 
 </ScrollView>

--- a/app/src/main/res/layout/activity_options_proxy.xml
+++ b/app/src/main/res/layout/activity_options_proxy.xml
@@ -19,6 +19,36 @@
             android:orientation="horizontal" >
 
             <TextView
+                android:id="@+id/textProxyProtocol"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight=".50"
+                android:text="@string/proxy_protocol" />
+
+            <RadioGroup
+                android:id="@+id/radioProxyProtocol"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight=".50" >
+
+                <RadioButton
+                    android:id="@+id/radioItemProxyHttp"
+                    android:layout_height="wrap_content"
+                    android:text="@string/proxy_protocol_http" />
+
+                <RadioButton
+                    android:id="@+id/radioItemProxySocks5"
+                    android:layout_height="wrap_content"
+                    android:text="@string/proxy_protocol_socks5" />
+            </RadioGroup>
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal" >
+
+            <TextView
                 android:id="@+id/textProxy"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"

--- a/app/src/main/res/layout/activity_options_spider.xml
+++ b/app/src/main/res/layout/activity_options_spider.xml
@@ -26,6 +26,27 @@
             android:orientation="horizontal" >
 
             <TextView
+                android:id="@+id/textCookiesFile"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight=".50"
+                android:text="@string/cookies_file" />
+
+            <EditText
+                android:id="@+id/editCookiesFile"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight=".50"
+                android:hint="@string/hint_cookies_file"
+                android:inputType="textNoSuggestions" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal" >
+
+            <TextView
                 android:id="@+id/textCheckDocumentType"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -77,7 +77,6 @@
     <string name="remove_host_if_slow">Cancel all links from host if too slow</string>
     <string name="browser_identity">Browser identity</string>
     <string name="html_footer">HTML footer</string>
-    <string name="default_browser_id">Mozilla/4.5 (compatible; HTTrack 3.0x; Windows 98)</string>
     <string name="default_html_footer" formatted="false">&lt;!-- Mirrored from %s%s by HTTrack Website Copier/3.x [XR&amp;CO\'2017], %s --&gt;</string>
     <string name="accept_cookies">Accept cookies</string>
     <string name="check_document_type">Check document type</string>
@@ -95,9 +94,21 @@
     <string name="radio_spider_always">follow robots.txt rules</string>
     <string name="proxy">Proxy address</string>
     <string name="proxy_port">Proxy port</string>
+    <string name="proxy_protocol">Proxy protocol</string>
+    <string name="proxy_protocol_http">HTTP</string>
+    <string name="proxy_protocol_socks5">SOCKS5</string>
     <string name="hint_proxy_address">proxy.example.com</string>
     <string name="hint_proxy_port">8080</string>
-    <string name="hint_browser_identity">Mozilla/4.5 (compatible; HTTrack 3.0x; Windows 98)</string>
+    <string name="cookies_file">Cookies file</string>
+    <string name="hint_cookies_file">cookies.txt (Netscape format)</string>
+    <string name="pause_between_downloads">Pause between downloads (sec, MIN:MAX)</string>
+    <string name="hint_pause">2:5</string>
+    <string name="strip_query">Strip query keys</string>
+    <string name="hint_strip_query">sid,utm_source</string>
+    <string name="keep_www_prefix">Keep www. prefix (www.x != x)</string>
+    <string name="keep_double_slashes">Keep double slashes (//)</string>
+    <string name="keep_query_order">Keep query-string order (?b&amp;a)</string>
+    <string name="hint_browser_identity">Mozilla/5.0 (compatible; HTTrack; +https://www.httrack.com/)</string>
     <string name="hint_footer" formatted="false">&lt;!-- Mirrored from %s%s by HTTrack Website Copier/3.x [XR&amp;CO\'2017], %s --&gt;</string>
     <string name="use_proxy_for_ftp">Use proxy for ftp transfers</string>
     <string name="store_all_files_in_cache">Store ALL files in cache</string>

--- a/app/src/test/java/com/httrack/android/OptionsEmissionTest.java
+++ b/app/src/test/java/com/httrack/android/OptionsEmissionTest.java
@@ -1,0 +1,86 @@
+package com.httrack.android;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.httrack.android.OptionsMapper.ArgumentOption;
+import com.httrack.android.OptionsMapper.OptionMapper;
+import com.httrack.android.OptionsMapper.ProxyHandler;
+import com.httrack.android.OptionsMapper.SimpleOptionFlag;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+
+/** Guards the argv emitted for the engine options exposed by issue #6. */
+public class OptionsEmissionTest {
+  /* Drive a proxy handler through its mappers and return the emitted argv. */
+  private static List<String> emitProxy(final String protocol,
+      final String address, final String port) {
+    final ProxyHandler handler = new ProxyHandler();
+    final StringBuilder flags = new StringBuilder();
+    final List<String> cmd = new ArrayList<String>();
+    handler.getProtocolMapper().emit(flags, cmd, protocol);
+    handler.getAddressMapper().emit(flags, cmd, address);
+    final OptionMapper portMapper = handler.getPortMapper();
+    portMapper.emit(flags, cmd, port);
+    ((OptionMapper.FinishMapper) portMapper).finish(flags, cmd);
+    return cmd;
+  }
+
+  @Test
+  public void socks5PrependsSchemeAndDefaultsPort1080() {
+    final List<String> cmd = emitProxy("1", "proxy.example", "");
+    assertEquals("-P", cmd.get(0));
+    assertEquals("socks5://proxy.example:1080", cmd.get(1));
+  }
+
+  @Test
+  public void socks5KeepsAnExplicitPort() {
+    assertEquals("socks5://proxy.example:9050",
+        emitProxy("1", "proxy.example", "9050").get(1));
+  }
+
+  @Test
+  public void httpProxyStaysBareAndDefaultsPort8080() {
+    assertEquals("proxy.example:8080", emitProxy("0", "proxy.example", "").get(1));
+    assertEquals("proxy.example:3128",
+        emitProxy("0", "proxy.example", "3128").get(1));
+  }
+
+  @Test
+  public void noProxyAddressEmitsNothing() {
+    assertTrue(emitProxy("1", "", "").isEmpty());
+  }
+
+  /* -%K/-%G/-%g emit two tokens only when set; empty stays silent. */
+  @Test
+  public void valueOptionEmitsFlagAndArgumentWhenSet() {
+    final List<String> cmd = new ArrayList<String>();
+    new ArgumentOption("-%K").emit(new StringBuilder(), cmd, "cookies.txt");
+    assertEquals("-%K", cmd.get(0));
+    assertEquals("cookies.txt", cmd.get(1));
+  }
+
+  @Test
+  public void valueOptionStaysSilentWhenEmpty() {
+    final List<String> cmd = new ArrayList<String>();
+    new ArgumentOption("-%K").emit(new StringBuilder(), cmd, "");
+    assertTrue(cmd.isEmpty());
+  }
+
+  /* keep-* toggles bundle their %-flag into the single dash token. */
+  @Test
+  public void keepToggleBundlesFlagWhenChecked() {
+    final StringBuilder flags = new StringBuilder();
+    new SimpleOptionFlag("%j").emit(flags, new ArrayList<String>(), "1");
+    assertTrue(flags.toString().contains("%j"));
+  }
+
+  @Test
+  public void keepToggleEmitsNothingWhenUnchecked() {
+    final StringBuilder flags = new StringBuilder();
+    new SimpleOptionFlag("%j").emit(flags, new ArrayList<String>(), "0");
+    assertFalse(flags.toString().contains("%j"));
+  }
+}


### PR DESCRIPTION
Surfaces the crawl options the HTTrack engine picked up between 3.49-3 and 3.49-12, which the Android GUI predates, so it lines up again with WinHTTrack (xroche/httrack-windows#31). The proxy panel gets an HTTP/SOCKS5 selector that prepends `socks5://` to the single `-P` value and defaults to the SOCKS port 1080. The spider panel gets a cookies-file field, flow control a random `--pause` in `MIN:MAX` seconds, the expert panel `--strip-query`, and the links panel the three `keep-*` toggles that opt out of parts of the `-%u` URL hack.

It also drops the hardcoded `Mozilla/4.5 ... Windows 98` User-Agent default. The browser-identity field now starts empty, so no `-F` is passed and the engine fills in its own current versioned token unless the user sets one.

A JUnit test covers the new argv emission: the SOCKS5 scheme and port default, the value tokens, the `%`-flag bundling, and the empty-skip that the User-Agent change relies on. There's no instrumentation suite in this repo, so the widgets themselves are compile-verified only, not device-tested.

Closes #6
