### PR TITLE
release: bump to 3.49.13.76 (versionCode 76)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,9 +16,9 @@ android {
         // insets (EdgeToEdge) are now mandatory: the platform ignores the opt-out at this level.
         targetSdk 36
         // Must exceed the versionCode currently live on the Play listing before uploading.
-        versionCode 75
+        versionCode 76
         // Prefix = engine HTTRACK_VERSIONID (htsglobal.h); track upstream.
-        versionName "3.49.13.75"
+        versionName "3.49.13.76"
 
         ndk {
             abiFilters "arm64-v8a", "x86_64"


### PR DESCRIPTION
Version bump for the next internal-track release. The only user-facing change since 3.49.13.75 is the WARC archive output toggle (#58). Engine unchanged at 3.49.13 (1e0c009).