### PR TITLE
release: bump to 3.49.13.78 (versionCode 78), engine WARC cmdguide

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,9 +16,9 @@ android {
         // insets (EdgeToEdge) are now mandatory: the platform ignores the opt-out at this level.
         targetSdk 36
         // Must exceed the versionCode currently live on the Play listing before uploading.
-        versionCode 77
+        versionCode 78
         // Prefix = engine HTTRACK_VERSIONID (htsglobal.h); track upstream.
-        versionName "3.49.13.77"
+        versionName "3.49.13.78"
 
         ndk {
             abiFilters "arm64-v8a", "x86_64"


### PR DESCRIPTION
Bumps versionCode to 78 / versionName 3.49.13.78 and the engine to d3d3bce, which adds a WARC/WACZ recipe to the command-line guide. That page ships in the in-app Help bundle (generated from the engine `html/` at build time), so the recipe reaches users. Engine version and sources are unchanged, so Android.mk and coucal stay put.

Rolls up the WARC toggle move (#62) and the Open folder fix (#64) already on master, for the internal-track release.