### PR TITLE
Surface the sitemap, single-file and change-report options in the GUI

### DIFF
--- a/app/src/main/java/com/httrack/android/OptionsActivity.java
+++ b/app/src/main/java/com/httrack/android/OptionsActivity.java
@@ -170,8 +170,8 @@ public class OptionsActivity extends FragmentActivity implements View.OnClickLis
   @ActivityId(R.layout.activity_options_build)
   @Fields({ R.id.checkDosNames, R.id.checkIso9660, R.id.checkNoErrorPages,
       R.id.checkNoExternalPages, R.id.checkHidePasswords,
-      R.id.checkHideQueryStrings, R.id.checkDoNotPurge, R.id.radioBuild,
-      R.id.editCustomBuild })
+      R.id.checkHideQueryStrings, R.id.checkDoNotPurge, R.id.checkSingleFile,
+      R.id.radioBuild, R.id.editCustomBuild })
   public static class BuildTab extends Tab {
   }
 
@@ -186,8 +186,8 @@ public class OptionsActivity extends FragmentActivity implements View.OnClickLis
   @ActivityId(R.layout.activity_options_spider)
   @Fields({ R.id.checkAcceptCookies, R.id.editCookiesFile,
       R.id.radioCheckDocumentType, R.id.checkParseJavaFiles, R.id.radioSpider,
-      R.id.checkUpdateHacks, R.id.checkUrlHacks, R.id.checkTolerentRequests,
-      R.id.checkForceHttp10 })
+      R.id.checkSitemap, R.id.checkUpdateHacks, R.id.checkUrlHacks,
+      R.id.checkTolerentRequests, R.id.checkForceHttp10 })
   public static class Spider extends Tab {
   }
 
@@ -202,8 +202,8 @@ public class OptionsActivity extends FragmentActivity implements View.OnClickLis
   @ActivityId(R.layout.activity_options_logindexcache)
   @Fields({ R.id.checkStoreAllFilesInCache,
       R.id.checkDoNotRedownloadLocallErasedFiles, R.id.checkWarc,
-      R.id.checkCreateLogFiles, R.id.radioVerbosity, R.id.checkUseIndex,
-      R.id.checkUseWordIndex, R.id.checkUseMailIndex })
+      R.id.checkChanges, R.id.checkCreateLogFiles, R.id.radioVerbosity,
+      R.id.checkUseIndex, R.id.checkUseWordIndex, R.id.checkUseMailIndex })
   public static class LogIndexCache extends Tab {
   }
 

