### PR TITLE
release: bump to 3.49.14.80 (versionCode 80), engine 3.49.14

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,9 +16,9 @@ android {
         // insets (EdgeToEdge) are now mandatory: the platform ignores the opt-out at this level.
         targetSdk 36
         // Must exceed the versionCode currently live on the Play listing before uploading.
-        versionCode 79
+        versionCode 80
         // Prefix = engine HTTRACK_VERSIONID (htsglobal.h); track upstream.
-        versionName "3.49.13.79"
+        versionName "3.49.14.80"
 
         ndk {
             abiFilters "arm64-v8a", "x86_64"


### PR DESCRIPTION
Bumps the vendored engine to the 3.49.14 tag and realigns the versionName prefix. versionCode 79 to 80. No new engine sources, so Android.mk is unchanged.