### PR TITLE
release: bump to 3.49.13.71 (versionCode 71), fresh engine

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,9 +17,9 @@ android {
         // edge-to-edge (35) is opted out in values-v35 until the layouts handle window insets.
         targetSdk 35
         // Must exceed the versionCode currently live on the Play listing before uploading.
-        versionCode 70
+        versionCode 71
         // Prefix = engine HTTRACK_VERSIONID (htsglobal.h); track upstream.
-        versionName "3.49.13.70"
+        versionName "3.49.13.71"
 
         ndk {
             abiFilters "arm64-v8a", "x86_64"


### PR DESCRIPTION
New internal release on a fresh httrack pin (d2e94b1, still 3.49.13): command-line guide and man-page doc fixes plus a few engine correctness fixes (minizip UB re-apply, non-ASCII -O cache path, port stripping on https/ftp, 206-resume refetch loop). No new engine sources, so Android.mk and the coucal pin are unchanged.

versionCode 70 is live on the Play internal track, so this steps to 71. The help bundle regenerates from the engine at build time now, so the refreshed docs ship without any manual step.