### PR TITLE
ci: a Play track clear answers 200 with no body

### DIFF
--- a/tools/ci/play_track_admin.py
+++ b/tools/ci/play_track_admin.py
@@ -133,7 +133,8 @@ def put_track(session, eid, track, releases):
     while True:
         r = session.put(f"{BASE}/edits/{eid}/tracks/{track}", json=body, timeout=TIMEOUT)
         if r.ok:
-            return r.json()
+            # Clearing a track answers 200 with no body at all, so do not assume JSON.
+            return r.json() if r.content else {}
         present = {n["language"] for rel in body["releases"] for n in rel.get("releaseNotes", [])}
         bad = unsupported_language(r, present)
         if bad is None:

--- a/tools/ci/play_track_admin_test.py
+++ b/tools/ci/play_track_admin_test.py
@@ -36,13 +36,18 @@ TRACKS = {
 
 
 class FakeResponse:
+    """payload=None models a body-less 200, which is what Play answers a track clear with."""
+
     def __init__(self, status=200, payload=None):
         self.status_code = status
-        self._payload = payload if payload is not None else {}
+        self._payload = payload
         self.ok = 200 <= status < 300
-        self.text = json.dumps(self._payload)
+        self.text = "" if payload is None else json.dumps(payload)
+        self.content = self.text.encode()
 
     def json(self):
+        if not self.content:
+            raise ValueError("Expecting value: line 1 column 1 (char 0)")
         return self._payload
 
     def raise_for_status(self):
@@ -97,7 +102,7 @@ class FakeSession:
             self.reject_times -= 1
             return FakeResponse(400, {"error": {"message": self.reject_message}})
         self.puts.append((track, copy.deepcopy(json)))
-        return FakeResponse(200, json)
+        return FakeResponse(200) if not json["releases"] else FakeResponse(200, json)
 
     def delete(self, url, **kw):
         self.deleted.append(self._edit_id(url))
@@ -159,6 +164,12 @@ class Test(unittest.TestCase):
             run(promote(), s)
         self.assertEqual(len(s.commits), 1)
         self.assertEqual(s.deleted, [])  # deleting a committed edit is an API error
+
+    def test_a_body_less_200_on_the_clear_is_not_an_error(self):
+        s = FakeSession()
+        run(promote("--clear-track", "alpha"), s)
+        self.assertEqual([t for t, _ in s.puts], ["beta", "alpha"])
+        self.assertEqual(len(s.commits), 1)
 
     def test_dry_run_commits_nothing(self):
         s = FakeSession()


### PR DESCRIPTION
Clearing a track answers 200 with an empty body, and `put_track` called `r.json()` on every 2xx, so the live promote of vc89 died between its two PUTs. Nothing had been committed at that point, so Play was left untouched and the tracks are exactly as they were, but the promote could not finish.

The test stub always answered a PUT with a JSON body, which is why the suite missed this; it now models the body-less 200, and reverting the one-line fix makes the suite fail with the same `JSONDecodeError` the run produced.