### PR TITLE
docs: fix broken License and Release Changes links in View Documentation

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -94,6 +94,8 @@ def buildResourcesBundle = tasks.register('buildResourcesBundle', Zip) {
     from('src/main/jni/httrack/html') { into 'html'; exclude 'Makefile.am' }
     from('src/main/jni/httrack/templates') { into 'templates'; exclude 'Makefile.am' }
     from('src/main/bundle/license') { into 'license' }
+    // html/index.html links to ../license.txt and ../history.txt at the bundle root.
+    from('src/main/jni/httrack') { include 'license.txt', 'history.txt' }
 }
 // preBuild is a transitive ancestor of every resource task, so this one edge gives
 // them all the dependency on the generated bundle that Gradle's validation requires.


### PR DESCRIPTION
The in-app "View Documentation" index (engine `html/index.html`) links to `../license.txt` ("License") and `../history.txt` ("Release Changes") at the bundle root, but the generated docs bundle only shipped `html/`, `templates/` and `license/`, so both links 404. Adds the two engine root files to the bundle root.