### PR TITLE
options: move the WARC toggle to the Log/Index/Cache tab

### DIFF
--- a/app/src/main/java/com/httrack/android/OptionsActivity.java
+++ b/app/src/main/java/com/httrack/android/OptionsActivity.java
@@ -170,8 +170,8 @@ public class OptionsActivity extends FragmentActivity implements View.OnClickLis
   @ActivityId(R.layout.activity_options_build)
   @Fields({ R.id.checkDosNames, R.id.checkIso9660, R.id.checkNoErrorPages,
       R.id.checkNoExternalPages, R.id.checkHidePasswords,
-      R.id.checkHideQueryStrings, R.id.checkDoNotPurge, R.id.checkWarc,
-      R.id.radioBuild, R.id.editCustomBuild })
+      R.id.checkHideQueryStrings, R.id.checkDoNotPurge, R.id.radioBuild,
+      R.id.editCustomBuild })
   public static class BuildTab extends Tab {
   }
 
@@ -201,9 +201,9 @@ public class OptionsActivity extends FragmentActivity implements View.OnClickLis
   @Title(R.string.log_index_cache)
   @ActivityId(R.layout.activity_options_logindexcache)
   @Fields({ R.id.checkStoreAllFilesInCache,
-      R.id.checkDoNotRedownloadLocallErasedFiles, R.id.checkCreateLogFiles,
-      R.id.radioVerbosity, R.id.checkUseIndex, R.id.checkUseWordIndex,
-      R.id.checkUseMailIndex })
+      R.id.checkDoNotRedownloadLocallErasedFiles, R.id.checkWarc,
+      R.id.checkCreateLogFiles, R.id.radioVerbosity, R.id.checkUseIndex,
+      R.id.checkUseWordIndex, R.id.checkUseMailIndex })
   public static class LogIndexCache extends Tab {
   }
 

--- a/app/src/main/res/layout/activity_options_build.xml
+++ b/app/src/main/res/layout/activity_options_build.xml
@@ -56,12 +56,6 @@
             android:layout_height="wrap_content"
             android:text="@string/do_not_purge_old_files" />
 
-        <CheckBox
-            android:id="@+id/checkWarc"
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/write_warc_archive" />
-
         <LinearLayout
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"

--- a/app/src/main/res/layout/activity_options_logindexcache.xml
+++ b/app/src/main/res/layout/activity_options_logindexcache.xml
@@ -25,6 +25,12 @@
             android:layout_height="wrap_content"
             android:text="@string/do_not_redownload_locally_erased_files" />
 
+        <CheckBox
+            android:id="@+id/checkWarc"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/write_warc_archive" />
+
         <LinearLayout
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"


### PR DESCRIPTION
Moves the WARC output toggle from the Build tab to Log/Index/Cache, next to the cache options. WARC archives what was fetched at the transaction level, so it belongs beside the hts-cache rather than in Build with the browsable-mirror output formats.

Relocation only: the id→"Warc"→%r mapping in OptionsMapper is tab-independent and untouched, so the toggle still emits `--warc`.