### PR TITLE
fix: open the mirror folder instead of a path toast

### DIFF
--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -515,9 +515,8 @@ public class HTTrackActivity extends FragmentActivity {
     final Intent intent = new Intent(Intent.ACTION_VIEW)
         .setDataAndType(uri, DocumentsContract.Document.MIME_TYPE_DIR)
         .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-    if (intent.resolveActivity(getPackageManager()) == null) {
-      return false;
-    }
+    // No resolveActivity() pre-check: targetSdk 30+ package visibility makes it return null even
+    // when startActivity would launch the handler; the catch covers a genuinely absent one.
     try {
       startActivity(intent);
       return true;


### PR DESCRIPTION
"Open folder" did nothing but flash a "Mirror folder: ..." toast, even with all-files access and a public mirror path. The `resolveActivity()` guard in `openFolderInFilesApp` returns null under targetSdk 36 package visibility (no `<queries>` declared), so it fell back to the toast although `startActivity` would have opened the folder. Dropping the guard fixes it; the existing catch still handles a device with genuinely no handler.

Closes #63