### PR TITLE
release: bump to 3.49.13.75 (versionCode 75)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,9 +16,9 @@ android {
         // insets (EdgeToEdge) are now mandatory: the platform ignores the opt-out at this level.
         targetSdk 36
         // Must exceed the versionCode currently live on the Play listing before uploading.
-        versionCode 74
+        versionCode 75
         // Prefix = engine HTTRACK_VERSIONID (htsglobal.h); track upstream.
-        versionName "3.49.13.74"
+        versionName "3.49.13.75"
 
         ndk {
             abiFilters "arm64-v8a", "x86_64"


### PR DESCRIPTION
Ships the three options-screen fixes to the internal track: the project name is kept across "load default options" (#51), the proxy protocol picker gains the HTTP CONNECT tunnel mode (#52), and Accept-Language is derived from the device locale instead of a leaked placeholder (#53). Engine unchanged (3.49.13); versionCode → 75.
