### PR TITLE
copyright: bump 2017 to 2026 (mirror footer, About credits)

### DIFF
--- a/app/src/main/java/com/httrack/android/OptionsMapper.java
+++ b/app/src/main/java/com/httrack/android/OptionsMapper.java
@@ -220,7 +220,7 @@ public class OptionsMapper {
       new Pair<String, String>("KeepDoubleSlashes", "0"),
       new Pair<String, String>("KeepQueryOrder", "0"),
       new Pair<String, String>("Footer",
-          "<!-- Mirrored from %s%s by HTTrack Website Copier/3.x [XR&CO'2017], %s -->"),
+          "<!-- Mirrored from %s%s by HTTrack Website Copier/3.x [XR&CO'2026], %s -->"),
       new Pair<String, String>("AcceptLanguage", "en,*"),
       new Pair<String, String>("OtherHeaders", ""),
       new Pair<String, String>("DefaultReferer", ""),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -77,7 +77,6 @@
     <string name="remove_host_if_slow">Cancel all links from host if too slow</string>
     <string name="browser_identity">Browser identity</string>
     <string name="html_footer">HTML footer</string>
-    <string name="default_html_footer" formatted="false">&lt;!-- Mirrored from %s%s by HTTrack Website Copier/3.x [XR&amp;CO\'2017], %s --&gt;</string>
     <string name="accept_cookies">Accept cookies</string>
     <string name="check_document_type">Check document type</string>
     <string name="parse_java_files">Parse java files</string>
@@ -109,7 +108,7 @@
     <string name="keep_double_slashes">Keep double slashes (//)</string>
     <string name="keep_query_order">Keep query-string order (?b&amp;a)</string>
     <string name="hint_browser_identity">Mozilla/5.0 (compatible; HTTrack; +https://www.httrack.com/)</string>
-    <string name="hint_footer" formatted="false">&lt;!-- Mirrored from %s%s by HTTrack Website Copier/3.x [XR&amp;CO\'2017], %s --&gt;</string>
+    <string name="hint_footer" formatted="false">&lt;!-- Mirrored from %s%s by HTTrack Website Copier/3.x [XR&amp;CO\'2026], %s --&gt;</string>
     <string name="use_proxy_for_ftp">Use proxy for ftp transfers</string>
     <string name="store_all_files_in_cache">Store ALL files in cache</string>
     <string name="do_not_redownload_locally_erased_files">Do not re-download locally erased files</string>
@@ -191,7 +190,7 @@
     <string name="no_index_html_in_xx">No \'index.html\' file in %s!</string>
     <string name="info_recreated_resources">Recreated HTTrack internal cached resources</string>
     <string name="info_could_not_create_resources">Could not create internal cached resources</string>
-    <string name="about_credits">\n(Please notify us of any bug or problem)\n\nDevelopment:\nInterface (Windows): Xavier Roche\nSpider: Xavier Roche\nJavaParserClasses: Yann Philippot\n\n&#169;1998-2017 Xavier Roche and other contributors\nMANY THANKS for translation tips to:\nRobert Lagadec (rlagadec@yahoo.fr)</string>
+    <string name="about_credits">\n(Please notify us of any bug or problem)\n\nDevelopment:\nInterface (Windows): Xavier Roche\nSpider: Xavier Roche\nJavaParserClasses: Yann Philippot\n\n&#169;1998-2026 Xavier Roche and other contributors\nMANY THANKS for translation tips to:\nRobert Lagadec (rlagadec@yahoo.fr)</string>
     <string name="could_not_get_external_directory">Could not get the system external storage directory</string>
     <string name="could_not_write_to">Could not write to:</string>
     <string name="read_only_storage_media">Read-only media (SDCARD)</string>


### PR DESCRIPTION
Updates the owned copyright/attribution years from 2017 to 2026: the HTML footer default HTTrack writes into every mirrored page, the footer field's hint, and the About dialog credits (`1998-2026`). Also drops the dead `default_html_footer` string.

Source-file license headers carry no year, so nothing there is stale. Vendored copyright (the bundled help docs in `resources.zip`, coffeecatch) belongs upstream and is out of scope here.