### PR TITLE
release: bump to 3.49.14.81 (versionCode 81)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,9 +16,9 @@ android {
         // insets (EdgeToEdge) are now mandatory: the platform ignores the opt-out at this level.
         targetSdk 36
         // Must exceed the versionCode currently live on the Play listing before uploading.
-        versionCode 80
+        versionCode 81
         // Prefix = engine HTTRACK_VERSIONID (htsglobal.h); track upstream.
-        versionName "3.49.14.80"
+        versionName "3.49.14.81"
 
         ndk {
             abiFilters "arm64-v8a", "x86_64"


### PR DESCRIPTION
Bumps versionCode to 81 to release the two changes that have been on master since vc80: the doc-index license.txt/history.txt bundling (#69) and the dropped Java `.class` parser credit (#70). Engine is unchanged at 3.49.14, so the versionName prefix stays and only build.gradle moves.