### PR TITLE
Release 3.50-beta-1 (versionCode 89) on engine 3.49.15

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,9 +16,10 @@ android {
         // insets (EdgeToEdge) are now mandatory: the platform ignores the opt-out at this level.
         targetSdk 36
         // Must exceed the versionCode currently live on the Play listing before uploading.
-        versionCode 88
-        // Prefix = engine HTTRACK_VERSIONID (htsglobal.h); track upstream.
-        versionName "3.49.14.88"
+        versionCode 89
+        // Deliberately off the engine's 3.49.15: this is the cross-platform 3.50 beta, named to
+        // match the Windows release. Realign the prefix with HTTRACK_VERSIONID once 3.50 is final.
+        versionName "3.50-beta-1"
 
         ndk {
             abiFilters "arm64-v8a", "x86_64"

--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -220,6 +220,7 @@ public class HTTrackActivity extends FragmentActivity {
   protected String version;
   protected String versionFeatures;
   protected int versionCode;
+  protected String versionName;
 
   /*
    * Mark this profile as in use.
@@ -689,6 +690,7 @@ public class HTTrackActivity extends FragmentActivity {
       final PackageInfo info = getPackageManager().getPackageInfo(
           getPackageName(), 0);
       versionCode = info.versionCode;
+      versionName = info.versionName;
     } catch (final NameNotFoundException e) {
       throw new RuntimeException(e);
     }
@@ -1979,13 +1981,14 @@ public class HTTrackActivity extends FragmentActivity {
       final StringBuilder str = new StringBuilder();
       str.append("<i>");
       if (version != null) {
+        // The app's own name leads: a 3.50 beta can ride a 3.49 engine.
         str.append("<br />Version: ");
-        // Library version
+        str.append(versionName);
+        str.append(" (build ");
+        str.append(versionCode);
+        str.append(", engine ");
         str.append(version);
         str.append(versionFeatures);
-        // Android version
-        str.append(" (Android version ");
-        str.append(versionCode);
         str.append(")");
       }
       // str.append(" • Path: ");


### PR DESCRIPTION
Ships the Android side of the coordinated 3.50 beta: versionCode 89, versionName 3.50-beta-1, engine pinned at 3.49.15.

The name deliberately leaves the engine's 3.49.15 behind, against the usual rule that the versionName prefix tracks `HTTRACK_VERSIONID`. Play treats versionName as an opaque string and orders releases only on versionCode, so this is safe, but the tag has to be `v3.50-beta-1` and a second beta build has to be `3.50-beta-2`, because Play refuses a duplicate versionCode.

The welcome screen also gained the app's own name. It used to show only `hts_version()`, which returns the engine's VERSIONID, so a 3.50 beta on a 3.49 engine would have read as 3.49 everywhere on screen. It now shows `3.50-beta-1 (build 89, engine 3.49.15)`.

The engine delta is documentation plus its own version bump; no C source changed, so `Android.mk` needs no new entries. On the built APK I checked that the manifest reports versionCode 89 and versionName 3.50-beta-1, that `libhttrack.so` carries 3.49.15, and that the generated `resources.zip` picked up the rewritten `html/`. I have not tested it on a device.