### PR TITLE
fix: clear the action bar so content isn't hidden under it

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,9 +16,9 @@ android {
         // insets (EdgeToEdge) are now mandatory: the platform ignores the opt-out at this level.
         targetSdk 36
         // Must exceed the versionCode currently live on the Play listing before uploading.
-        versionCode 72
+        versionCode 73
         // Prefix = engine HTTRACK_VERSIONID (htsglobal.h); track upstream.
-        versionName "3.49.13.72"
+        versionName "3.49.13.73"
 
         ndk {
             abiFilters "arm64-v8a", "x86_64"

--- a/app/src/main/java/com/httrack/android/EdgeToEdge.java
+++ b/app/src/main/java/com/httrack/android/EdgeToEdge.java
@@ -3,6 +3,7 @@ package com.httrack.android;
 import android.app.Activity;
 import android.content.res.Configuration;
 import android.os.Build;
+import android.util.TypedValue;
 import android.view.View;
 import android.view.Window;
 
@@ -12,12 +13,12 @@ import androidx.core.view.WindowCompat;
 import androidx.core.view.WindowInsetsCompat;
 import androidx.core.view.WindowInsetsControllerCompat;
 
-/** Re-fits the platform title bar and content inside the system bars where edge-to-edge is forced (API 35+). */
+/** Fits content inside the system bars and below the platform action bar where edge-to-edge is forced (API 35+). */
 final class EdgeToEdge {
   private EdgeToEdge() {
   }
 
-  /** Pad the decor so title bar + content clear the status/nav bars and the keyboard; survives setContentView swaps. */
+  /** Pad the decor for the system bars, and the content for the action bar it now overlaps; survives setContentView swaps. */
   static void fitSystemWindows(final Activity activity) {
     // Below API 35 the framework still fits system windows and resizes for the IME; don't disturb it.
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.VANILLA_ICE_CREAM) {
@@ -26,11 +27,17 @@ final class EdgeToEdge {
     final Window window = activity.getWindow();
     WindowCompat.setDecorFitsSystemWindows(window, false);
     final View decor = window.getDecorView();
+    final View content = activity.findViewById(android.R.id.content);
+    // Edge-to-edge puts the Holo action bar into overlay mode over the content, so content must clear its height.
+    final int actionBarHeight = actionBarHeight(activity);
     ViewCompat.setOnApplyWindowInsetsListener(decor, (v, insets) -> {
-      // ime() in the union pads the bottom by max(nav bar, keyboard) so a focused field stays visible.
+      // ime() pads the bottom by max(nav bar, keyboard) so a focused field stays visible.
       final Insets bars = insets.getInsets(WindowInsetsCompat.Type.systemBars()
           | WindowInsetsCompat.Type.displayCutout() | WindowInsetsCompat.Type.ime());
       v.setPadding(bars.left, bars.top, bars.right, bars.bottom);
+      if (content != null) {
+        content.setPadding(0, actionBarHeight, 0, 0);
+      }
       return insets;
     });
     // Dark icons on the light day theme, light icons on the night (Holo dark) theme.
@@ -39,5 +46,14 @@ final class EdgeToEdge {
     final WindowInsetsControllerCompat controller = WindowCompat.getInsetsController(window, decor);
     controller.setAppearanceLightStatusBars(!night);
     controller.setAppearanceLightNavigationBars(!night);
+  }
+
+  /** The theme's action bar height in px, or 0 if the theme has no action bar. */
+  private static int actionBarHeight(final Activity activity) {
+    final TypedValue tv = new TypedValue();
+    if (activity.getTheme().resolveAttribute(android.R.attr.actionBarSize, tv, true)) {
+      return TypedValue.complexToDimensionPixelSize(tv.data, activity.getResources().getDisplayMetrics());
+    }
+    return 0;
   }
 }


### PR DESCRIPTION
Fixes a regression from the targetSdk-36 edge-to-edge change (vc72): on the project setup screen the project-name field is hidden behind the "HTTrack Website Copier" action bar and can't be tapped.

The theme is `Theme.Holo.Light`, whose platform action bar switches to overlay mode once the decor stops fitting system windows (forced at API 36). The decor padding placed the action bar below the status bar but left the content drawing behind it. This additionally pads `android.R.id.content` down by the action bar height, so content starts below the bar. versionCode → 73.
