### PR TITLE
Add the sitemap URL, inlined-asset cap and WARC name fields

### DIFF
--- a/app/src/main/java/com/httrack/android/OptionsActivity.java
+++ b/app/src/main/java/com/httrack/android/OptionsActivity.java
@@ -171,7 +171,7 @@ public class OptionsActivity extends FragmentActivity implements View.OnClickLis
   @Fields({ R.id.checkDosNames, R.id.checkIso9660, R.id.checkNoErrorPages,
       R.id.checkNoExternalPages, R.id.checkHidePasswords,
       R.id.checkHideQueryStrings, R.id.checkDoNotPurge, R.id.checkSingleFile,
-      R.id.radioBuild, R.id.editCustomBuild })
+      R.id.editSingleFileMaxSize, R.id.radioBuild, R.id.editCustomBuild })
   public static class BuildTab extends Tab {
   }
 
@@ -186,8 +186,8 @@ public class OptionsActivity extends FragmentActivity implements View.OnClickLis
   @ActivityId(R.layout.activity_options_spider)
   @Fields({ R.id.checkAcceptCookies, R.id.editCookiesFile,
       R.id.radioCheckDocumentType, R.id.checkParseJavaFiles, R.id.radioSpider,
-      R.id.checkSitemap, R.id.checkUpdateHacks, R.id.checkUrlHacks,
-      R.id.checkTolerentRequests, R.id.checkForceHttp10 })
+      R.id.checkSitemap, R.id.editSitemapUrl, R.id.checkUpdateHacks,
+      R.id.checkUrlHacks, R.id.checkTolerentRequests, R.id.checkForceHttp10 })
   public static class Spider extends Tab {
   }
 
@@ -202,8 +202,9 @@ public class OptionsActivity extends FragmentActivity implements View.OnClickLis
   @ActivityId(R.layout.activity_options_logindexcache)
   @Fields({ R.id.checkStoreAllFilesInCache,
       R.id.checkDoNotRedownloadLocallErasedFiles, R.id.checkWarc,
-      R.id.checkChanges, R.id.checkCreateLogFiles, R.id.radioVerbosity,
-      R.id.checkUseIndex, R.id.checkUseWordIndex, R.id.checkUseMailIndex })
+      R.id.editWarcFile, R.id.checkChanges, R.id.checkCreateLogFiles,
+      R.id.radioVerbosity, R.id.checkUseIndex, R.id.checkUseWordIndex,
+      R.id.checkUseMailIndex })
   public static class LogIndexCache extends Tab {
   }
 

