### PR TITLE
A packed option flag can be misread as its two-letter variant

### DIFF
--- a/app/src/main/java/com/httrack/android/OptionValues.java
+++ b/app/src/main/java/com/httrack/android/OptionValues.java
@@ -1,0 +1,74 @@
+/*
+HTTrack Android Java Interface.
+
+HTTrack Website Copier, Offline Browser for Windows and Unix
+Copyright (C) Xavier Roche and other contributors
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 3
+of the License, or any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+package com.httrack.android;
+
+import java.util.regex.Pattern;
+
+/**
+ * Numeric helpers for the option mappers; pure, Android-free, so the mappers
+ * that use them stay reachable from unit tests.
+ */
+public final class OptionValues {
+  private OptionValues() {
+  }
+
+  private static final Pattern patternDigits = Pattern.compile("^[0-9]+$");
+
+  /**
+   * True if the value is a non-empty run of ASCII digits.
+   *
+   * @param value
+   *          The value, possibly null
+   * @return true if the value is pure digits
+   */
+  public static boolean isDigits(final String value) {
+    return value != null && patternDigits.matcher(value).matches();
+  }
+
+  /**
+   * Parse an integer.
+   *
+   * @param value
+   *          The integer value
+   * @param defaultValue
+   *          Default value on error or out-of-range
+   * @return The parsed value, or defaultValue on error
+   */
+  public static int parseInt(final String value, final int defaultValue) {
+    try {
+      return Integer.parseInt(value);
+    } catch (final NumberFormatException nfe) {
+      return defaultValue;
+    }
+  }
+
+  /**
+   * Parse an integer.
+   *
+   * @param value
+   *          The integer value
+   * @return The parsed value, or 999999999 on error
+   */
+  public static int parseInt(final String value) {
+    return parseInt(value, 999999999);
+  }
+}

