### PR TITLE
Bump the engine and cut versionCode 85

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,9 +16,9 @@ android {
         // insets (EdgeToEdge) are now mandatory: the platform ignores the opt-out at this level.
         targetSdk 36
         // Must exceed the versionCode currently live on the Play listing before uploading.
-        versionCode 84
+        versionCode 85
         // Prefix = engine HTTRACK_VERSIONID (htsglobal.h); track upstream.
-        versionName "3.49.14.84"
+        versionName "3.49.14.85"
 
         ndk {
             abiFilters "arm64-v8a", "x86_64"


### PR DESCRIPTION
Moves the pinned engine 52 commits to cd3051c and cuts versionCode 85. The bump brings in 374087a, the fix for the log-callback va_list bug that segfaulted the crawl when the sitemap checkbox was set in vc84, so this closes #82.

Engine version is still 3.49.14, so the versionName prefix stays. The build list and the option table did not move either, so nothing changes in Android.mk or the GUI wiring. I checked that the new engine actually linked by grepping the built libhttrack.so for a symbol new to the bump: 11 hits, against 0 in the vc84 .so.

Not device-tested. The sitemap arm has only ever been proven against a locally patched engine, never against this pin.