### PR TITLE
feat: add the HTTP CONNECT tunnel proxy option

### DIFF
--- a/app/src/main/java/com/httrack/android/OptionsMapper.java
+++ b/app/src/main/java/com/httrack/android/OptionsMapper.java
@@ -809,7 +809,7 @@ public class OptionsMapper {
     protected boolean finished = false;
     protected String address;
     protected String port;
-    protected String protocol; // radio index: "1" == SOCKS5, else HTTP
+    protected String protocol; // radio index: "1" == SOCKS5, "2" == CONNECT, else HTTP
 
     /*
      * Build type.

--- a/app/src/main/java/com/httrack/android/OptionsMapper.java
+++ b/app/src/main/java/com/httrack/android/OptionsMapper.java
@@ -868,7 +868,7 @@ public class OptionsMapper {
     }
 
     /*
-     * Proxy protocol selector (HTTP vs SOCKS5).
+     * Proxy protocol selector (HTTP vs SOCKS5 vs HTTP CONNECT tunnel).
      */
     private class Protocol implements OptionMapper, OptionMapper.FinishMapper {
       @Override
@@ -896,8 +896,9 @@ public class OptionsMapper {
     }
 
     /*
-     * Where we really emit the option; SOCKS5 prepends the scheme and defaults
-     * to the SOCKS port 1080 instead of 8080.
+     * Where we really emit the option; each protocol prepends its scheme, and
+     * only SOCKS5 defaults to port 1080 instead of 8080. Value is the radio
+     * index: 0 HTTP, 1 SOCKS5, 2 HTTP CONNECT tunnel.
      */
     private void finish(final StringBuilder flags,
         final List<String> commandline) {
@@ -905,7 +906,9 @@ public class OptionsMapper {
         finished = true;
         if (address != null) {
           final boolean socks5 = "1".equals(protocol);
-          final String scheme = socks5 ? "socks5://" : "";
+          final boolean connect = "2".equals(protocol);
+          final String scheme =
+              socks5 ? "socks5://" : connect ? "connect://" : "";
           final String defaultPort = socks5 ? "1080" : "8080";
           commandline.add("-P");
           commandline.add(scheme + address + ":"

--- a/app/src/main/res/layout/activity_options_proxy.xml
+++ b/app/src/main/res/layout/activity_options_proxy.xml
@@ -40,6 +40,11 @@
                     android:id="@+id/radioItemProxySocks5"
                     android:layout_height="wrap_content"
                     android:text="@string/proxy_protocol_socks5" />
+
+                <RadioButton
+                    android:id="@+id/radioItemProxyConnect"
+                    android:layout_height="wrap_content"
+                    android:text="@string/proxy_protocol_connect" />
             </RadioGroup>
         </LinearLayout>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -96,6 +96,7 @@
     <string name="proxy_protocol">Proxy protocol</string>
     <string name="proxy_protocol_http">HTTP</string>
     <string name="proxy_protocol_socks5">SOCKS5</string>
+    <string name="proxy_protocol_connect">HTTP (CONNECT tunnel)</string>
     <string name="hint_proxy_address">proxy.example.com</string>
     <string name="hint_proxy_port">8080</string>
     <string name="cookies_file">Cookies file</string>


### PR DESCRIPTION
Adds a third proxy protocol option — CONNECT (HTTP CONNECT tunnel, engine scheme `connect://`) — alongside HTTP and SOCKS5. The engine has supported this mode for a while and winhttrack exposes it; Android didn't.

Mirrors the change that added SOCKS5: a third radio button, a string, and a `connect://` branch in `ProxyHandler.finish` (default port 8080, same as HTTP). The protocol is persisted as the radio index, so it round-trips without any scheme parsing.

Closes #52.
