### PR TITLE
Surface storage access on the base-path panel

### DIFF
--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -69,6 +69,7 @@ import android.os.Environment;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.Parcelable;
+import android.provider.DocumentsContract;
 import android.provider.Settings;
 import android.text.Editable;
 import android.text.Html;
@@ -457,24 +458,96 @@ public class HTTrackActivity extends FragmentActivity {
           .setPositiveButton(android.R.string.ok, (dialog, which) -> {
             getSharedPreferences(PREFS_NAME, 0).edit()
                 .putBoolean(STORAGE_ASKED_NAME, true).apply();
-            try {
-              startActivity(new Intent(
-                  Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION,
-                  Uri.parse("package:" + getPackageName())));
-            } catch (final Exception e) {
-              // Some OEMs lack the per-app screen; fall back to the global list.
-              try {
-                startActivity(new Intent(Settings.ACTION_MANAGE_ALL_FILES_ACCESS_PERMISSION));
-              } catch (final Exception e2) {
-                Log.d(getClass().getSimpleName(), "no all-files-access settings screen", e2);
-              }
-            }
+            requestAllFilesAccess();
           })
           .setNegativeButton(R.string.import_mirrors_offer_later, null)
           .show();
     } else {
+      requestAllFilesAccess();
+    }
+  }
+
+  /*
+   * Grant all-files access (Android 11+ settings screen, or the global-list fallback) or the legacy
+   * WRITE permission. Ungated, unlike the one-shot install prompt, so the panel button can reuse it.
+   */
+  private void requestAllFilesAccess() {
+    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
+      try {
+        startActivity(new Intent(Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION,
+            Uri.parse("package:" + getPackageName())));
+      } catch (final Exception e) {
+        try {
+          startActivity(new Intent(Settings.ACTION_MANAGE_ALL_FILES_ACCESS_PERMISSION));
+        } catch (final Exception e2) {
+          Log.d(getClass().getSimpleName(), "no all-files-access settings screen", e2);
+        }
+      }
+    } else {
       ActivityCompat.requestPermissions(this,
               new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE}, REQUEST_WRITE_STORAGE);
+    }
+  }
+
+  /*
+   * Base-path panel button: grant all-files access so mirrors move to the public HTTrack/ folder.
+   */
+  public void onClickEnableAllFilesAccess(final View view) {
+    requestAllFilesAccess();
+  }
+
+  /*
+   * Base-path panel button: open the mirror folder in the system file UI. Private storage is hidden
+   * from file managers on Android 11+, so fall back to showing the path when it can't be opened.
+   */
+  public void onClickBrowseFolder(final View view) {
+    final File dir = getProjectRootFile();
+    if (hasAllFilesAccess() && openFolderInFilesApp(dir)) {
+      return;
+    }
+    Toast.makeText(this, getString(R.string.base_path_toast, dir.getAbsolutePath()),
+        Toast.LENGTH_LONG).show();
+  }
+
+  /* Try to view dir through the external-storage documents provider. False if unmapped/unhandled. */
+  private boolean openFolderInFilesApp(final File dir) {
+    final File shared = Environment.getExternalStorageDirectory();
+    if (shared == null) {
+      return false;
+    }
+    final String root = shared.getAbsolutePath();
+    final String path = dir.getAbsolutePath();
+    if (!path.startsWith(root + File.separator)) {
+      return false;
+    }
+    final String docId = "primary:" + path.substring(root.length() + 1);
+    final Uri uri =
+        DocumentsContract.buildDocumentUri("com.android.externalstorage.documents", docId);
+    final Intent intent = new Intent(Intent.ACTION_VIEW)
+        .setDataAndType(uri, DocumentsContract.Document.MIME_TYPE_DIR)
+        .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+    if (intent.resolveActivity(getPackageManager()) == null) {
+      return false;
+    }
+    try {
+      startActivity(intent);
+      return true;
+    } catch (final Exception e) {
+      Log.d(getClass().getSimpleName(), "cannot open folder in files app", e);
+      return false;
+    }
+  }
+
+  /* Show the grant button and private-storage warning on the base-path panel only when access is off. */
+  private void refreshStorageAccessHints() {
+    final boolean granted = hasAllFilesAccess();
+    final View grant = findViewById(R.id.buttonEnableAllFiles);
+    if (grant != null) {
+      grant.setVisibility(granted ? View.GONE : View.VISIBLE);
+    }
+    final View warning = findViewById(R.id.textStorageWarning);
+    if (warning != null) {
+      warning.setVisibility(granted ? View.GONE : View.VISIBLE);
     }
   }
 
