### PR TITLE
release: bump to 3.49.14.82 (versionCode 82)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,9 +16,9 @@ android {
         // insets (EdgeToEdge) are now mandatory: the platform ignores the opt-out at this level.
         targetSdk 36
         // Must exceed the versionCode currently live on the Play listing before uploading.
-        versionCode 81
+        versionCode 82
         // Prefix = engine HTTRACK_VERSIONID (htsglobal.h); track upstream.
-        versionName "3.49.14.81"
+        versionName "3.49.14.82"
 
         ndk {
             abiFilters "arm64-v8a", "x86_64"


### PR DESCRIPTION
Bumps versionCode to 82 for a beta release carrying the project-name wizard fix (#72): selecting an existing project no longer loses the Web address after navigating Back and forward. Engine unchanged at 3.49.14, so only `build.gradle` moves.