### PR TITLE
Relabel the "Build a mail archive" checkbox

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -218,7 +218,7 @@
     <string name="default_referer">Default referer URL</string>
     <string name="hint_default_referer">http://www.example.com/</string>
     <string name="use_word_index">Make a word database</string>
-    <string name="use_mail_index">Build a mail archive</string>
+    <string name="use_mail_index">Build a single-file MHTML archive (.mht)</string>
     <string name="base_path">Base path</string>
     <string name="open_base_folder">Open folder</string>
     <string name="enable_all_files_access">Grant all-files access</string>


### PR DESCRIPTION
The `Build a mail archive` checkbox on the Log, Index, Cache tab maps to `-%M`, which the engine documents as "generate a RFC MIME-encapsulated full-archive (.mht)" (`src/htshelp.c`). That has nothing to do with mail, so the label now reads `Build a single-file MHTML archive (.mht)`. It says MHTML rather than just "single-file" because the Build tab already has a self-contained-page option (`--single-file`) and the two would otherwise read alike.

Closes #88
