### PR TITLE
Drop the removed Java .class parser from the About-box credits

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -192,7 +192,7 @@
     <string name="no_index_html_in_xx">No \'index.html\' file in %s!</string>
     <string name="info_recreated_resources">Recreated HTTrack internal cached resources</string>
     <string name="info_could_not_create_resources">Could not create internal cached resources</string>
-    <string name="about_credits">\n(Please notify us of any bug or problem)\n\nDevelopment:\nInterface (Windows): Xavier Roche\nSpider: Xavier Roche\nJavaParserClasses: Yann Philippot\n\n&#169;1998-2026 Xavier Roche and other contributors\nMANY THANKS for translation tips to:\nRobert Lagadec (rlagadec@yahoo.fr)</string>
+    <string name="about_credits">\n(Please notify us of any bug or problem)\n\nDevelopment:\nInterface (Windows): Xavier Roche\nSpider: Xavier Roche\n\n&#169;1998-2026 Xavier Roche and other contributors\nMANY THANKS for translation tips to:\nRobert Lagadec (rlagadec@yahoo.fr)</string>
     <string name="could_not_get_external_directory">Could not get the system external storage directory</string>
     <string name="could_not_write_to">Could not write to:</string>
     <string name="read_only_storage_media">Read-only media (SDCARD)</string>


### PR DESCRIPTION
The About box still credited a Java `.class` parser the engine removed years ago (httrack#552). xroche/httrack#691 dropped that line from the engine credits; this mirrors it in the app's hand-maintained `about_credits` string. That one string is the only copy in the repo, so it's the whole change.