@@ -1893,6 +1966,7 @@ public class HTTrackActivity extends FragmentActivity {
       /* Base path */
       TextView.class.cast(findViewById(R.id.fieldBasePath)).setText(
           getProjectRootFile().getAbsolutePath());
+      refreshStorageAccessHints();
 
       // "Next" button is disabled if no project name is defined
       switchEmptyProjectName = !OptionsMapper.isStringNonEmpty(mapper
@@ -3065,6 +3139,8 @@ public class HTTrackActivity extends FragmentActivity {
         && getSharedPreferences(PREFS_NAME, 0).getString(BASE_NAME, null) == null) {
       computeStorageTarget();
     }
+    // A grant made on the settings screen flips the button/warning off (no-op off this panel).
+    refreshStorageAccessHints();
   }
 
   @Override

--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -467,10 +467,7 @@ public class HTTrackActivity extends FragmentActivity {
     }
   }
 
-  /*
-   * Grant all-files access (Android 11+ settings screen, or the global-list fallback) or the legacy
-   * WRITE permission. Ungated, unlike the one-shot install prompt, so the panel button can reuse it.
-   */
+  // Ungated, unlike the one-shot install prompt, so the base-path panel button can reuse it.
   private void requestAllFilesAccess() {
     if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
       try {
@@ -496,31 +493,23 @@ public class HTTrackActivity extends FragmentActivity {
     requestAllFilesAccess();
   }
 
-  /*
-   * Base-path panel button: open the mirror folder in the system file UI. Private storage is hidden
-   * from file managers on Android 11+, so fall back to showing the path when it can't be opened.
-   */
+  // Base-path panel button. Private storage can't be opened in a file manager on Android 11+, so
+  // openFolderInFilesApp returns false there and we fall back to showing the path.
   public void onClickBrowseFolder(final View view) {
     final File dir = getProjectRootFile();
-    if (hasAllFilesAccess() && openFolderInFilesApp(dir)) {
-      return;
+    if (!openFolderInFilesApp(dir)) {
+      Toast.makeText(this, getString(R.string.base_path_toast, dir.getAbsolutePath()),
+          Toast.LENGTH_LONG).show();
     }
-    Toast.makeText(this, getString(R.string.base_path_toast, dir.getAbsolutePath()),
-        Toast.LENGTH_LONG).show();
   }
 
   /* Try to view dir through the external-storage documents provider. False if unmapped/unhandled. */
   private boolean openFolderInFilesApp(final File dir) {
-    final File shared = Environment.getExternalStorageDirectory();
-    if (shared == null) {
+    final String docId =
+        StoragePaths.externalStorageDocId(dir, Environment.getExternalStorageDirectory());
+    if (docId == null) {
       return false;
     }
-    final String root = shared.getAbsolutePath();
-    final String path = dir.getAbsolutePath();
-    if (!path.startsWith(root + File.separator)) {
-      return false;
-    }
-    final String docId = "primary:" + path.substring(root.length() + 1);
     final Uri uri =
         DocumentsContract.buildDocumentUri("com.android.externalstorage.documents", docId);
     final Intent intent = new Intent(Intent.ACTION_VIEW)
@@ -538,16 +527,18 @@ public class HTTrackActivity extends FragmentActivity {
     }
   }
 
-  /* Show the grant button and private-storage warning on the base-path panel only when access is off. */
+  // Base-path panel: warn whenever the mirror folder isn't browsable (private storage), which can
+  // outlast the permission bit when a private base path is persisted; offer the grant when it's off.
   private void refreshStorageAccessHints() {
-    final boolean granted = hasAllFilesAccess();
+    final boolean browsable = StoragePaths.externalStorageDocId(
+        getProjectRootFile(), Environment.getExternalStorageDirectory()) != null;
     final View grant = findViewById(R.id.buttonEnableAllFiles);
     if (grant != null) {
-      grant.setVisibility(granted ? View.GONE : View.VISIBLE);
+      grant.setVisibility(hasAllFilesAccess() ? View.GONE : View.VISIBLE);
     }
     final View warning = findViewById(R.id.textStorageWarning);
     if (warning != null) {
-      warning.setVisibility(granted ? View.GONE : View.VISIBLE);
+      warning.setVisibility(browsable ? View.GONE : View.VISIBLE);
     }
   }
 

--- a/app/src/main/java/com/httrack/android/StoragePaths.java
+++ b/app/src/main/java/com/httrack/android/StoragePaths.java
@@ -56,6 +56,36 @@ final class StoragePaths {
   }
 
   /**
+   * Documents-provider id ("primary:&lt;relative&gt;") to open {@code dir} in the system Files app via
+   * ACTION_VIEW, or null when it lies outside the primary shared volume or inside the Android/ subtree
+   * (both hidden from file managers on Android 11+), so the caller falls back.
+   *
+   * @param dir
+   *          the folder to open, need not exist
+   * @param shared
+   *          the primary shared root (getExternalStorageDirectory()), or null while unmounted
+   */
+  static String externalStorageDocId(final File dir, final File shared) {
+    if (dir == null || shared == null) {
+      return null;
+    }
+    try {
+      final String root = shared.getCanonicalPath();
+      final String path = dir.getCanonicalPath();
+      if (!path.startsWith(root + File.separator)) {
+        return null;
+      }
+      final String rel = path.substring(root.length() + 1);
+      if (rel.equals("Android") || rel.startsWith("Android" + File.separator)) {
+        return null;
+      }
+      return "primary:" + rel;
+    } catch (final IOException e) {
+      return null;
+    }
+  }
+
+  /**
    * Whether {@code name} is safe to append to a root as one directory. File does not fold "..", so
    * a crafted winprofile.ini name like "../../sdcard/evil" would otherwise steer the engine's -O
    * outside the Websites tree. Rejects empty, ".", ".." and anything carrying a path separator.

--- a/app/src/main/res/layout/activity_proj_name.xml
+++ b/app/src/main/res/layout/activity_proj_name.xml
@@ -107,6 +107,45 @@
 
     <LinearLayout
         android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical" >
+
+        <LinearLayout
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal" >
+
+            <Button
+                android:id="@+id/buttonBrowseFolder"
+                style="@style/ButtonStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:onClick="onClickBrowseFolder"
+                android:text="@string/open_base_folder" />
+
+            <Button
+                android:id="@+id/buttonEnableAllFiles"
+                style="@style/ButtonStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:onClick="onClickEnableAllFilesAccess"
+                android:text="@string/enable_all_files_access"
+                android:visibility="gone" />
+        </LinearLayout>
+
+        <TextView
+            android:id="@+id/textStorageWarning"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:paddingTop="4dp"
+            android:text="@string/storage_private_warning"
+            android:textStyle="italic"
+            android:visibility="gone" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="fill_parent"
         android:layout_height="fill_parent"
         android:gravity="bottom"
         android:orientation="vertical" >

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -217,6 +217,10 @@
     <string name="use_word_index">Make a word database</string>
     <string name="use_mail_index">Build a mail archive</string>
     <string name="base_path">Base path</string>
+    <string name="open_base_folder">Open folder</string>
+    <string name="enable_all_files_access">Grant all-files access</string>
+    <string name="storage_private_warning">Without all-files access, mirrors are saved in a private folder that other apps and file managers can\'t open. Grant access to keep them in a public HTTrack folder.</string>
+    <string name="base_path_toast">Mirror folder: %s</string>
     <string name="title_activity_file_chooser">FileChooserActivity</string>
     <string name="apply_base_path">Save prefs</string>
     <string name="ellipsis">…</string>

--- a/app/src/test/java/com/httrack/android/StoragePathsTest.java
+++ b/app/src/test/java/com/httrack/android/StoragePathsTest.java
@@ -104,4 +104,29 @@ public class StoragePathsTest {
     assertTrue(StoragePaths.isWritable(new File(external, "Websites"), external, internal));
     assertTrue(StoragePaths.isWritable(new File(internal, "Websites"), null, internal));
   }
+
+  /** A public folder maps to its "primary:<relative>" documents id. */
+  @Test
+  public void mapsAPublicFolderToItsDocId() throws Exception {
+    final File shared = tmp.newFolder("shared");
+    final File mirror = new File(new File(shared, "HTTrack"), "Websites");
+    assertEquals("primary:HTTrack" + File.separator + "Websites",
+        StoragePaths.externalStorageDocId(mirror, shared));
+  }
+
+  /** The Android/ subtree is hidden from file managers, so it must not map. */
+  @Test
+  public void refusesThePrivateAndroidSubtree() throws Exception {
+    final File shared = tmp.newFolder("shared2");
+    final File priv = new File(shared, "Android/data/com.httrack.android/files/Websites");
+    assertNull(StoragePaths.externalStorageDocId(priv, shared));
+  }
+
+  @Test
+  public void refusesAPathOutsideTheSharedRootOrWithoutIt() throws Exception {
+    final File shared = tmp.newFolder("shared3");
+    assertNull(StoragePaths.externalStorageDocId(new File(tmp.getRoot(), "elsewhere"), shared));
+    assertNull(StoragePaths.externalStorageDocId(shared, shared)); // the root itself, no sub-path
+    assertNull(StoragePaths.externalStorageDocId(new File(shared, "HTTrack"), null));
+  }
 }


### PR DESCRIPTION
Mirrors default to the app's private external storage, which file managers can't open on Android 11+, and all-files access (the public HTTrack/ folder) was only offered once at install with no way back. This adds three controls to the project base-path panel: a warning line when access is off, a "Grant all-files access" button to turn it on at any time, and an "Open folder" button that opens the mirror in the system Files app (falling back to showing the path when private storage can't be browsed).

Verified with a local arm64 + x86_64 build. The panel logic is Activity-bound so it isn't unit-testable here (stub android.jar), and the emulator is unavailable, so on-device behavior is unverified.