### PR TITLE
release: bump to 3.49.14.84 (versionCode 84)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,9 +16,9 @@ android {
         // insets (EdgeToEdge) are now mandatory: the platform ignores the opt-out at this level.
         targetSdk 36
         // Must exceed the versionCode currently live on the Play listing before uploading.
-        versionCode 83
+        versionCode 84
         // Prefix = engine HTTRACK_VERSIONID (htsglobal.h); track upstream.
-        versionName "3.49.14.83"
+        versionName "3.49.14.84"
 
         ndk {
             abiFilters "arm64-v8a", "x86_64"


### PR DESCRIPTION
Cuts an internal release carrying the three new engine options from #77. The engine is unchanged at 3.49.14, so only the versionCode moves.