### PR TITLE
release: bump to 3.49.13.72 (versionCode 72), refresh engine

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,9 +16,9 @@ android {
         // insets (EdgeToEdge) are now mandatory: the platform ignores the opt-out at this level.
         targetSdk 36
         // Must exceed the versionCode currently live on the Play listing before uploading.
-        versionCode 71
+        versionCode 72
         // Prefix = engine HTTRACK_VERSIONID (htsglobal.h); track upstream.
-        versionName "3.49.13.71"
+        versionName "3.49.13.72"
 
         ndk {
             abiFilters "arm64-v8a", "x86_64"


### PR DESCRIPTION
Refreshes the bundled httrack engine and bumps the version for a Play release.

Engine submodule d2e94b1 → 8f7bfbb, docs/help/CI only: help-letter fixes plus `-%z`/`-%t`/`-y` docs, FAQ and man-page cleanup, webhttrack heading localization, and a Windows-CI watchdog. No engine source or version change (`HTTRACK_VERSIONID` stays 3.49.13), so the only user-visible effect is a refreshed in-app help bundle, which is generated from the engine at build time. versionCode → 72 (exceeds 71, the highest on the listing); versionName → 3.49.13.72.
