### PR TITLE
ci: default the Play publish status to completed

### DIFF
--- a/.github/workflows/play-publish.yml
+++ b/.github/workflows/play-publish.yml
@@ -20,8 +20,8 @@ on:
         description: 'Play track (internal, alpha, beta, or a closed-track name)'
         default: internal
       status:
-        description: 'draft leaves it unreleased for Console review; completed releases to the track'
-        default: draft
+        description: 'completed releases to the track; draft leaves it unreleased for Console review'
+        default: completed
 
 permissions:
   contents: read
@@ -97,4 +97,4 @@ jobs:
           packageName: com.httrack.android
           releaseFiles: aab/app-release.aab
           track: ${{ github.event.inputs.track || 'internal' }}
-          status: ${{ github.event.inputs.status || 'draft' }}
+          status: ${{ github.event.inputs.status || 'completed' }}


### PR DESCRIPTION
Defaults the publish workflow status to `completed`, so a `v*` tag or a bare `workflow_dispatch` releases straight to the internal track instead of leaving a draft that needs a manual promote in the Console. Pass `status=draft` explicitly to stage for review.