### PR TITLE
release: correct versionName to upstream 3.49.12.69

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,7 +18,8 @@ android {
         targetSdk 35
         // Must exceed the versionCode currently live on the Play listing before uploading.
         versionCode 69
-        versionName "3.49.02.69"
+        // Prefix = engine HTTRACK_VERSIONID (htsglobal.h); track upstream.
+        versionName "3.49.12.69"
 
         ndk {
             abiFilters "arm64-v8a", "x86_64"


### PR DESCRIPTION
vc69 landed as `3.49.02.69` (#37), but the vendored engine reports `HTTRACK_VERSIONID` 3.49.12. versionCode 69 was never uploaded to Play, so this corrects the versionName string in place (code stays 69) to track upstream HTTrack.

A stuck GitHub PR object caused #37 to merge at the pre-correction commit; this is that same one-line fix, re-landed cleanly.