### PR TITLE
submodule: bump httrack engine to 3.49.13

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,7 +19,7 @@ android {
         // Must exceed the versionCode currently live on the Play listing before uploading.
         versionCode 69
         // Prefix = engine HTTRACK_VERSIONID (htsglobal.h); track upstream.
-        versionName "3.49.12.69"
+        versionName "3.49.13.69"
 
         ndk {
             abiFilters "arm64-v8a", "x86_64"

--- a/app/src/main/jni/Android.mk
+++ b/app/src/main/jni/Android.mk
@@ -75,6 +75,7 @@ LOCAL_SRC_FILES := httrack/src/htscore.c httrack/src/htsparse.c 			\
 	httrack/src/htssniff.c httrack/src/htsselftest.c						\
 	httrack/src/htscache_selftest.c httrack/src/htsdns_selftest.c			\
 	httrack/src/htscodec.c httrack/src/htsproxy.c							\
+	httrack/src/htsurlport.c												\
 	httrack/src/minizip/ioapi.c												\
 	httrack/src/minizip/mztools.c httrack/src/minizip/unzip.c				\
 	httrack/src/minizip/zip.c


### PR DESCRIPTION
Moves the pinned httrack engine from ed05faa to db31be5 (release 3.49.13), 41 commits of upstream fixes including the out-of-range port range-checks, the path-ceiling truncation loss, and the signed-shift UB in the zip-repair reader. coffeecatch and coucal already sit at their intended tips, so this only advances the httrack pointer.

The versionName prefix is realigned to the engine HTTRACK_VERSIONID per the repo golden rule. versionCode stays 69; that only bumps for a Play upload.