### PR TITLE
release: bump to 3.49.14.88 (versionCode 88), fresh engine

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,9 +16,9 @@ android {
         // insets (EdgeToEdge) are now mandatory: the platform ignores the opt-out at this level.
         targetSdk 36
         // Must exceed the versionCode currently live on the Play listing before uploading.
-        versionCode 87
+        versionCode 88
         // Prefix = engine HTTRACK_VERSIONID (htsglobal.h); track upstream.
-        versionName "3.49.14.87"
+        versionName "3.49.14.88"
 
         ndk {
             abiFilters "arm64-v8a", "x86_64"


### PR DESCRIPTION
Bumps the engine to 401323f (8 commits) and cuts versionCode 88 / versionName 3.49.14.88.

The point of the release is the help bundle, which is generated from the pinned engine at build time. The Android help page used to be a stub pointing at the desktop reference; it now documents all eleven option tabs with screenshots recaptured from vc85, including six settings the desktop pages never covered. `android.html` redirects into `guide.html#droid/` and `index.html` links straight to the guide.

No compiled code changed: the only C delta in the range is `htsserver.c`, which `Android.mk` does not build, and the coucal bump touches CI files only. The generated `resources.zip` carries `guide.html`, `guide.js` and 37 screenshots that do not exist at the old pin, which is the proof the bump reached the build product. Costs about 1 MB of APK. Not device-tested.