### PR TITLE
app: target API 36 with edge-to-edge window insets

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,18 +4,17 @@ plugins {
 
 android {
     namespace 'com.httrack.android'
-    compileSdk 35
+    compileSdk 36
     // Pinned to what the toolchain image installs, so no build-tools are fetched at build time.
-    buildToolsVersion "35.0.0"
+    buildToolsVersion "36.0.0"
     ndkVersion "27.3.13750724"
 
     defaultConfig {
         applicationId "com.httrack.android"
         minSdk 24
-        // Play's upload floor. The behaviour changes crossed to here are handled: notification
-        // channels + POST_NOTIFICATIONS (#10), scoped storage (#11), predictive back (#12);
-        // edge-to-edge (35) is opted out in values-v35 until the layouts handle window insets.
-        targetSdk 35
+        // Google requires API 36 to keep publishing updates from 2026-08-31. Edge-to-edge window
+        // insets (EdgeToEdge) are now mandatory: the platform ignores the opt-out at this level.
+        targetSdk 36
         // Must exceed the versionCode currently live on the Play listing before uploading.
         versionCode 71
         // Prefix = engine HTTRACK_VERSIONID (htsglobal.h); track upstream.

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,6 +20,7 @@
     <!-- uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" -->
 
     <application
+        android:name=".HTTrackApplication"
         android:allowBackup="true"
         android:description="@string/app_description"
         android:icon="@drawable/ic_launcher"

--- a/app/src/main/java/com/httrack/android/EdgeToEdge.java
+++ b/app/src/main/java/com/httrack/android/EdgeToEdge.java
@@ -1,0 +1,43 @@
+package com.httrack.android;
+
+import android.app.Activity;
+import android.content.res.Configuration;
+import android.os.Build;
+import android.view.View;
+import android.view.Window;
+
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowCompat;
+import androidx.core.view.WindowInsetsCompat;
+import androidx.core.view.WindowInsetsControllerCompat;
+
+/** Re-fits the platform title bar and content inside the system bars where edge-to-edge is forced (API 35+). */
+final class EdgeToEdge {
+  private EdgeToEdge() {
+  }
+
+  /** Pad the decor so title bar + content clear the status/nav bars and the keyboard; survives setContentView swaps. */
+  static void fitSystemWindows(final Activity activity) {
+    // Below API 35 the framework still fits system windows and resizes for the IME; don't disturb it.
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+      return;
+    }
+    final Window window = activity.getWindow();
+    WindowCompat.setDecorFitsSystemWindows(window, false);
+    final View decor = window.getDecorView();
+    ViewCompat.setOnApplyWindowInsetsListener(decor, (v, insets) -> {
+      // ime() in the union pads the bottom by max(nav bar, keyboard) so a focused field stays visible.
+      final Insets bars = insets.getInsets(WindowInsetsCompat.Type.systemBars()
+          | WindowInsetsCompat.Type.displayCutout() | WindowInsetsCompat.Type.ime());
+      v.setPadding(bars.left, bars.top, bars.right, bars.bottom);
+      return insets;
+    });
+    // Dark icons on the light day theme, light icons on the night (Holo dark) theme.
+    final boolean night = (activity.getResources().getConfiguration().uiMode
+        & Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES;
+    final WindowInsetsControllerCompat controller = WindowCompat.getInsetsController(window, decor);
+    controller.setAppearanceLightStatusBars(!night);
+    controller.setAppearanceLightNavigationBars(!night);
+  }
+}

--- a/app/src/main/java/com/httrack/android/HTTrackApplication.java
+++ b/app/src/main/java/com/httrack/android/HTTrackApplication.java
@@ -1,0 +1,43 @@
+package com.httrack.android;
+
+import android.app.Activity;
+import android.app.Application;
+import android.os.Bundle;
+
+/** Registers edge-to-edge inset handling for every activity, so a newly added one can't silently miss it. */
+public final class HTTrackApplication extends Application {
+  @Override
+  public void onCreate() {
+    super.onCreate();
+    registerActivityLifecycleCallbacks(new ActivityLifecycleCallbacks() {
+      @Override
+      public void onActivityCreated(final Activity activity, final Bundle savedInstanceState) {
+        EdgeToEdge.fitSystemWindows(activity);
+      }
+
+      @Override
+      public void onActivityStarted(final Activity activity) {
+      }
+
+      @Override
+      public void onActivityResumed(final Activity activity) {
+      }
+
+      @Override
+      public void onActivityPaused(final Activity activity) {
+      }
+
+      @Override
+      public void onActivityStopped(final Activity activity) {
+      }
+
+      @Override
+      public void onActivitySaveInstanceState(final Activity activity, final Bundle outState) {
+      }
+
+      @Override
+      public void onActivityDestroyed(final Activity activity) {
+      }
+    });
+  }
+}

--- a/app/src/main/res/values-v35/styles.xml
+++ b/app/src/main/res/values-v35/styles.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <!-- targetSdk 35 forces edge-to-edge; opt out until the layouts handle window insets. -->
-    <style name="AppTheme" parent="AppBaseTheme">
-        <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
-    </style>
-</resources>


### PR DESCRIPTION
Google requires targeting API 36 to keep publishing updates after 2026-08-31. Bumps compileSdk/buildToolsVersion/targetSdk to 36.

The only forced behaviour change is edge-to-edge: the platform ignores the `windowOptOutEdgeToEdgeEnforcement` opt-out at 36. On the legacy platform `Theme.Light`, whose title bar sits above `android.R.id.content`, padding the content root would leave the title bar under the status bar, so `EdgeToEdge` pads the DecorView instead, and includes the `ime()` inset so the keyboard doesn't cover the text fields. A `registerActivityLifecycleCallbacks` hook applies it to every activity so a future one can't silently miss it. It is gated to API 35+ where edge-to-edge is actually enforced; below that it is a no-op and the framework keeps its native handling, so minSdk-24 devices are unchanged. Removes the now-dead `values-v35` opt-out (which also drops it for Android 15).

Depends on #46, which adds SDK 36 to the CI build image; the `assemble` check stays red here until that image ships, so this is a draft until then. Reviewed per-invariant: the title-bar-vs-decor behaviour was checked on two models (both pass), and the review caught two bugs since fixed, keyboard occlusion (missing `ime()`) and dark-mode icon contrast. Built locally at compileSdk 36; on-device edge-to-edge check on a real Android 16 phone still pending.