--- a/app/src/main/java/com/httrack/android/OptionsMapper.java
+++ b/app/src/main/java/com/httrack/android/OptionsMapper.java
@@ -296,10 +296,9 @@ public class OptionsMapper {
       new Pair<String, OptionMapper>("NoPurgeOldFiles", new SimpleOptionFlag(
           "X0")),
       new Pair<String, OptionMapper>("Warc", new SimpleOptionFlag("%r")),
-      new Pair<String, OptionMapper>("Sitemap", new LongOptionFlag("--sitemap")),
-      new Pair<String, OptionMapper>("SingleFile", new LongOptionFlag(
-          "--single-file")),
-      new Pair<String, OptionMapper>("Changes", new LongOptionFlag("--changes")),
+      new Pair<String, OptionMapper>("Sitemap", new SimpleOptionFlag("%m")),
+      new Pair<String, OptionMapper>("SingleFile", new SimpleOptionFlag("%Z")),
+      new Pair<String, OptionMapper>("Changes", new SimpleOptionFlag("%d")),
       new Pair<String, OptionMapper>("Build", buildHandler.getTypeMapper()),
       new Pair<String, OptionMapper>("BuildString",
           buildHandler.getCustomMapper()),
@@ -392,9 +391,6 @@ public class OptionsMapper {
   // String-to-OptionMapper map
   protected final HashMap<String, OptionMapper> fieldsNameToMapper = new HashMap<String, OptionMapper>();
 
-  // Pure digits (0..9) pattern.
-  protected static final Pattern patternDigits = Pattern.compile("^[0-9]+$");
-
   // The options mapping
   protected final SparseArraySerializable map = new SparseArraySerializable();
 
@@ -408,35 +404,6 @@ public class OptionsMapper {
   static {
     // Create fieldsNameToId
     createFieldsNameToId();
-  }
-
-  /**
-   * Parse an integer.
-   * 
-   * @param value
-   *          The integer value
-   * @param defaultValue
-   *          Default value on error or out-of-range
-   * @return The parsed value, or defaultValue on error
-   */
-  public static int parseInt(final String value, final int defaultValue) {
-    try {
-      return Integer.parseInt(value);
-    } catch (final NumberFormatException nfe) {
-      Log.d(OptionsMapper.class.getSimpleName(), "format number exception", nfe);
-      return defaultValue;
-    }
-  }
-
-  /**
-   * Parse an integer.
-   * 
-   * @param value
-   *          The integer value
-   * @return The parsed value, or 999999999 on error
-   */
-  public static int parseInt(final String value) {
-    return parseInt(value, 999999999);
   }
 
   /**
@@ -581,9 +548,8 @@ public class OptionsMapper {
       @Override
       public void emit(final StringBuilder flags,
           final List<String> commandline, final String value) {
-        if (value != null && value.length() != 0
-            && patternDigits.matcher(value).matches()) {
-          MaxSizeHandler.this.maxHtml = OptionsMapper.parseInt(value);
+        if (OptionValues.isDigits(value)) {
+          MaxSizeHandler.this.maxHtml = OptionValues.parseInt(value);
         }
       }
 
@@ -601,9 +567,8 @@ public class OptionsMapper {
       @Override
       public void emit(final StringBuilder flags,
           final List<String> commandline, final String value) {
-        if (value != null && value.length() != 0
-            && patternDigits.matcher(value).matches()) {
-          MaxSizeHandler.this.maxNonHtml = OptionsMapper.parseInt(value);
+        if (OptionValues.isDigits(value)) {
+          MaxSizeHandler.this.maxNonHtml = OptionValues.parseInt(value);
         }
       }
 
@@ -642,14 +607,15 @@ public class OptionsMapper {
       if (!finished) {
         finished = true;
         if (maxNonHtml != -1 || maxHtml != -1) {
-          flags.append("m");
+          final StringBuilder option = new StringBuilder("-m");
           if (maxNonHtml != -1) {
-            flags.append(maxNonHtml);
+            option.append(maxNonHtml);
           }
           if (maxHtml != -1) {
-            flags.append(',');
-            flags.append(maxHtml);
+            option.append(',');
+            option.append(maxHtml);
           }
+          commandline.add(option.toString());
         }
       }
     }
@@ -726,8 +692,7 @@ public class OptionsMapper {
         final List<String> commandline) {
       if (!finished) {
         finished = true;
-        flags.append("H");
-        flags.append(flag);
+        commandline.add("-H" + flag);
       }
     }
   }
@@ -805,12 +770,7 @@ public class OptionsMapper {
         finished = true;
         // Note: same logic (...) as WinHTTrack ; see WinHTTrack/Shell.cpp
         if (dos || iso9660) {
-          flags.append("L");
-          if (dos) {
-            flags.append('0');
-          } else {
-            flags.append('2');
-          }
+          commandline.add(dos ? "-L0" : "-L2");
         }
       }
     }
@@ -947,8 +907,7 @@ public class OptionsMapper {
       @Override
       public void emit(final StringBuilder flags,
           final List<String> commandline, final String value) {
-        if (value != null && value.length() != 0
-            && patternDigits.matcher(value).matches()) {
+        if (OptionValues.isDigits(value)) {
           BuildHandler.this.build = Integer.parseInt(value);
         }
       }
@@ -1009,8 +968,7 @@ public class OptionsMapper {
       if (!finished) {
         finished = true;
         if (build < mapping.length) {
-          flags.append('N');
-          flags.append(mapping[build]);
+          commandline.add("-N" + mapping[build]);
         } else if (build == mapping.length) {
           commandline.add("-N");
           commandline.add(custom);
@@ -1034,8 +992,7 @@ public class OptionsMapper {
       @Override
       public void emit(final StringBuilder flags,
           final List<String> commandline, final String value) {
-        if (value != null && value.length() != 0
-            && patternDigits.matcher(value).matches()) {
+        if (OptionValues.isDigits(value)) {
           LogHandler.this.type = Integer.parseInt(value);
         }
       }
@@ -1124,8 +1081,7 @@ public class OptionsMapper {
       @Override
       public void emit(final StringBuilder flags,
           final List<String> commandline, final String value) {
-        if (value != null && value.length() != 0
-            && patternDigits.matcher(value).matches()) {
+        if (OptionValues.isDigits(value)) {
           PrimaryScanHandler.this.type = Integer.parseInt(value);
         }
       }
@@ -1299,8 +1255,7 @@ public class OptionsMapper {
     public void emit(final StringBuilder flags, final List<String> commandline,
         final String value) {
       if (value != null && value.length() != 0) {
-        flags.append(option);
-        flags.append(value);
+        commandline.add("-" + option + value);
       }
     }
   }
@@ -1341,10 +1296,7 @@ public class OptionsMapper {
     public void emit(final StringBuilder flags, final List<String> commandline,
         final String value) {
       if (value != null && value.length() != 0) {
-        flags.append(option);
-        if ("0".equals(value)) {
-          flags.append('0');
-        }
+        commandline.add("-" + option + ("0".equals(value) ? "0" : ""));
       }
     }
   }
@@ -1370,29 +1322,8 @@ public class OptionsMapper {
         final String value) {
       if (value != null && value.length() != 0) {
         if ((!reverted && "1".equals(value)) || (reverted && "0".equals(value))) {
-          flags.append(option);
+          commandline.add("-" + option);
         }
-      }
-    }
-  }
-
-  /**
-   * Required for a short flag with a two-letter variant (-%m / -%mu, -%Z /
-   * -%Zs): packed in the compacted string, the next flag's first letter would
-   * be misread as that variant and swallow an argument.
-   */
-  public static class LongOptionFlag implements OptionMapper {
-    protected final String option;
-
-    public LongOptionFlag(final String option) {
-      this.option = option;
-    }
-
-    @Override
-    public void emit(final StringBuilder flags, final List<String> commandline,
-        final String value) {
-      if ("1".equals(value)) {
-        commandline.add(option);
       }
     }
   }
@@ -1412,8 +1343,7 @@ public class OptionsMapper {
     @Override
     public void emit(final StringBuilder flags, final List<String> commandline,
         final String value) {
-      if (value != null && value.length() != 0
-          && patternDigits.matcher(value).matches()) {
+      if (OptionValues.isDigits(value)) {
         final int choiceId = Integer.parseInt(value);
         if (choiceId >= 0 && choiceId < choices.length) {
           final String choice = choices[choiceId];
@@ -1916,6 +1846,8 @@ public class OptionsMapper {
    * @return The commandline argument(s)
    */
   public List<String> buildCommandline() {
+    // Leftover compacted token: only options with no two-letter variant may be
+    // packed here, or the next flag's letter is read as that variant (issue #78).
     final StringBuilder flags = new StringBuilder("-");
     final List<String> list = new ArrayList<String>();
 

--- a/app/src/test/java/com/httrack/android/OptionTokenizationTest.java
+++ b/app/src/test/java/com/httrack/android/OptionTokenizationTest.java
@@ -1,0 +1,277 @@
+package com.httrack.android;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.httrack.android.OptionsMapper.BuildHandler;
+import com.httrack.android.OptionsMapper.DosIso9660Handler;
+import com.httrack.android.OptionsMapper.HostControlHandler;
+import com.httrack.android.OptionsMapper.MaxSizeHandler;
+import com.httrack.android.OptionsMapper.OptionMapper;
+import com.httrack.android.OptionsMapper.SimpleOption;
+import com.httrack.android.OptionsMapper.SimpleOption0;
+import com.httrack.android.OptionsMapper.SimpleOptionFlag;
+import com.httrack.android.OptionsMapper.UrlSplit;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+
+/** Each engine option must be its own argv token, never packed (issue #78). */
+public class OptionTokenizationTest {
+  /* Two-letter forms that swallow the next argv token (engine htsalias.c). */
+  private static final String[] ARGUMENT_VARIANTS = { "%rf", "%rs", "%rc",
+      "%rz", "%mu", "%Zs" };
+
+  private static void assertNoArgumentVariant(final List<String> argv) {
+    for (final String token : argv) {
+      for (final String variant : ARGUMENT_VARIANTS) {
+        assertFalse("token " + token + " spells " + variant,
+            token.contains(variant));
+      }
+    }
+  }
+
+  /* Assemble as buildCommandline() does: leading flags token, then the rest. */
+  private static List<String> argv(final StringBuilder flags,
+      final List<String> commandline) {
+    final List<String> args = new ArrayList<String>();
+    if (flags.length() > 1) {
+      args.add(flags.toString());
+    }
+    args.addAll(commandline);
+    return args;
+  }
+
+  private static List<String> emit(final OptionMapper mapper, final String value) {
+    final List<String> cmd = new ArrayList<String>();
+    final StringBuilder flags = new StringBuilder("-");
+    mapper.emit(flags, cmd, value);
+    assertEquals("nothing may be packed", "-", flags.toString());
+    return cmd;
+  }
+
+  private static List<String> finish(final OptionMapper mapper) {
+    final List<String> cmd = new ArrayList<String>();
+    final StringBuilder flags = new StringBuilder("-");
+    ((OptionMapper.FinishMapper) mapper).finish(flags, cmd);
+    assertEquals("nothing may be packed", "-", flags.toString());
+    return cmd;
+  }
+
+  /* Reported profile: WARC on, no CheckType to separate it from robots. */
+  @Test
+  public void warcWithoutCheckTypeKeepsTheCrawlUrl() {
+    final StringBuilder flags = new StringBuilder("-");
+    final List<String> cmd = new ArrayList<String>();
+    UrlSplit.INSTANCE.emit(flags, cmd, "http://www.example.com/");
+    new SimpleOptionFlag("X0").emit(flags, cmd, "1"); // NoPurgeOldFiles
+    new SimpleOptionFlag("%r").emit(flags, cmd, "1"); // Warc
+    new SimpleOption("u").emit(flags, cmd, ""); // CheckType, out of range
+    new SimpleOption("s").emit(flags, cmd, "2"); // FollowRobotsTxt
+    new SimpleOptionFlag("%s").emit(flags, cmd, "1"); // UpdateHack
+
+    final List<String> args = argv(flags, cmd);
+    assertNoArgumentVariant(args);
+    assertEquals(Arrays.asList("http://www.example.com/", "-X0", "-%r", "-s2",
+        "-%s"), args);
+  }
+
+  /* Sitemap and single-file have the same shape, and the same neighbours. */
+  @Test
+  public void sitemapAndSingleFileNeverSpellTheirArgumentVariant() {
+    final StringBuilder flags = new StringBuilder("-");
+    final List<String> cmd = new ArrayList<String>();
+    UrlSplit.INSTANCE.emit(flags, cmd, "http://www.example.com/");
+    new SimpleOptionFlag("%m").emit(flags, cmd, "1"); // Sitemap
+    new SimpleOption0("%u").emit(flags, cmd, "1"); // URLHack
+    new SimpleOptionFlag("%Z").emit(flags, cmd, "1"); // SingleFile
+    new SimpleOption("s").emit(flags, cmd, "0"); // FollowRobotsTxt
+
+    final List<String> args = argv(flags, cmd);
+    assertNoArgumentVariant(args);
+    assertEquals(Arrays.asList("http://www.example.com/", "-%m", "-%u", "-%Z",
+        "-s0"), args);
+  }
+
+  @Test
+  public void simpleOptionAppendsItsValue() {
+    assertEquals(Arrays.asList("-r5"), emit(new SimpleOption("r"), "5"));
+    assertEquals(Arrays.asList("-#L500"), emit(new SimpleOption("#L"), "500"));
+    assertEquals(Arrays.asList("-u0"), emit(new SimpleOption("u"), "0"));
+  }
+
+  @Test
+  public void simpleOptionStaysSilentWithoutAValue() {
+    assertTrue(emit(new SimpleOption("r"), "").isEmpty());
+    assertTrue(emit(new SimpleOption("r"), null).isEmpty());
+  }
+
+  /* -%f is on unless the value is exactly "0", which spells -%f0. */
+  @Test
+  public void simpleOption0AppendsTheDisableDigitOnlyForZero() {
+    assertEquals(Arrays.asList("-%f0"), emit(new SimpleOption0("%f"), "0"));
+    assertEquals(Arrays.asList("-%f"), emit(new SimpleOption0("%f"), "1"));
+    assertEquals(Arrays.asList("-%f"), emit(new SimpleOption0("%f"), "2"));
+  }
+
+  @Test
+  public void simpleOption0StaysSilentWithoutAValue() {
+    assertTrue(emit(new SimpleOption0("%f"), "").isEmpty());
+    assertTrue(emit(new SimpleOption0("%f"), null).isEmpty());
+  }
+
+  @Test
+  public void simpleOptionFlagEmitsOnlyOnOne() {
+    assertEquals(Arrays.asList("-n"), emit(new SimpleOptionFlag("n"), "1"));
+    for (final String value : new String[] { "0", "2", "", null }) {
+      assertTrue(emit(new SimpleOptionFlag("n"), value).isEmpty());
+    }
+  }
+
+  /* The reverted form (b0, I0, C0, j) emits on "0" and stays silent on "1". */
+  @Test
+  public void revertedFlagEmitsOnlyOnZero() {
+    assertEquals(Arrays.asList("-b0"),
+        emit(new SimpleOptionFlag("b0", true), "0"));
+    for (final String value : new String[] { "1", "2", "", null }) {
+      assertTrue(emit(new SimpleOptionFlag("b0", true), value).isEmpty());
+    }
+  }
+
+  private static List<String> emitMaxSize(final String html,
+      final String nonHtml) {
+    final MaxSizeHandler handler = new MaxSizeHandler();
+    final StringBuilder flags = new StringBuilder("-");
+    final List<String> cmd = new ArrayList<String>();
+    handler.getHtml().emit(flags, cmd, html);
+    final OptionMapper nonHtmlMapper = handler.getNonHtml();
+    nonHtmlMapper.emit(flags, cmd, nonHtml);
+    ((OptionMapper.FinishMapper) nonHtmlMapper).finish(flags, cmd);
+    assertEquals("nothing may be packed", "-", flags.toString());
+    return cmd;
+  }
+
+  @Test
+  public void maxSizeMergesBothLimitsIntoOneToken() {
+    assertEquals(Arrays.asList("-m2000,1000"), emitMaxSize("1000", "2000"));
+    assertEquals(Arrays.asList("-m,1000"), emitMaxSize("1000", ""));
+    assertEquals(Arrays.asList("-m2000"), emitMaxSize("", "2000"));
+  }
+
+  @Test
+  public void maxSizeStaysSilentWithNoLimit() {
+    assertTrue(emitMaxSize("", "").isEmpty());
+    assertTrue(emitMaxSize(null, "not-a-number").isEmpty());
+  }
+
+  @Test
+  public void maxSizeEmitsOnce() {
+    final MaxSizeHandler handler = new MaxSizeHandler();
+    final OptionMapper mapper = handler.getHtml();
+    final StringBuilder flags = new StringBuilder("-");
+    final List<String> cmd = new ArrayList<String>();
+    mapper.emit(flags, cmd, "1000");
+    ((OptionMapper.FinishMapper) mapper).finish(flags, cmd);
+    ((OptionMapper.FinishMapper) handler.getNonHtml()).finish(flags, cmd);
+    assertEquals(Arrays.asList("-m,1000"), cmd);
+  }
+
+  private static List<String> emitHostControl(final String time,
+      final String rate) {
+    final HostControlHandler handler = new HostControlHandler();
+    final StringBuilder flags = new StringBuilder("-");
+    final List<String> cmd = new ArrayList<String>();
+    handler.getTimeMapper().emit(flags, cmd, time);
+    final OptionMapper rateMapper = handler.getRateMapper();
+    rateMapper.emit(flags, cmd, rate);
+    ((OptionMapper.FinishMapper) rateMapper).finish(flags, cmd);
+    assertEquals("nothing may be packed", "-", flags.toString());
+    return cmd;
+  }
+
+  @Test
+  public void hostControlOrsTheTwoAbandonFlags() {
+    assertEquals(Arrays.asList("-H0"), emitHostControl("0", "0"));
+    assertEquals(Arrays.asList("-H1"), emitHostControl("1", "0"));
+    assertEquals(Arrays.asList("-H2"), emitHostControl("0", "1"));
+    assertEquals(Arrays.asList("-H3"), emitHostControl("1", "1"));
+  }
+
+  @Test
+  public void hostControlEmitsOnce() {
+    final HostControlHandler handler = new HostControlHandler();
+    final List<String> cmd = finish(handler.getTimeMapper());
+    ((OptionMapper.FinishMapper) handler.getRateMapper()).finish(
+        new StringBuilder("-"), cmd);
+    assertEquals(Arrays.asList("-H0"), cmd);
+  }
+
+  private static List<String> emitDosIso(final String dos, final String iso) {
+    final DosIso9660Handler handler = new DosIso9660Handler();
+    final StringBuilder flags = new StringBuilder("-");
+    final List<String> cmd = new ArrayList<String>();
+    handler.getDosMapper().emit(flags, cmd, dos);
+    final OptionMapper isoMapper = handler.getIso9660Mapper();
+    isoMapper.emit(flags, cmd, iso);
+    ((OptionMapper.FinishMapper) isoMapper).finish(flags, cmd);
+    assertEquals("nothing may be packed", "-", flags.toString());
+    return cmd;
+  }
+
+  @Test
+  public void dosIso9660PrefersDosOverIso() {
+    assertTrue(emitDosIso("0", "0").isEmpty());
+    assertEquals(Arrays.asList("-L0"), emitDosIso("1", "0"));
+    assertEquals(Arrays.asList("-L2"), emitDosIso("0", "1"));
+    assertEquals(Arrays.asList("-L0"), emitDosIso("1", "1"));
+  }
+
+  @Test
+  public void dosIso9660EmitsOnce() {
+    final DosIso9660Handler handler = new DosIso9660Handler();
+    final OptionMapper mapper = handler.getDosMapper();
+    final StringBuilder flags = new StringBuilder("-");
+    final List<String> cmd = new ArrayList<String>();
+    mapper.emit(flags, cmd, "1");
+    ((OptionMapper.FinishMapper) mapper).finish(flags, cmd);
+    ((OptionMapper.FinishMapper) handler.getIso9660Mapper()).finish(flags, cmd);
+    assertEquals(Arrays.asList("-L0"), cmd);
+  }
+
+  private static List<String> emitBuild(final String type, final String custom) {
+    final BuildHandler handler = new BuildHandler();
+    final StringBuilder flags = new StringBuilder("-");
+    final List<String> cmd = new ArrayList<String>();
+    handler.getCustomMapper().emit(flags, cmd, custom);
+    final OptionMapper typeMapper = handler.getTypeMapper();
+    typeMapper.emit(flags, cmd, type);
+    ((OptionMapper.FinishMapper) typeMapper).finish(flags, cmd);
+    assertEquals("nothing may be packed", "-", flags.toString());
+    return cmd;
+  }
+
+  /* Radio index into the engine's structure numbers; 14 is "custom". */
+  @Test
+  public void buildMapsTheRadioIndexToAStructureNumber() {
+    assertEquals(Arrays.asList("-N0"), emitBuild("0", "%h%p/%n%q.%t"));
+    assertEquals(Arrays.asList("-N100"), emitBuild("6", "%h%p/%n%q.%t"));
+    assertEquals(Arrays.asList("-N199"), emitBuild("13", "%h%p/%n%q.%t"));
+    assertEquals(Arrays.asList("-N", "%h%p/%n%q.%t"),
+        emitBuild("14", "%h%p/%n%q.%t"));
+    assertTrue(emitBuild("15", "%h%p/%n%q.%t").isEmpty());
+  }
+
+  @Test
+  public void buildEmitsOnce() {
+    final BuildHandler handler = new BuildHandler();
+    final OptionMapper mapper = handler.getTypeMapper();
+    final StringBuilder flags = new StringBuilder("-");
+    final List<String> cmd = new ArrayList<String>();
+    mapper.emit(flags, cmd, "6");
+    ((OptionMapper.FinishMapper) mapper).finish(flags, cmd);
+    ((OptionMapper.FinishMapper) handler.getCustomMapper()).finish(flags, cmd);
+    assertEquals(Arrays.asList("-N100"), cmd);
+  }
+}

--- a/app/src/test/java/com/httrack/android/OptionsEmissionTest.java
+++ b/app/src/test/java/com/httrack/android/OptionsEmissionTest.java
@@ -1,11 +1,9 @@
 package com.httrack.android;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import com.httrack.android.OptionsMapper.ArgumentOption;
-import com.httrack.android.OptionsMapper.LongOptionFlag;
 import com.httrack.android.OptionsMapper.OptionMapper;
 import com.httrack.android.OptionsMapper.ProxyHandler;
 import com.httrack.android.OptionsMapper.SimpleOptionFlag;
@@ -70,57 +68,57 @@ public class OptionsEmissionTest {
     assertTrue(cmd.isEmpty());
   }
 
-  /* keep-* toggles bundle their %-flag into the single dash token. */
+  /* keep-* toggles emit their %-flag as a standalone token. */
   @Test
-  public void keepToggleBundlesFlagWhenChecked() {
-    final StringBuilder flags = new StringBuilder();
-    new SimpleOptionFlag("%j").emit(flags, new ArrayList<String>(), "1");
-    assertTrue(flags.toString().contains("%j"));
+  public void keepToggleEmitsFlagWhenChecked() {
+    final List<String> cmd = new ArrayList<String>();
+    new SimpleOptionFlag("%j").emit(new StringBuilder("-"), cmd, "1");
+    assertEquals("-%j", cmd.get(0));
   }
 
   @Test
   public void keepToggleEmitsNothingWhenUnchecked() {
-    final StringBuilder flags = new StringBuilder();
-    new SimpleOptionFlag("%j").emit(flags, new ArrayList<String>(), "0");
-    assertFalse(flags.toString().contains("%j"));
+    final List<String> cmd = new ArrayList<String>();
+    new SimpleOptionFlag("%j").emit(new StringBuilder("-"), cmd, "0");
+    assertTrue(cmd.isEmpty());
   }
 
-  /* WARC toggle bundles -%r only when checked. */
+  /* WARC emits -%r only when checked. */
   @Test
-  public void warcToggleBundlesFlagWhenChecked() {
-    final StringBuilder flags = new StringBuilder();
-    new SimpleOptionFlag("%r").emit(flags, new ArrayList<String>(), "1");
-    assertTrue(flags.toString().contains("%r"));
+  public void warcToggleEmitsFlagWhenChecked() {
+    final List<String> cmd = new ArrayList<String>();
+    new SimpleOptionFlag("%r").emit(new StringBuilder("-"), cmd, "1");
+    assertEquals("-%r", cmd.get(0));
   }
 
   @Test
   public void warcToggleEmitsNothingWhenUnchecked() {
-    final StringBuilder flags = new StringBuilder();
-    new SimpleOptionFlag("%r").emit(flags, new ArrayList<String>(), "0");
-    assertFalse(flags.toString().contains("%r"));
+    final List<String> cmd = new ArrayList<String>();
+    new SimpleOptionFlag("%r").emit(new StringBuilder("-"), cmd, "0");
+    assertTrue(cmd.isEmpty());
   }
 
-  /* sitemap/single-file/changes: own token, and never in the packed string. */
+  /* sitemap/single-file/changes keep the short forms the engine aliases them to. */
   @Test
-  public void longOptionEmitsItsOwnTokenWhenChecked() {
-    for (final String option : new String[] { "--sitemap", "--single-file",
-        "--changes" }) {
-      /* seeded as buildCommandline() does, so a guarded append cannot hide */
+  public void spiderTogglesEmitTheirEngineFlag() {
+    final String[][] cases = { { "%m", "-%m" }, { "%Z", "-%Z" },
+        { "%d", "-%d" } };
+    for (final String[] c : cases) {
       final StringBuilder flags = new StringBuilder("-");
       final List<String> cmd = new ArrayList<String>();
-      new LongOptionFlag(option).emit(flags, cmd, "1");
+      new SimpleOptionFlag(c[0]).emit(flags, cmd, "1");
       assertEquals(1, cmd.size());
-      assertEquals(option, cmd.get(0));
+      assertEquals(c[1], cmd.get(0));
       assertEquals("-", flags.toString());
     }
   }
 
   @Test
-  public void longOptionStaysSilentWhenUncheckedOrUnset() {
-    for (final String value : new String[] { "0", "", null }) {
+  public void spiderToggleStaysSilentWhenUncheckedOrUnset() {
+    for (final String value : new String[] { "0", "2", "", null }) {
       final StringBuilder flags = new StringBuilder("-");
       final List<String> cmd = new ArrayList<String>();
-      new LongOptionFlag("--single-file").emit(flags, cmd, value);
+      new SimpleOptionFlag("%Z").emit(flags, cmd, value);
       assertTrue(cmd.isEmpty());
       assertEquals("-", flags.toString());
     }
@@ -128,13 +126,13 @@ public class OptionsEmissionTest {
 
   /* the mappers are static singletons: emitting again must not go quiet. */
   @Test
-  public void longOptionEmitsOnEveryBuild() {
-    final OptionMapper mapper = new LongOptionFlag("--changes");
+  public void flagEmitsOnEveryBuild() {
+    final OptionMapper mapper = new SimpleOptionFlag("%d");
     final List<String> first = new ArrayList<String>();
     final List<String> second = new ArrayList<String>();
     mapper.emit(new StringBuilder("-"), first, "1");
     mapper.emit(new StringBuilder("-"), second, "1");
     assertEquals(first, second);
-    assertEquals("--changes", second.get(0));
+    assertEquals("-%d", second.get(0));
   }
 }


### PR DESCRIPTION
The engine reads a packed `-...` token one character at a time, so a `%r`, `%m` or `%Z` followed by the wrong letter turns into the two-letter form that eats the next argv token. With WARC on and CheckType empty the packed string spelled `%rs`, the engine took it for `--warc-max-size`, and the first crawl URL went with it. Each `-` token is parsed on its own, so the three `SimpleOption*` classes and the four merge handlers now emit one token each, and `LongOptionFlag` (added in #77 to sidestep this for `--sitemap`, `--single-file` and `--changes`) is gone. The shared buffer stays for `LogHandler`, `PrimaryScanHandler` and `MultipleChoicesOption`, whose flags have no two-letter variant.

The digit check and int parse move into a pure `OptionValues`, which stops `MaxSizeHandler` and `BuildHandler` from pulling in `OptionsMapper`'s Android-dependent static init and makes them testable (#81). Mutate the fix back to packing and the new test fails with `token -X0%rs2%s spells %rs`.

Closes #78
