### PR TITLE
release: bump to 3.49.13.77 (versionCode 77)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,9 +16,9 @@ android {
         // insets (EdgeToEdge) are now mandatory: the platform ignores the opt-out at this level.
         targetSdk 36
         // Must exceed the versionCode currently live on the Play listing before uploading.
-        versionCode 76
+        versionCode 77
         // Prefix = engine HTTRACK_VERSIONID (htsglobal.h); track upstream.
-        versionName "3.49.13.76"
+        versionName "3.49.13.77"
 
         ndk {
             abiFilters "arm64-v8a", "x86_64"


### PR DESCRIPTION
Cuts vc77 to ship the base-path storage-access controls (#60), which landed after the vc76 tag and so aren't in the internal build yet, and to freshen the WARC engine. The engine moves 1e0c009 to b3e51d7: WACZ packaging, a --warc-cdx index, verbatim response bodies by default, and WARC segment rotation. The version prefix stays 3.49.13 (unchanged upstream), and there are no new engine sources so Android.mk is untouched. The Android UI still exposes only the --warc toggle.

Validated with a local arm64 and x86_64 build, with the WACZ/CDX code present in libhttrack.so.