### PR TITLE
release: bump to 3.49.14.83 (versionCode 83)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,9 +16,9 @@ android {
         // insets (EdgeToEdge) are now mandatory: the platform ignores the opt-out at this level.
         targetSdk 36
         // Must exceed the versionCode currently live on the Play listing before uploading.
-        versionCode 82
+        versionCode 83
         // Prefix = engine HTTRACK_VERSIONID (htsglobal.h); track upstream.
-        versionName "3.49.14.82"
+        versionName "3.49.14.83"
 
         ndk {
             abiFilters "arm64-v8a", "x86_64"


### PR DESCRIPTION
Internal release carrying the coffeecatch bump (#75): the crash handler now picks the old signal handler by `SA_SIGINFO` rather than by NULL-ness, and guards against a fault inside the unwinder recursing.

Engine unchanged at 3.49.14, so only `build.gradle` moves.