### PR TITLE
fix: pad content by the action bar's measured height

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,9 +16,9 @@ android {
         // insets (EdgeToEdge) are now mandatory: the platform ignores the opt-out at this level.
         targetSdk 36
         // Must exceed the versionCode currently live on the Play listing before uploading.
-        versionCode 73
+        versionCode 74
         // Prefix = engine HTTRACK_VERSIONID (htsglobal.h); track upstream.
-        versionName "3.49.13.73"
+        versionName "3.49.13.74"
 
         ndk {
             abiFilters "arm64-v8a", "x86_64"

--- a/app/src/main/java/com/httrack/android/EdgeToEdge.java
+++ b/app/src/main/java/com/httrack/android/EdgeToEdge.java
@@ -1,5 +1,6 @@
 package com.httrack.android;
 
+import android.app.ActionBar;
 import android.app.Activity;
 import android.content.res.Configuration;
 import android.os.Build;
@@ -18,7 +19,7 @@ final class EdgeToEdge {
   private EdgeToEdge() {
   }
 
-  /** Pad the decor for the system bars, and the content for the action bar it now overlaps; survives setContentView swaps. */
+  /** Pad the decor for the system bars, and the content for the action bar it overlaps; survives setContentView swaps. */
   static void fitSystemWindows(final Activity activity) {
     // Below API 35 the framework still fits system windows and resizes for the IME; don't disturb it.
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.VANILLA_ICE_CREAM) {
@@ -27,19 +28,26 @@ final class EdgeToEdge {
     final Window window = activity.getWindow();
     WindowCompat.setDecorFitsSystemWindows(window, false);
     final View decor = window.getDecorView();
-    final View content = activity.findViewById(android.R.id.content);
-    // Edge-to-edge puts the Holo action bar into overlay mode over the content, so content must clear its height.
-    final int actionBarHeight = actionBarHeight(activity);
     ViewCompat.setOnApplyWindowInsetsListener(decor, (v, insets) -> {
       // ime() pads the bottom by max(nav bar, keyboard) so a focused field stays visible.
       final Insets bars = insets.getInsets(WindowInsetsCompat.Type.systemBars()
           | WindowInsetsCompat.Type.displayCutout() | WindowInsetsCompat.Type.ime());
       v.setPadding(bars.left, bars.top, bars.right, bars.bottom);
-      if (content != null) {
-        content.setPadding(0, actionBarHeight, 0, 0);
-      }
       return insets;
     });
+    final View content = activity.findViewById(android.R.id.content);
+    if (content != null) {
+      // Edge-to-edge overlays the Holo action bar on the content; clear it by the bar's real laid-out
+      // height (the themed actionBarSize under-measures it on some densities), refreshed on every layout.
+      content.setPadding(0, themedActionBarSize(activity), 0, 0);
+      decor.getViewTreeObserver().addOnGlobalLayoutListener(() -> {
+        final ActionBar bar = activity.getActionBar();
+        final int height = bar != null ? bar.getHeight() : 0;
+        if (height > 0 && content.getPaddingTop() != height) {
+          content.setPadding(0, height, 0, 0);
+        }
+      });
+    }
     // Dark icons on the light day theme, light icons on the night (Holo dark) theme.
     final boolean night = (activity.getResources().getConfiguration().uiMode
         & Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES;
@@ -49,7 +57,7 @@ final class EdgeToEdge {
   }
 
   /** The theme's action bar height in px, or 0 if the theme has no action bar. */
-  private static int actionBarHeight(final Activity activity) {
+  private static int themedActionBarSize(final Activity activity) {
     final TypedValue tv = new TypedValue();
     if (activity.getTheme().resolveAttribute(android.R.attr.actionBarSize, tv, true)) {
       return TypedValue.complexToDimensionPixelSize(tv.data, activity.getResources().getDisplayMetrics());


### PR DESCRIPTION
Follow-up to #49. The top row was still clipped a few dp under the action bar: the themed `?actionBarSize` under-measures the actual laid-out Holo action bar at this device's density. The content padding now tracks the action bar's real measured height via `getActionBar().getHeight()` in a layout listener, with the themed size as the first-frame fallback. versionCode → 74.
