### PR TITLE
fix: open the folder via the SAF picker where no directory viewer exists

### DIFF
--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -53,6 +53,8 @@ import android.app.Notification;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.ActivityNotFoundException;
+import android.content.ClipData;
+import android.content.ClipboardManager;
 import android.content.ContentResolver;
 import android.content.Context;
 import android.content.Intent;
@@ -493,17 +495,23 @@ public class HTTrackActivity extends FragmentActivity {
     requestAllFilesAccess();
   }
 
-  // Base-path panel button. Private storage can't be opened in a file manager on Android 11+, so
-  // openFolderInFilesApp returns false there and we fall back to showing the path.
+  // Base-path panel button. Tries a viewer then the SAF picker; if neither resolves (e.g. private
+  // storage), copies the path to the clipboard so the user can paste it into a file manager.
   public void onClickBrowseFolder(final View view) {
     final File dir = getProjectRootFile();
     if (!openFolderInFilesApp(dir)) {
-      Toast.makeText(this, getString(R.string.base_path_toast, dir.getAbsolutePath()),
-          Toast.LENGTH_LONG).show();
+      final String path = dir.getAbsolutePath();
+      final ClipboardManager clipboard =
+          ClipboardManager.class.cast(getSystemService(CLIPBOARD_SERVICE));
+      if (clipboard != null) {
+        clipboard.setPrimaryClip(ClipData.newPlainText("path", path));
+      }
+      Toast.makeText(this, getString(R.string.base_path_toast, path), Toast.LENGTH_LONG).show();
     }
   }
 
-  /* Try to view dir through the external-storage documents provider. False if unmapped/unhandled. */
+  /* Open dir in a file viewer, else the SAF picker pre-navigated to it. False if neither resolves
+   * (e.g. private storage), so the caller falls back to the path. */
   private boolean openFolderInFilesApp(final File dir) {
     final String docId =
         StoragePaths.externalStorageDocId(dir, Environment.getExternalStorageDirectory());
@@ -512,16 +520,23 @@ public class HTTrackActivity extends FragmentActivity {
     }
     final Uri uri =
         DocumentsContract.buildDocumentUri("com.android.externalstorage.documents", docId);
-    final Intent intent = new Intent(Intent.ACTION_VIEW)
+    // ACTION_VIEW on a directory is honored only by AOSP DocumentsUI; Samsung My Files has none, so
+    // fall back to the SAF picker, which every device ships and pre-navigates to the folder.
+    return startFolderIntent(new Intent(Intent.ACTION_VIEW)
         .setDataAndType(uri, DocumentsContract.Document.MIME_TYPE_DIR)
-        .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-    // No resolveActivity() pre-check: targetSdk 30+ package visibility makes it return null even
-    // when startActivity would launch the handler; the catch covers a genuinely absent one.
+        .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION))
+        || startFolderIntent(new Intent(Intent.ACTION_OPEN_DOCUMENT_TREE)
+            .putExtra(DocumentsContract.EXTRA_INITIAL_URI, uri));
+  }
+
+  // Launch one folder-opening intent; false when unhandled so the next rung can try. startActivity
+  // beats a resolveActivity() pre-check, which targetSdk 30+ visibility makes null for real handlers.
+  private boolean startFolderIntent(final Intent intent) {
     try {
       startActivity(intent);
       return true;
     } catch (final Exception e) {
-      Log.d(getClass().getSimpleName(), "cannot open folder in files app", e);
+      Log.d(getClass().getSimpleName(), "folder intent unhandled: " + intent.getAction(), e);
       return false;
     }
   }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -220,7 +220,7 @@
     <string name="open_base_folder">Open folder</string>
     <string name="enable_all_files_access">Grant all-files access</string>
     <string name="storage_private_warning">Without all-files access, mirrors are saved in a private folder that other apps and file managers can\'t open. Grant access to keep them in a public HTTrack folder.</string>
-    <string name="base_path_toast">Mirror folder: %s</string>
+    <string name="base_path_toast">Folder path copied to clipboard: %s</string>
     <string name="title_activity_file_chooser">FileChooserActivity</string>
     <string name="apply_base_path">Save prefs</string>
     <string name="ellipsis">…</string>


### PR DESCRIPTION
Follow-up to #64, which removed the `resolveActivity` guard but was not enough: on Samsung One UI (S25, verified) no activity handles `ACTION_VIEW` on a directory document URI, so `startActivity` throws and "Open folder" still only toasts.

Replaces the single intent with a fallback chain: the document-URI viewer (AOSP DocumentsUI), then the SAF folder picker (`ACTION_OPEN_DOCUMENT_TREE` + `EXTRA_INITIAL_URI`, which every device ships and pre-navigates to the folder), then copy the path to the clipboard as a last resort. No `<queries>` needed since `startActivity` is not visibility-filtered.

The picker rung is a folder picker rather than a pure viewer, so it carries a Use-this-folder/Cancel bar, but it does show the mirror files and is the only thing that resolves on One UI.

Closes #63