### PR TITLE
Add a WARC archive output toggle

### DIFF
--- a/app/src/main/java/com/httrack/android/OptionsActivity.java
+++ b/app/src/main/java/com/httrack/android/OptionsActivity.java
@@ -170,8 +170,8 @@ public class OptionsActivity extends FragmentActivity implements View.OnClickLis
   @ActivityId(R.layout.activity_options_build)
   @Fields({ R.id.checkDosNames, R.id.checkIso9660, R.id.checkNoErrorPages,
       R.id.checkNoExternalPages, R.id.checkHidePasswords,
-      R.id.checkHideQueryStrings, R.id.checkDoNotPurge, R.id.radioBuild,
-      R.id.editCustomBuild })
+      R.id.checkHideQueryStrings, R.id.checkDoNotPurge, R.id.checkWarc,
+      R.id.radioBuild, R.id.editCustomBuild })
   public static class BuildTab extends Tab {
   }
 

--- a/app/src/main/java/com/httrack/android/OptionsMapper.java
+++ b/app/src/main/java/com/httrack/android/OptionsMapper.java
@@ -104,6 +104,7 @@ public class OptionsMapper {
       new Pair<Integer, String>(R.id.checkHidePasswords, "NoPwdInPages"),
       new Pair<Integer, String>(R.id.checkHideQueryStrings, "NoQueryStrings"),
       new Pair<Integer, String>(R.id.checkDoNotPurge, "NoPurgeOldFiles"),
+      new Pair<Integer, String>(R.id.checkWarc, "Warc"),
       new Pair<Integer, String>(R.id.radioBuild, "Build"),
       new Pair<Integer, String>(R.id.editCustomBuild, "BuildString"),
 
@@ -198,6 +199,7 @@ public class OptionsMapper {
       new Pair<String, String>("NoPwdInPages", "0"),
       new Pair<String, String>("NoQueryStrings", "0"),
       new Pair<String, String>("NoPurgeOldFiles", "0"),
+      new Pair<String, String>("Warc", "0"),
       new Pair<String, String>("Cookies", "1"),
       new Pair<String, String>("CheckType", "1"),
       new Pair<String, String>("ParseJava", "1"),
@@ -287,6 +289,7 @@ public class OptionsMapper {
       new Pair<String, OptionMapper>("NoQueryStrings", new SimpleOption0("%q")),
       new Pair<String, OptionMapper>("NoPurgeOldFiles", new SimpleOptionFlag(
           "X0")),
+      new Pair<String, OptionMapper>("Warc", new SimpleOptionFlag("%r")),
       new Pair<String, OptionMapper>("Build", buildHandler.getTypeMapper()),
       new Pair<String, OptionMapper>("BuildString",
           buildHandler.getCustomMapper()),

--- a/app/src/main/jni/Android.mk
+++ b/app/src/main/jni/Android.mk
@@ -75,7 +75,7 @@ LOCAL_SRC_FILES := httrack/src/htscore.c httrack/src/htsparse.c 			\
 	httrack/src/htssniff.c httrack/src/htsselftest.c						\
 	httrack/src/htscache_selftest.c httrack/src/htsdns_selftest.c			\
 	httrack/src/htscodec.c httrack/src/htsproxy.c							\
-	httrack/src/htsurlport.c												\
+	httrack/src/htsurlport.c httrack/src/htswarc.c							\
 	httrack/src/minizip/ioapi.c												\
 	httrack/src/minizip/mztools.c httrack/src/minizip/unzip.c				\
 	httrack/src/minizip/zip.c

--- a/app/src/main/res/layout/activity_options_build.xml
+++ b/app/src/main/res/layout/activity_options_build.xml
@@ -56,6 +56,12 @@
             android:layout_height="wrap_content"
             android:text="@string/do_not_purge_old_files" />
 
+        <CheckBox
+            android:id="@+id/checkWarc"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/write_warc_archive" />
+
         <LinearLayout
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -68,6 +68,7 @@
     <string name="hide_passwords">Hide passwords</string>
     <string name="hide_query_strings">Hide query strings</string>
     <string name="do_not_purge_old_files">Do not purge old files</string>
+    <string name="write_warc_archive">Write WARC archive</string>
     <string name="number_of_connections">Max simultaneous connections</string>
     <string name="persistent_connections">Persistent connections (Keep-Alive)</string>
     <string name="timeout">File timeout</string>

--- a/app/src/test/java/com/httrack/android/OptionsEmissionTest.java
+++ b/app/src/test/java/com/httrack/android/OptionsEmissionTest.java
@@ -83,4 +83,19 @@ public class OptionsEmissionTest {
     new SimpleOptionFlag("%j").emit(flags, new ArrayList<String>(), "0");
     assertFalse(flags.toString().contains("%j"));
   }
+
+  /* WARC toggle bundles -%r only when checked. */
+  @Test
+  public void warcToggleBundlesFlagWhenChecked() {
+    final StringBuilder flags = new StringBuilder();
+    new SimpleOptionFlag("%r").emit(flags, new ArrayList<String>(), "1");
+    assertTrue(flags.toString().contains("%r"));
+  }
+
+  @Test
+  public void warcToggleEmitsNothingWhenUnchecked() {
+    final StringBuilder flags = new StringBuilder();
+    new SimpleOptionFlag("%r").emit(flags, new ArrayList<String>(), "0");
+    assertFalse(flags.toString().contains("%r"));
+  }
 }


### PR DESCRIPTION
The engine gained ISO-28500 WARC/1.1 output (`--warc` / `-%r`) in xroche/httrack #671. This bumps the vendored engine to `1e0c009` and adds a "Write WARC archive" checkbox to the Build options tab.

The engine writes the whole `.warc.gz` itself, so the front-end only has to inject `-%r` into the argv it already assembles, wired through the same three OptionsMapper registries as every other Build-tab toggle. `htswarc.c` is registered in the ndk-build source list and links against the OpenSSL statics already used for TLS.

Checked with a local arm64-v8a and x86_64 build: the WARC symbols and the `-%r` help text are present in `libhttrack.so`. A unit test asserts the flag is emitted only when the box is ticked.