--- a/app/src/main/java/com/httrack/android/OptionsMapper.java
+++ b/app/src/main/java/com/httrack/android/OptionsMapper.java
@@ -1377,11 +1377,9 @@ public class OptionsMapper {
   }
 
   /**
-   * Boolean option emitted as its own argument, in long form.
-   *
-   * Mandatory when the short form has a two-letter variant (-%m / -%mu, -%Z /
-   * -%Zs): packed in the compacted flag string, the next flag's first letter
-   * would be read as that variant and swallow an argument.
+   * Required for a short flag with a two-letter variant (-%m / -%mu, -%Z /
+   * -%Zs): packed in the compacted string, the next flag's first letter would
+   * be misread as that variant and swallow an argument.
    */
   public static class LongOptionFlag implements OptionMapper {
     protected final String option;

--- a/app/src/main/java/com/httrack/android/OptionsMapper.java
+++ b/app/src/main/java/com/httrack/android/OptionsMapper.java
@@ -104,6 +104,7 @@ public class OptionsMapper {
       new Pair<Integer, String>(R.id.checkHidePasswords, "NoPwdInPages"),
       new Pair<Integer, String>(R.id.checkHideQueryStrings, "NoQueryStrings"),
       new Pair<Integer, String>(R.id.checkDoNotPurge, "NoPurgeOldFiles"),
+      new Pair<Integer, String>(R.id.checkSingleFile, "SingleFile"),
       new Pair<Integer, String>(R.id.checkWarc, "Warc"),
       new Pair<Integer, String>(R.id.radioBuild, "Build"),
       new Pair<Integer, String>(R.id.editCustomBuild, "BuildString"),
@@ -121,6 +122,7 @@ public class OptionsMapper {
       new Pair<Integer, String>(R.id.radioCheckDocumentType, "CheckType"),
       new Pair<Integer, String>(R.id.checkParseJavaFiles, "ParseJava"),
       new Pair<Integer, String>(R.id.radioSpider, "FollowRobotsTxt"),
+      new Pair<Integer, String>(R.id.checkSitemap, "Sitemap"),
       new Pair<Integer, String>(R.id.checkUpdateHacks, "UpdateHack"),
       new Pair<Integer, String>(R.id.checkUrlHacks, "URLHack"),
       new Pair<Integer, String>(R.id.checkTolerentRequests, "TolerantRequests"),
@@ -137,6 +139,7 @@ public class OptionsMapper {
           "StoreAllInCache"),
       new Pair<Integer, String>(R.id.checkDoNotRedownloadLocallErasedFiles,
           "NoRecatch"),
+      new Pair<Integer, String>(R.id.checkChanges, "Changes"),
       new Pair<Integer, String>(R.id.checkCreateLogFiles, "Log"),
       /* FIXME with Log */
       new Pair<Integer, String>(R.id.radioVerbosity, "LogType"),
@@ -200,6 +203,9 @@ public class OptionsMapper {
       new Pair<String, String>("NoQueryStrings", "0"),
       new Pair<String, String>("NoPurgeOldFiles", "0"),
       new Pair<String, String>("Warc", "0"),
+      new Pair<String, String>("Sitemap", "0"),
+      new Pair<String, String>("SingleFile", "0"),
+      new Pair<String, String>("Changes", "0"),
       new Pair<String, String>("Cookies", "1"),
       new Pair<String, String>("CheckType", "1"),
       new Pair<String, String>("ParseJava", "1"),
@@ -290,6 +296,10 @@ public class OptionsMapper {
       new Pair<String, OptionMapper>("NoPurgeOldFiles", new SimpleOptionFlag(
           "X0")),
       new Pair<String, OptionMapper>("Warc", new SimpleOptionFlag("%r")),
+      new Pair<String, OptionMapper>("Sitemap", new LongOptionFlag("--sitemap")),
+      new Pair<String, OptionMapper>("SingleFile", new LongOptionFlag(
+          "--single-file")),
+      new Pair<String, OptionMapper>("Changes", new LongOptionFlag("--changes")),
       new Pair<String, OptionMapper>("Build", buildHandler.getTypeMapper()),
       new Pair<String, OptionMapper>("BuildString",
           buildHandler.getCustomMapper()),
@@ -1362,6 +1372,29 @@ public class OptionsMapper {
         if ((!reverted && "1".equals(value)) || (reverted && "0".equals(value))) {
           flags.append(option);
         }
+      }
+    }
+  }
+
+  /**
+   * Boolean option emitted as its own argument, in long form.
+   *
+   * Mandatory when the short form has a two-letter variant (-%m / -%mu, -%Z /
+   * -%Zs): packed in the compacted flag string, the next flag's first letter
+   * would be read as that variant and swallow an argument.
+   */
+  public static class LongOptionFlag implements OptionMapper {
+    protected final String option;
+
+    public LongOptionFlag(final String option) {
+      this.option = option;
+    }
+
+    @Override
+    public void emit(final StringBuilder flags, final List<String> commandline,
+        final String value) {
+      if ("1".equals(value)) {
+        commandline.add(option);
       }
     }
   }

--- a/app/src/main/jni/Android.mk
+++ b/app/src/main/jni/Android.mk
@@ -76,6 +76,8 @@ LOCAL_SRC_FILES := httrack/src/htscore.c httrack/src/htsparse.c 			\
 	httrack/src/htscache_selftest.c httrack/src/htsdns_selftest.c			\
 	httrack/src/htscodec.c httrack/src/htsproxy.c							\
 	httrack/src/htsurlport.c httrack/src/htswarc.c							\
+	httrack/src/htssitemap.c httrack/src/htssinglefile.c					\
+	httrack/src/htschanges.c httrack/src/htscmdline.c						\
 	httrack/src/minizip/ioapi.c												\
 	httrack/src/minizip/mztools.c httrack/src/minizip/unzip.c				\
 	httrack/src/minizip/zip.c

--- a/app/src/main/res/layout/activity_options_build.xml
+++ b/app/src/main/res/layout/activity_options_build.xml
@@ -56,6 +56,12 @@
             android:layout_height="wrap_content"
             android:text="@string/do_not_purge_old_files" />
 
+        <CheckBox
+            android:id="@+id/checkSingleFile"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/single_file" />
+
         <LinearLayout
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"

--- a/app/src/main/res/layout/activity_options_logindexcache.xml
+++ b/app/src/main/res/layout/activity_options_logindexcache.xml
@@ -31,6 +31,12 @@
             android:layout_height="wrap_content"
             android:text="@string/write_warc_archive" />
 
+        <CheckBox
+            android:id="@+id/checkChanges"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/report_changes" />
+
         <LinearLayout
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"

--- a/app/src/main/res/layout/activity_options_spider.xml
+++ b/app/src/main/res/layout/activity_options_spider.xml
@@ -119,6 +119,13 @@
         </LinearLayout>
 
         <CheckBox
+            android:id="@+id/checkSitemap"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="end"
+            android:text="@string/sitemap" />
+
+        <CheckBox
             android:id="@+id/checkUpdateHacks"
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -68,7 +68,10 @@
     <string name="hide_passwords">Hide passwords</string>
     <string name="hide_query_strings">Hide query strings</string>
     <string name="do_not_purge_old_files">Do not purge old files</string>
+    <string name="single_file">Inline assets as data: URIs (self-contained pages)</string>
     <string name="write_warc_archive">Write WARC archive</string>
+    <string name="report_changes">Report what changed since the previous mirror</string>
+    <string name="sitemap">Seed the crawl from the site\'s sitemap</string>
     <string name="number_of_connections">Max simultaneous connections</string>
     <string name="persistent_connections">Persistent connections (Keep-Alive)</string>
     <string name="timeout">File timeout</string>

--- a/app/src/test/java/com/httrack/android/OptionsEmissionTest.java
+++ b/app/src/test/java/com/httrack/android/OptionsEmissionTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import com.httrack.android.OptionsMapper.ArgumentOption;
+import com.httrack.android.OptionsMapper.LongOptionFlag;
 import com.httrack.android.OptionsMapper.OptionMapper;
 import com.httrack.android.OptionsMapper.ProxyHandler;
 import com.httrack.android.OptionsMapper.SimpleOptionFlag;
@@ -97,5 +98,27 @@ public class OptionsEmissionTest {
     final StringBuilder flags = new StringBuilder();
     new SimpleOptionFlag("%r").emit(flags, new ArrayList<String>(), "0");
     assertFalse(flags.toString().contains("%r"));
+  }
+
+  /* sitemap/single-file/changes: own token, and never in the packed string. */
+  @Test
+  public void longOptionEmitsItsOwnTokenWhenChecked() {
+    final StringBuilder flags = new StringBuilder();
+    final List<String> cmd = new ArrayList<String>();
+    new LongOptionFlag("--sitemap").emit(flags, cmd, "1");
+    assertEquals(1, cmd.size());
+    assertEquals("--sitemap", cmd.get(0));
+    assertEquals("", flags.toString());
+  }
+
+  @Test
+  public void longOptionStaysSilentWhenUncheckedOrUnset() {
+    for (final String value : new String[] { "0", "", null }) {
+      final StringBuilder flags = new StringBuilder();
+      final List<String> cmd = new ArrayList<String>();
+      new LongOptionFlag("--single-file").emit(flags, cmd, value);
+      assertTrue(cmd.isEmpty());
+      assertEquals("", flags.toString());
+    }
   }
 }

--- a/app/src/test/java/com/httrack/android/OptionsEmissionTest.java
+++ b/app/src/test/java/com/httrack/android/OptionsEmissionTest.java
@@ -103,22 +103,38 @@ public class OptionsEmissionTest {
   /* sitemap/single-file/changes: own token, and never in the packed string. */
   @Test
   public void longOptionEmitsItsOwnTokenWhenChecked() {
-    final StringBuilder flags = new StringBuilder();
-    final List<String> cmd = new ArrayList<String>();
-    new LongOptionFlag("--sitemap").emit(flags, cmd, "1");
-    assertEquals(1, cmd.size());
-    assertEquals("--sitemap", cmd.get(0));
-    assertEquals("", flags.toString());
+    for (final String option : new String[] { "--sitemap", "--single-file",
+        "--changes" }) {
+      /* seeded as buildCommandline() does, so a guarded append cannot hide */
+      final StringBuilder flags = new StringBuilder("-");
+      final List<String> cmd = new ArrayList<String>();
+      new LongOptionFlag(option).emit(flags, cmd, "1");
+      assertEquals(1, cmd.size());
+      assertEquals(option, cmd.get(0));
+      assertEquals("-", flags.toString());
+    }
   }
 
   @Test
   public void longOptionStaysSilentWhenUncheckedOrUnset() {
     for (final String value : new String[] { "0", "", null }) {
-      final StringBuilder flags = new StringBuilder();
+      final StringBuilder flags = new StringBuilder("-");
       final List<String> cmd = new ArrayList<String>();
       new LongOptionFlag("--single-file").emit(flags, cmd, value);
       assertTrue(cmd.isEmpty());
-      assertEquals("", flags.toString());
+      assertEquals("-", flags.toString());
     }
+  }
+
+  /* the mappers are static singletons: emitting again must not go quiet. */
+  @Test
+  public void longOptionEmitsOnEveryBuild() {
+    final OptionMapper mapper = new LongOptionFlag("--changes");
+    final List<String> first = new ArrayList<String>();
+    final List<String> second = new ArrayList<String>();
+    mapper.emit(new StringBuilder("-"), first, "1");
+    mapper.emit(new StringBuilder("-"), second, "1");
+    assertEquals(first, second);
+    assertEquals("--changes", second.get(0));
   }
 }


### PR DESCRIPTION
The engine gained `--sitemap`, `--single-file` and `--changes`. This bumps the vendored snapshot to core master and adds a checkbox for each, on the same tab the reference GUI uses: Spider, Build, Log/Index/Cache.

The three go out as their own argv token instead of being packed into the compacted `-%…` string, unlike every other boolean here. `-%m` and `-%Z` each have a two-letter variant (`-%mu` takes a URL, `-%Zs` takes a size), and the engine reads the packed string one character at a time, so the next flag's first letter would be taken for that variant and swallow an argument. On Spider the neighbour is `-u`, on Build it is `-s`.

`Android.mk` lists engine sources by hand, so the bump also registers `htssitemap.c`, `htssinglefile.c`, `htschanges.c` and `htscmdline.c`. The last one came with an unrelated core change and would have broken the link by itself, confirmed by symbol-checking `libhttrack.so`.

The tests cover the emitter and were checked against three broken versions of it. The table wiring behind it has no test seam, because `android.util.Pair` in the static tables throws under the stub `android.jar`, so that part rests on the build and on trying the checkboxes.
