### PR TITLE
release: bump to 3.49.12.69 (versionCode 69)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,8 +17,8 @@ android {
         // edge-to-edge (35) is opted out in values-v35 until the layouts handle window insets.
         targetSdk 35
         // Must exceed the versionCode currently live on the Play listing before uploading.
-        versionCode 68
-        versionName "3.49.02.68"
+        versionCode 69
+        versionName "3.49.02.69"
 
         ndk {
             abiFilters "arm64-v8a", "x86_64"


### PR DESCRIPTION
Cuts an internal release carrying #6 (SOCKS5 proxy, cookies-file, random pause, strip-query, keep-* toggles, and the modernized default User-Agent).

Also realigns the versionName prefix to the upstream engine: the vendored HTTrack reports `HTTRACK_VERSIONID` 3.49.12, so this ships as `3.49.12.69` rather than perpetuating the stale `3.49.02` prefix.