### PR TITLE
fix: view license / documentation 404 (wrong mirror-server root)

### DIFF
--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -2652,32 +2652,33 @@ public class HTTrackActivity extends FragmentActivity {
     }
   }
 
-  /** Browse a mirror file by serving it over loopback HTTP to a real external browser. */
+  /** Browse a crawled mirror file, served from the Websites root over loopback HTTP. */
   private void browse(final File index) {
+    browse(getProjectRootFile(), index);
+  }
+
+  /**
+   * Browse {@code index} over the loopback mirror server rooted at {@code root}. The root is
+   * explicit because bundled docs/license live under the resources cache, not the Websites tree;
+   * server root and relative-path base must be the same dir or the URL 404s.
+   */
+  private void browse(final File root, final File index) {
     if (index == null || !index.exists()) {
       return;
     }
     try {
-      final MirrorServer server = ensureMirrorServer(getProjectRootFile());
+      final MirrorServer server = ensureMirrorServer(root);
       if (server == null) {
         showNotification("Could not start the local mirror server");
         return;
       }
-      // Path relative to the served root, canonicalised so symlinks/".." cannot escape it.
-      final String rootPath = getProjectRootFile().getCanonicalPath();
-      final String filePath = index.getCanonicalPath();
-      String relative = filePath.substring(rootPath.length());
-      if (relative.startsWith(File.separator)) {
-        relative = relative.substring(1);
+      // Canonicalised + confined to root, so symlinks/".." and an out-of-root file cannot leak.
+      final String relative = MirrorServer.relativeUrlPath(root, index);
+      if (relative == null) {
+        showNotification("Cannot browse a file outside the served folder");
+        return;
       }
-      final StringBuilder encoded = new StringBuilder();
-      for (final String segment : relative.split("/")) {
-        if (encoded.length() != 0) {
-          encoded.append('/');
-        }
-        encoded.append(java.net.URLEncoder.encode(segment, "UTF-8").replace("+", "%20"));
-      }
-      final String url = server.getBaseUrl() + "/" + encoded;
+      final String url = server.getBaseUrl() + "/" + relative;
       final Intent intent = new Intent(Intent.ACTION_VIEW);
       intent.setData(Uri.parse(url));
       startActivity(intent);
@@ -2791,7 +2792,7 @@ public class HTTrackActivity extends FragmentActivity {
           .setMessage(about0 + "\n" + about + "\n\n" + aboutLegal).show();
       break;
     case R.id.action_license:
-      browse(new File(new File(getResourceFile(), "license"),
+      browse(getResourceFile(), new File(new File(getResourceFile(), "license"),
           "gpl-3.0-standalone.html"));
       break;
     case R.id.action_forum:
@@ -2801,7 +2802,8 @@ public class HTTrackActivity extends FragmentActivity {
       browse(Uri.parse("http://www.httrack.com/"));
       break;
     case R.id.action_help:
-      browse(new File(new File(getResourceFile(), "html"), "index.html"));
+      browse(getResourceFile(), new File(new File(getResourceFile(), "html"),
+          "index.html"));
       break;
     case R.id.action_import_mirrors:
       startLegacyMirrorImport();

--- a/app/src/main/java/com/httrack/android/MirrorServer.java
+++ b/app/src/main/java/com/httrack/android/MirrorServer.java
@@ -24,6 +24,7 @@ package com.httrack.android;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.net.URLEncoder;
 
 import fi.iki.elonen.NanoHTTPD;
 
@@ -136,5 +137,41 @@ final class MirrorServer extends NanoHTTPD {
       // Any decode/canonicalisation failure on hostile input denies rather than leaks.
       return null;
     }
+  }
+
+  /**
+   * Root-relative, percent-encoded URL path for {@code file}, or null if {@code file} is not
+   * inside {@code root}. Inverse of {@link #resolveWithinRoot}: refusing an out-of-root file is
+   * what stops a bogus sliced path (a resources-cache file addressed against the Websites root)
+   * from ever reaching the server.
+   *
+   * @param root
+   *          the served tree
+   * @param file
+   *          the file to link to, expected under root
+   * @return the root-relative %-encoded path, or null if file is outside root
+   */
+  static String relativeUrlPath(final File root, final File file) throws IOException {
+    final String rootPath = root.getCanonicalPath();
+    final String filePath = file.getCanonicalPath();
+    if (!filePath.equals(rootPath)
+        && !filePath.startsWith(rootPath + File.separator)) {
+      return null;
+    }
+    String relative = filePath.substring(rootPath.length());
+    if (relative.startsWith(File.separator)) {
+      relative = relative.substring(1);
+    }
+    final StringBuilder encoded = new StringBuilder();
+    for (final String segment : relative.split("/")) {
+      if (segment.length() == 0) {
+        continue;
+      }
+      if (encoded.length() != 0) {
+        encoded.append('/');
+      }
+      encoded.append(URLEncoder.encode(segment, "UTF-8").replace("+", "%20"));
+    }
+    return encoded.toString();
   }
 }

--- a/app/src/test/java/com/httrack/android/MirrorServerTest.java
+++ b/app/src/test/java/com/httrack/android/MirrorServerTest.java
@@ -61,4 +61,35 @@ public class MirrorServerTest {
     Files.createSymbolicLink(new File(root, "escape").toPath(), outside.toPath());
     assertNull(MirrorServer.resolveWithinRoot(root, "/escape/secret"));
   }
+
+  @Test
+  public void relativeUrlPathForAFileUnderRoot() throws Exception {
+    final File page = new File(new File(root, "html"), "index.html");
+    assertEquals("html/index.html", MirrorServer.relativeUrlPath(root, page));
+  }
+
+  @Test
+  public void relativeUrlPathForRootItselfIsEmpty() throws Exception {
+    assertEquals("", MirrorServer.relativeUrlPath(root, root));
+  }
+
+  @Test
+  public void relativeUrlPathEncodesSpaces() throws Exception {
+    assertEquals("a%20b/c.html",
+        MirrorServer.relativeUrlPath(root, new File(new File(root, "a b"), "c.html")));
+  }
+
+  /** The doc/license 404: a resources-cache file addressed against the Websites root is refused. */
+  @Test
+  public void relativeUrlPathRefusesAFileOutsideRoot() throws Exception {
+    final File resources = tmp.newFolder("resources");
+    final File doc = new File(new File(resources, "license"), "gpl-3.0-standalone.html");
+    assertNull(MirrorServer.relativeUrlPath(root, doc));
+  }
+
+  @Test
+  public void relativeUrlPathRefusesASiblingSharingRootsNamePrefix() throws Exception {
+    final File sibling = tmp.newFolder("Websites-evil");
+    assertNull(MirrorServer.relativeUrlPath(root, new File(sibling, "secret.txt")));
+  }
 }


### PR DESCRIPTION
"View license" and "View documentation" 404'd. `browse()` always rooted the loopback mirror server at the Websites dir and built the URL by slicing that root off the file path, but the license/help files live under the resources cache (`getResourceFile()`). The slice produced a bogus path (the `/.httrack.android/cache/resources` fragment) that the server, confined to Websites, rejected.

`browse()` now takes the root explicitly, and the doc/license handlers pass `getResourceFile()`. The root-relative URL math moves into `MirrorServer.relativeUrlPath`, the inverse of `resolveWithinRoot`: it refuses a file outside root (returns null, and `browse()` bails) instead of emitting a sliced path. Unit-tested with the out-of-root case that reproduced the bug.

No device test (emulator still blocked), so this is compile- and unit-verified.