### PR TITLE
A recovered native crash still kills the app

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,9 +16,9 @@ android {
         // insets (EdgeToEdge) are now mandatory: the platform ignores the opt-out at this level.
         targetSdk 36
         // Must exceed the versionCode currently live on the Play listing before uploading.
-        versionCode 86
+        versionCode 87
         // Prefix = engine HTTRACK_VERSIONID (htsglobal.h); track upstream.
-        versionName "3.49.14.86"
+        versionName "3.49.14.87"
 
         ndk {
             abiFilters "arm64-v8a", "x86_64"

--- a/app/src/main/java/com/httrack/android/CleanupActivity.java
+++ b/app/src/main/java/com/httrack/android/CleanupActivity.java
@@ -257,7 +257,13 @@ public class CleanupActivity extends ListActivity {
           }
         } else {
           // Rebuild top index
-          HTTrackLib.buildTopIndex(projectRootFile, resourceFile);
+          try {
+            HTTrackLib.buildTopIndex(projectRootFile, resourceFile);
+          } catch (final Throwable t) {
+            // Recovered native fault: a stale top index must not kill the cleanup thread.
+            Log.e(getClass().getSimpleName(), "could not rebuild top index", t);
+            HTTrackActivity.emergencyDump(getApplicationContext(), t);
+          }
         }
 
         deliverDeleteOutcome(deleted, deleteRootPath);

--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -303,7 +303,12 @@ public class HTTrackActivity extends FragmentActivity {
 
     // Set root path for logs
     if (HTTrackLib.loadedSuccessfully()) {
-      HTTrackLib.initRootPath(projectPath.getAbsolutePath());
+      try {
+        HTTrackLib.initRootPath(projectPath.getAbsolutePath());
+      } catch (final Throwable t) {
+        // Recovered native fault: losing the crash log is better than losing the app.
+        Log.e(getClass().getSimpleName(), "could not set the log root path", t);
+      }
     }
 
     // Change ?
@@ -1123,7 +1128,14 @@ public class HTTrackActivity extends FragmentActivity {
     // Build top index
     final File rsc = getResourceFile();
     if (rsc != null) {
-      return HTTrackLib.buildTopIndex(getProjectRootFile(), rsc);
+      try {
+        return HTTrackLib.buildTopIndex(getProjectRootFile(), rsc);
+      } catch (final Throwable t) {
+        // Recovered native fault: a missing top index is not worth the process.
+        Log.e(getClass().getSimpleName(), "could not build top index", t);
+        emergencyDump(getApplicationContext(), t);
+        return 0;
+      }
     } else {
       return 0;
     }
@@ -1421,7 +1433,10 @@ public class HTTrackActivity extends FragmentActivity {
         // Build top index
         buildTopIndex();
       } catch (final IOException io) {
-        message = io.getMessage();
+        // Carries user-supplied paths, and the panel renders it as HTML.
+        final String detail = io.getMessage();
+        message = TextUtils.htmlEncode(
+            detail != null ? detail : HTTrackActivity.describeCrash(io));
       } catch (final Throwable t) {
         // A native fault recovered by coffeecatch lands here as java.lang.Error.
         Log.e(getClass().getSimpleName(), "crawl aborted", t);

--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -1423,8 +1423,7 @@ public class HTTrackActivity extends FragmentActivity {
       } catch (final IOException io) {
         message = io.getMessage();
       } catch (final Throwable t) {
-        // A native fault recovered by coffeecatch lands here as java.lang.Error: report it on
-        // the finished panel instead of letting it take the process down.
+        // A native fault recovered by coffeecatch lands here as java.lang.Error.
         Log.e(getClass().getSimpleName(), "crawl aborted", t);
         HTTrackActivity.emergencyDump(appContext, t);
         message = "<b>Error</b>: "

--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -1101,6 +1101,20 @@ public class HTTrackActivity extends FragmentActivity {
   }
 
   /**
+   * Describe a throwable that aborted a crawl, for the finished panel.
+   *
+   * @param e
+   *          the throwable to describe
+   * @return plain text, not HTML-escaped
+   */
+  static String describeCrash(final Throwable e) {
+    final String detail = e.getMessage();
+    return detail != null && !detail.isEmpty()
+        ? e.getClass().getName() + ": " + detail
+        : e.getClass().getName();
+  }
+
+  /**
    * Build the top index.
    * 
    * @return 1 upon success
@@ -1304,7 +1318,8 @@ public class HTTrackActivity extends FragmentActivity {
     protected Void doInBackground(final Void... arg0) {
       try {
         runInternal();
-      } catch (final RuntimeException e) {
+      } catch (final Throwable e) {
+        // Last resort: runInternal absorbs its own failures, this only covers what comes after.
         HTTrackActivity.emergencyDump(appContext, e);
         throw e;
       } finally {
@@ -1407,6 +1422,13 @@ public class HTTrackActivity extends FragmentActivity {
         buildTopIndex();
       } catch (final IOException io) {
         message = io.getMessage();
+      } catch (final Throwable t) {
+        // A native fault recovered by coffeecatch lands here as java.lang.Error: report it on
+        // the finished panel instead of letting it take the process down.
+        Log.e(getClass().getSimpleName(), "crawl aborted", t);
+        HTTrackActivity.emergencyDump(appContext, t);
+        message = "<b>Error</b>: "
+            + TextUtils.htmlEncode(HTTrackActivity.describeCrash(t));
       } finally {
         // Release inter-thread lock
         if (profile != null) {

--- a/app/src/main/jni/htslibjni.c
+++ b/app/src/main/jni/htslibjni.c
@@ -348,10 +348,7 @@ JNICALL void Java_com_httrack_android_jni_HTTrackLib_initStatic(JNIEnv* env, jcl
   hts_set_log_vprint_callback(httrackLogCallback);
 }
 
-JNICALL void
-Java_com_httrack_android_jni_HTTrackLib_initRootPath(JNIEnv* env,
-                                                     jclass clazz,
-                                                     jstring opath) {
+static void HTTrackLib_initRootPath(JNIEnv* env, jclass clazz, jstring opath) {
   if (opath != NULL) {
     const char* path = (*env)->GetStringUTFChars(env, opath, NULL);
 
@@ -407,6 +404,17 @@ Java_com_httrack_android_jni_HTTrackLib_initRootPath(JNIEnv* env,
 #undef ASSERT_THROWS
 #undef L
 #undef L_
+}
+
+JNICALL void
+Java_com_httrack_android_jni_HTTrackLib_initRootPath(JNIEnv* env,
+                                                     jclass clazz,
+                                                     jstring opath) {
+#ifdef USE_COFFEECATCH
+  COFFEE_TRY_JNI(env, HTTrackLib_initRootPath(env, clazz, opath));
+#else
+  HTTrackLib_initRootPath(env, clazz, opath);
+#endif
 }
 
 /* note: never called on Android */
@@ -777,9 +785,8 @@ Java_com_httrack_android_jni_HTTrackLib_stop(JNIEnv* env, jobject object,
   return stopped;
 }
 
-JNICALL jint
-Java_com_httrack_android_jni_HTTrackLib_buildTopIndex(JNIEnv* env, jclass clazz,
-                                                      jstring opath, jstring otemplates) {
+static jint HTTrackLib_buildTopIndex(JNIEnv* env, jclass clazz, jstring opath,
+                                     jstring otemplates) {
   if (opath != NULL && otemplates != NULL) {
     const char* path = (*env)->GetStringUTFChars(env, opath, NULL);
     const char* templates = (*env)->GetStringUTFChars(env, otemplates, NULL);
@@ -800,6 +807,18 @@ Java_com_httrack_android_jni_HTTrackLib_buildTopIndex(JNIEnv* env, jclass clazz,
     return -1;
   }
   UNUSED(clazz);
+}
+
+JNICALL jint
+Java_com_httrack_android_jni_HTTrackLib_buildTopIndex(JNIEnv* env, jclass clazz,
+                                                      jstring opath, jstring otemplates) {
+#ifdef USE_COFFEECATCH
+  volatile jint ret = -1;
+  COFFEE_TRY_JNI(env, ret = HTTrackLib_buildTopIndex(env, clazz, opath, otemplates));
+  return ret;
+#else
+  return HTTrackLib_buildTopIndex(env, clazz, opath, otemplates);
+#endif
 }
 
 jint HTTrackLib_main(JNIEnv* env, jobject object, jobjectArray stringArray) {

--- a/app/src/test/java/com/httrack/android/CrashDescriptionTest.java
+++ b/app/src/test/java/com/httrack/android/CrashDescriptionTest.java
@@ -1,0 +1,24 @@
+package com.httrack.android;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+/** Guards HTTrackActivity.describeCrash, the text a crashed crawl shows on the finished panel. */
+public class CrashDescriptionTest {
+  @Test
+  public void keepsTheNativeFaultDetail() {
+    // What coffeecatch rethrows for a recovered SIGSEGV.
+    assertEquals("java.lang.Error: signal 11 (SIGSEGV) at address 0x0",
+        HTTrackActivity.describeCrash(
+            new Error("signal 11 (SIGSEGV) at address 0x0")));
+  }
+
+  @Test
+  public void namesTheClassWhenThereIsNoDetail() {
+    assertEquals("java.lang.NullPointerException",
+        HTTrackActivity.describeCrash(new NullPointerException()));
+    assertEquals("java.lang.IllegalStateException",
+        HTTrackActivity.describeCrash(new IllegalStateException("")));
+  }
+}


### PR DESCRIPTION
A native fault recovered by coffeecatch arrives in Java as `java.lang.Error`, and nothing in the runner caught it: it escaped the AsyncTask worker and killed the process anyway, taking `emergencyDump` and the native backtrace with it. So the recovery shipped in #85 was invisible to users. `runInternal` now catches `Throwable` and reports the fault on the finished panel like any other failure, and the last-resort dump in `doInBackground` widens to match.

Reviewing that turned up the same hole one layer down: only `main` was wrapped in `COFFEE_TRY_JNI`, so a fault in `buildTopIndex` or `initRootPath` killed the process with no `Error` for anyone to catch, and `CleanupActivity`'s cleanup thread had no protection at all. Both are wrapped now, and their callers degrade instead of dying: a missing top index, or a lost crash-log path. `stop()` is deliberately left alone, since its body runs under the context mutex and unwinding out of it would trade a crash for a deadlock on the next stop.

The catch itself has no unit-test seam (it needs a live Activity), so the test covers only the message helper. Not yet device-verified: the check is `-#c=segv` in the Scan Rules field, which should now end on the finished panel instead of killing the app.

Also cuts vc87 (`3.49.14.87`). The engine and coffeecatch pins are untouched.

Closes #86
