### PR TITLE
fix: derive Accept-Language from the device locale, not a placeholder

### DIFF
--- a/app/src/main/java/com/httrack/android/OptionsMapper.java
+++ b/app/src/main/java/com/httrack/android/OptionsMapper.java
@@ -33,6 +33,7 @@ import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.regex.Pattern;
 
 import android.content.Context;
@@ -1425,8 +1426,10 @@ public class OptionsMapper {
    */
   private void setDynamicDefaults() {
     if (context != null) {
+      // Derive the ISO code from the runtime locale, not a build-time placeholder.
+      final String iso = Locale.getDefault().getLanguage();
       map.put(fieldsNameToId.get("AcceptLanguage"),
-          context.getString(R.string.language_iso_code) + ",*");
+          (iso == null || iso.isEmpty() ? "en" : iso) + ",*");
     }
   }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -204,7 +204,6 @@
     <string name="hint_language">en,fr,ja</string>
     <string name="other_headers">Additional HTTP Headers</string>
     <string name="hint_other_headers">X-Magic: 42</string>
-    <string name="language_iso_code">LANGUAGE_ISO</string>
     <string name="hint_ext_def">doc,docx</string>
     <string name="hint_mime_def">application/msword</string>
     <string name="double_arrow">↔</string>


### PR DESCRIPTION
The Languages option showed the literal placeholder `LANGUAGE_ISO,*` and sent it as the Accept-Language header. It read a string resource meant to be overridden per locale by translations that were never shipped, so the placeholder always leaked through.

The ISO code now comes from `Locale.getDefault().getLanguage()` (falling back to `en`), and the unused placeholder string is removed.

Closes #53.