--- a/app/src/main/java/com/httrack/android/OptionsMapper.java
+++ b/app/src/main/java/com/httrack/android/OptionsMapper.java
@@ -105,7 +105,10 @@ public class OptionsMapper {
       new Pair<Integer, String>(R.id.checkHideQueryStrings, "NoQueryStrings"),
       new Pair<Integer, String>(R.id.checkDoNotPurge, "NoPurgeOldFiles"),
       new Pair<Integer, String>(R.id.checkSingleFile, "SingleFile"),
+      new Pair<Integer, String>(R.id.editSingleFileMaxSize,
+          "SingleFileMaxSize"),
       new Pair<Integer, String>(R.id.checkWarc, "Warc"),
+      new Pair<Integer, String>(R.id.editWarcFile, "WarcFile"),
       new Pair<Integer, String>(R.id.radioBuild, "Build"),
       new Pair<Integer, String>(R.id.editCustomBuild, "BuildString"),
 
@@ -123,6 +126,7 @@ public class OptionsMapper {
       new Pair<Integer, String>(R.id.checkParseJavaFiles, "ParseJava"),
       new Pair<Integer, String>(R.id.radioSpider, "FollowRobotsTxt"),
       new Pair<Integer, String>(R.id.checkSitemap, "Sitemap"),
+      new Pair<Integer, String>(R.id.editSitemapUrl, "SitemapUrl"),
       new Pair<Integer, String>(R.id.checkUpdateHacks, "UpdateHack"),
       new Pair<Integer, String>(R.id.checkUrlHacks, "URLHack"),
       new Pair<Integer, String>(R.id.checkTolerentRequests, "TolerantRequests"),
@@ -296,9 +300,16 @@ public class OptionsMapper {
       new Pair<String, OptionMapper>("NoPurgeOldFiles", new SimpleOptionFlag(
           "X0")),
       new Pair<String, OptionMapper>("Warc", new SimpleOptionFlag("%r")),
+      /* each companion enables its own feature; the toggle is optional */
+      new Pair<String, OptionMapper>("WarcFile", new ArgumentOption(
+          "--warc-file")),
       new Pair<String, OptionMapper>("Sitemap", new LongOptionFlag("--sitemap")),
+      new Pair<String, OptionMapper>("SitemapUrl", new ArgumentOption(
+          "--sitemap-url")),
       new Pair<String, OptionMapper>("SingleFile", new LongOptionFlag(
           "--single-file")),
+      new Pair<String, OptionMapper>("SingleFileMaxSize", new ArgumentOption(
+          "--single-file-max-size")),
       new Pair<String, OptionMapper>("Changes", new LongOptionFlag("--changes")),
       new Pair<String, OptionMapper>("Build", buildHandler.getTypeMapper()),
       new Pair<String, OptionMapper>("BuildString",

--- a/app/src/main/res/layout/activity_options_build.xml
+++ b/app/src/main/res/layout/activity_options_build.xml
@@ -68,6 +68,27 @@
             android:orientation="horizontal" >
 
             <TextView
+                android:id="@+id/textSingleFileMaxSize"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight=".50"
+                android:text="@string/single_file_max_size" />
+
+            <EditText
+                android:id="@+id/editSingleFileMaxSize"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight=".50"
+                android:hint="@string/hint_single_file_max_size"
+                android:inputType="number" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal" >
+
+            <TextView
                 android:id="@+id/textBuild"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"

--- a/app/src/main/res/layout/activity_options_logindexcache.xml
+++ b/app/src/main/res/layout/activity_options_logindexcache.xml
@@ -31,6 +31,27 @@
             android:layout_height="wrap_content"
             android:text="@string/write_warc_archive" />
 
+        <LinearLayout
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal" >
+
+            <TextView
+                android:id="@+id/textWarcFile"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight=".50"
+                android:text="@string/warc_file" />
+
+            <EditText
+                android:id="@+id/editWarcFile"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight=".50"
+                android:hint="@string/hint_warc_file"
+                android:inputType="textNoSuggestions" />
+        </LinearLayout>
+
         <CheckBox
             android:id="@+id/checkChanges"
             android:layout_width="fill_parent"

--- a/app/src/main/res/layout/activity_options_spider.xml
+++ b/app/src/main/res/layout/activity_options_spider.xml
@@ -125,6 +125,27 @@
             android:layout_gravity="end"
             android:text="@string/sitemap" />
 
+        <LinearLayout
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal" >
+
+            <TextView
+                android:id="@+id/textSitemapUrl"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight=".50"
+                android:text="@string/sitemap_url" />
+
+            <EditText
+                android:id="@+id/editSitemapUrl"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight=".50"
+                android:hint="@string/hint_sitemap_url"
+                android:inputType="textUri" />
+        </LinearLayout>
+
         <CheckBox
             android:id="@+id/checkUpdateHacks"
             android:layout_width="fill_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -69,9 +69,15 @@
     <string name="hide_query_strings">Hide query strings</string>
     <string name="do_not_purge_old_files">Do not purge old files</string>
     <string name="single_file">Inline assets as data: URIs (self-contained pages)</string>
+    <string name="single_file_max_size">Max size of an inlined asset (bytes)</string>
+    <string name="hint_single_file_max_size">10485760</string>
     <string name="write_warc_archive">Write WARC archive</string>
+    <string name="warc_file">WARC file name</string>
+    <string name="hint_warc_file">mysite.warc.gz</string>
     <string name="report_changes">Report what changed since the previous mirror</string>
     <string name="sitemap">Seed the crawl from the site\'s sitemap</string>
+    <string name="sitemap_url">Sitemap URL</string>
+    <string name="hint_sitemap_url">http://www.example.com/sitemap.xml</string>
     <string name="number_of_connections">Max simultaneous connections</string>
     <string name="persistent_connections">Persistent connections (Keep-Alive)</string>
     <string name="timeout">File timeout</string>

--- a/app/src/test/java/com/httrack/android/OptionsEmissionTest.java
+++ b/app/src/test/java/com/httrack/android/OptionsEmissionTest.java
@@ -126,6 +126,37 @@ public class OptionsEmissionTest {
     }
   }
 
+  /* companions of the sitemap, single-file and WARC toggles. */
+  private static final String[] COMPANIONS = { "--sitemap-url",
+      "--single-file-max-size", "--warc-file" };
+
+  @Test
+  public void companionEmitsItsOwnTokenPairWhenSet() {
+    for (final String option : COMPANIONS) {
+      final StringBuilder flags = new StringBuilder("-");
+      final List<String> cmd = new ArrayList<String>();
+      new ArgumentOption(option).emit(flags, cmd, "value");
+      assertEquals(2, cmd.size());
+      assertEquals(option, cmd.get(0));
+      assertEquals("value", cmd.get(1));
+      assertEquals("-", flags.toString());
+    }
+  }
+
+  /* an empty field emits nothing: a bare --opt would eat the next token. */
+  @Test
+  public void companionStaysSilentWhenEmptyOrUnset() {
+    for (final String option : COMPANIONS) {
+      for (final String value : new String[] { "", null }) {
+        final StringBuilder flags = new StringBuilder("-");
+        final List<String> cmd = new ArrayList<String>();
+        new ArgumentOption(option).emit(flags, cmd, value);
+        assertTrue(cmd.isEmpty());
+        assertEquals("-", flags.toString());
+      }
+    }
+  }
+
   /* the mappers are static singletons: emitting again must not go quiet. */
   @Test
   public void longOptionEmitsOnEveryBuild() {


### PR DESCRIPTION
PR #77 added the sitemap, single-file and change-report toggles but not the value fields the reference GUI puts beside them, so there was no way to name a sitemap directly or to raise the 10 MB cap on inlined assets. Both are here, along with `--warc-file`, which was missing for the same reason.

The three are `ArgumentOption` entries: two argv tokens of their own, nothing packed into the compacted flag string, and nothing at all emitted when the field is empty. Each option switches its feature on by itself in the engine, so ticking the matching box is optional. The unit tests cover emission and the empty case; the fields have not been tried on a device.

Closes #79
