### PR TITLE
Keep-alive checkbox drove the wrong engine option and aborted the crawl when unticked

### DIFF
--- a/app/src/main/java/com/httrack/android/OptionsMapper.java
+++ b/app/src/main/java/com/httrack/android/OptionsMapper.java
@@ -276,7 +276,7 @@ public class OptionsMapper {
       new Pair<String, OptionMapper>("MaxConn", new SimpleOption("%c")),
       new Pair<String, OptionMapper>("MaxLinks", new SimpleOption("#L")),
       new Pair<String, OptionMapper>("Sockets", new SimpleOption("c")),
-      new Pair<String, OptionMapper>("KeepAlive", new SimpleOption0("k")),
+      new Pair<String, OptionMapper>("KeepAlive", KeepAliveOption.INSTANCE),
       new Pair<String, OptionMapper>("TimeOut", new SimpleOption("T")),
       new Pair<String, OptionMapper>("RemoveTimeout",
           hostControlHandler.getTimeMapper()),
@@ -1309,6 +1309,21 @@ public class OptionsMapper {
       if (value != null && value.length() != 0) {
         commandline.add("-" + option + ("0".equals(value) ? "0" : ""));
       }
+    }
+  }
+
+  /**
+   * Keep-alive toggle: -%k enables it, -%k0 disables it. Beware the bare -k,
+   * which is the unrelated store-everything-in-cache option.
+   */
+  public static class KeepAliveOption extends SimpleOption0 {
+    /**
+     * An instance of the KeepAliveOption class.
+     */
+    public static final KeepAliveOption INSTANCE = new KeepAliveOption();
+
+    private KeepAliveOption() {
+      super("%k");
     }
   }
 

--- a/app/src/main/java/com/httrack/android/OptionsMapper.java
+++ b/app/src/main/java/com/httrack/android/OptionsMapper.java
@@ -276,7 +276,8 @@ public class OptionsMapper {
       new Pair<String, OptionMapper>("MaxConn", new SimpleOption("%c")),
       new Pair<String, OptionMapper>("MaxLinks", new SimpleOption("#L")),
       new Pair<String, OptionMapper>("Sockets", new SimpleOption("c")),
-      new Pair<String, OptionMapper>("KeepAlive", KeepAliveOption.INSTANCE),
+      /* keep-alive is -%k; the bare -k is StoreAllInCache. */
+      new Pair<String, OptionMapper>("KeepAlive", new SimpleOption0("%k")),
       new Pair<String, OptionMapper>("TimeOut", new SimpleOption("T")),
       new Pair<String, OptionMapper>("RemoveTimeout",
           hostControlHandler.getTimeMapper()),
@@ -1309,21 +1310,6 @@ public class OptionsMapper {
       if (value != null && value.length() != 0) {
         commandline.add("-" + option + ("0".equals(value) ? "0" : ""));
       }
-    }
-  }
-
-  /**
-   * Keep-alive toggle: -%k enables it, -%k0 disables it. Beware the bare -k,
-   * which is the unrelated store-everything-in-cache option.
-   */
-  public static class KeepAliveOption extends SimpleOption0 {
-    /**
-     * An instance of the KeepAliveOption class.
-     */
-    public static final KeepAliveOption INSTANCE = new KeepAliveOption();
-
-    private KeepAliveOption() {
-      super("%k");
     }
   }
 

--- a/app/src/test/java/com/httrack/android/OptionTokenizationTest.java
+++ b/app/src/test/java/com/httrack/android/OptionTokenizationTest.java
@@ -122,6 +122,16 @@ public class OptionTokenizationTest {
     assertTrue(emit(new SimpleOption0("%f"), null).isEmpty());
   }
 
+  /* Keep-alive is the second-set -%k; the bare -k is store-all-in-cache. */
+  @Test
+  public void keepAliveEmitsTheSecondSetOption() {
+    assertEquals(Arrays.asList("-%k"), emit(new SimpleOption0("%k"), "1"));
+    assertEquals(Arrays.asList("-%k0"), emit(new SimpleOption0("%k"), "0"));
+    for (final String value : new String[] { "", null }) {
+      assertTrue(emit(new SimpleOption0("%k"), value).isEmpty());
+    }
+  }
+
   @Test
   public void simpleOptionFlagEmitsOnlyOnOne() {
     assertEquals(Arrays.asList("-n"), emit(new SimpleOptionFlag("n"), "1"));

--- a/app/src/test/java/com/httrack/android/OptionsEmissionTest.java
+++ b/app/src/test/java/com/httrack/android/OptionsEmissionTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import com.httrack.android.OptionsMapper.ArgumentOption;
+import com.httrack.android.OptionsMapper.KeepAliveOption;
 import com.httrack.android.OptionsMapper.OptionMapper;
 import com.httrack.android.OptionsMapper.ProxyHandler;
 import com.httrack.android.OptionsMapper.SimpleOptionFlag;
@@ -152,6 +153,19 @@ public class OptionsEmissionTest {
         assertTrue(cmd.isEmpty());
         assertEquals("-", flags.toString());
       }
+    }
+  }
+
+  /* -%k / -%k0, never the bare -k the engine reads as store-all-in-cache. */
+  @Test
+  public void keepAliveEmitsTheSecondSetOptionBothWays() {
+    for (final String[] c : new String[][] { { "1", "-%k" }, { "0", "-%k0" } }) {
+      final StringBuilder flags = new StringBuilder("-");
+      final List<String> cmd = new ArrayList<String>();
+      KeepAliveOption.INSTANCE.emit(flags, cmd, c[0]);
+      assertEquals(1, cmd.size());
+      assertEquals(c[1], cmd.get(0));
+      assertEquals("-", flags.toString());
     }
   }
 

--- a/app/src/test/java/com/httrack/android/OptionsEmissionTest.java
+++ b/app/src/test/java/com/httrack/android/OptionsEmissionTest.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import com.httrack.android.OptionsMapper.ArgumentOption;
-import com.httrack.android.OptionsMapper.KeepAliveOption;
 import com.httrack.android.OptionsMapper.OptionMapper;
 import com.httrack.android.OptionsMapper.ProxyHandler;
 import com.httrack.android.OptionsMapper.SimpleOptionFlag;
@@ -153,19 +152,6 @@ public class OptionsEmissionTest {
         assertTrue(cmd.isEmpty());
         assertEquals("-", flags.toString());
       }
-    }
-  }
-
-  /* -%k / -%k0, never the bare -k the engine reads as store-all-in-cache. */
-  @Test
-  public void keepAliveEmitsTheSecondSetOptionBothWays() {
-    for (final String[] c : new String[][] { { "1", "-%k" }, { "0", "-%k0" } }) {
-      final StringBuilder flags = new StringBuilder("-");
-      final List<String> cmd = new ArrayList<String>();
-      KeepAliveOption.INSTANCE.emit(flags, cmd, c[0]);
-      assertEquals(1, cmd.size());
-      assertEquals(c[1], cmd.get(0));
-      assertEquals("-", flags.toString());
     }
   }
 


### PR DESCRIPTION
The Keep-alive checkbox mapped to `-k`, which is the engine's store-all-in-cache option, so it never controlled keep-alive, and unticking it aborted the crawl. It now maps to `-%k`, disabled with `-%k0`.

The test pins the option string the mapper emits, not the `KeepAlive` table row, so a row wired to the wrong mapper would still slip through (#81).

Closes #99