### PR TITLE
release: bump to 3.49.13.79 (versionCode 79), Open folder SAF picker fix

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,9 +16,9 @@ android {
         // insets (EdgeToEdge) are now mandatory: the platform ignores the opt-out at this level.
         targetSdk 36
         // Must exceed the versionCode currently live on the Play listing before uploading.
-        versionCode 78
+        versionCode 79
         // Prefix = engine HTTRACK_VERSIONID (htsglobal.h); track upstream.
-        versionName "3.49.13.78"
+        versionName "3.49.13.79"
 
         ndk {
             abiFilters "arm64-v8a", "x86_64"


### PR DESCRIPTION
Bumps versionCode to 79 / versionName 3.49.13.79. Ships the Open folder fallback fix (#66): on devices with no directory viewer (Samsung One UI), it now opens the SAF folder picker pre-navigated to the mirror folder instead of only toasting. Engine unchanged, so the versionName prefix stays 3.49.13.