### PR TITLE
Numeric option fields offer a decimal point the keyboard should not draw

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -102,6 +102,11 @@ def buildResourcesBundle = tasks.register('buildResourcesBundle', Zip) {
 // them all the dependency on the generated bundle that Gradle's validation requires.
 tasks.named('preBuild').configure { dependsOn buildResourcesBundle }
 
+// NumericFieldInputTypeTest reads the layout XMLs off disk, which Gradle can't infer.
+tasks.withType(Test).configureEach {
+    inputs.dir('src/main/res/layout').withPathSensitivity(PathSensitivity.RELATIVE)
+}
+
 dependencies {
     // Without this, coroutines' stale jdk7/jdk8 shims collide with the stdlib that absorbed them.
     implementation platform('org.jetbrains.kotlin:kotlin-bom:1.8.22')

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -104,7 +104,9 @@ tasks.named('preBuild').configure { dependsOn buildResourcesBundle }
 
 // NumericFieldInputTypeTest reads the layout XMLs off disk, which Gradle can't infer.
 tasks.withType(Test).configureEach {
-    inputs.dir('src/main/res/layout').withPathSensitivity(PathSensitivity.RELATIVE)
+    inputs.files(fileTree('src/main/res') { include 'layout*/**/*.xml' })
+            .withPathSensitivity(PathSensitivity.RELATIVE)
+            .withPropertyName('layoutXml')
 }
 
 dependencies {

--- a/app/src/main/res/layout/activity_options_flowcontrol.xml
+++ b/app/src/main/res/layout/activity_options_flowcontrol.xml
@@ -32,7 +32,7 @@
                 android:layout_weight=".30"
                 android:digits="@string/latin_digits_list"
                 android:hint="8"
-                android:inputType="numberDecimal" >
+                android:inputType="number" >
 
                 <requestFocus />
             </EditText>
@@ -64,7 +64,7 @@
                 android:layout_weight=".30"
                 android:digits="@string/latin_digits_list"
                 android:hint="120"
-                android:inputType="numberDecimal" />
+                android:inputType="number" />
         </LinearLayout>
 
         <CheckBox
@@ -93,7 +93,7 @@
                 android:layout_weight=".30"
                 android:digits="@string/latin_digits_list"
                 android:hint="2"
-                android:inputType="numberDecimal" />
+                android:inputType="number" />
         </LinearLayout>
 
         <LinearLayout
@@ -114,7 +114,7 @@
                 android:layout_height="wrap_content"
                 android:layout_weight=".30"
                 android:digits="@string/latin_digits_list"
-                android:inputType="numberDecimal" />
+                android:inputType="number" />
         </LinearLayout>
 
         <CheckBox

--- a/app/src/main/res/layout/activity_options_limits.xml
+++ b/app/src/main/res/layout/activity_options_limits.xml
@@ -32,7 +32,7 @@
                 android:layout_weight=".30"
                 android:digits="@string/latin_digits_list"
                 android:hint="999"
-                android:inputType="numberDecimal" >
+                android:inputType="number" >
 
                 <requestFocus />
             </EditText>
@@ -57,7 +57,7 @@
                 android:layout_weight=".30"
                 android:digits="@string/latin_digits_list"
                 android:hint="0"
-                android:inputType="numberDecimal" />
+                android:inputType="number" />
         </LinearLayout>
 
         <LinearLayout
@@ -78,7 +78,7 @@
                 android:layout_height="wrap_content"
                 android:layout_weight=".30"
                 android:digits="@string/latin_digits_list"
-                android:inputType="numberDecimal" />
+                android:inputType="number" />
         </LinearLayout>
 
         <LinearLayout
@@ -99,7 +99,7 @@
                 android:layout_height="wrap_content"
                 android:layout_weight=".30"
                 android:digits="@string/latin_digits_list"
-                android:inputType="numberDecimal" />
+                android:inputType="number" />
         </LinearLayout>
 
         <LinearLayout
@@ -120,7 +120,7 @@
                 android:layout_height="wrap_content"
                 android:layout_weight=".30"
                 android:digits="@string/latin_digits_list"
-                android:inputType="numberDecimal" />
+                android:inputType="number" />
         </LinearLayout>
 
         <LinearLayout
@@ -141,7 +141,7 @@
                 android:layout_height="wrap_content"
                 android:layout_weight=".30"
                 android:digits="@string/latin_digits_list"
-                android:inputType="numberDecimal" />
+                android:inputType="number" />
         </LinearLayout>
 
         <LinearLayout
@@ -163,7 +163,7 @@
                 android:layout_weight=".30"
                 android:digits="@string/latin_digits_list"
                 android:hint="25000"
-                android:inputType="numberDecimal" />
+                android:inputType="number" />
         </LinearLayout>
 
         <LinearLayout
@@ -206,7 +206,7 @@
                 android:layout_weight=".30"
                 android:digits="@string/latin_digits_list"
                 android:hint="100000"
-                android:inputType="numberDecimal" />
+                android:inputType="number" />
         </LinearLayout>
     </LinearLayout>
 

--- a/app/src/main/res/layout/activity_options_proxy.xml
+++ b/app/src/main/res/layout/activity_options_proxy.xml
@@ -88,7 +88,7 @@
                 android:layout_weight=".30"
                 android:digits="@string/latin_digits_list"
                 android:hint="@string/hint_proxy_port"
-                android:inputType="numberDecimal" />
+                android:inputType="number" />
         </LinearLayout>
 
         <CheckBox

--- a/app/src/test/java/com/httrack/android/NumericFieldInputTypeTest.java
+++ b/app/src/test/java/com/httrack/android/NumericFieldInputTypeTest.java
@@ -1,9 +1,13 @@
 package com.httrack.android;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.util.HashSet;
+import java.util.Set;
+import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import org.junit.Test;
 import org.w3c.dom.Document;
@@ -12,54 +16,103 @@ import org.w3c.dom.NodeList;
 
 /**
  * The engine's cmdl_opt() reads a '.' inside a '%'-less token such as "-r1.5" as
- * a URL, so integer option fields must not offer a decimal point.
+ * a URL and drops the option, so a numeric option field may offer a decimal
+ * point only when the option it maps to carries a '%'.
  */
 public class NumericFieldInputTypeTest {
   private static final String ANDROID_NS =
       "http://schemas.android.com/apk/res/android";
 
-  /** -%c is the only mapped option the engine scans with "%f". */
-  private static final String DECIMAL_FIELD = "editMaxConnectionsSecond";
+  /** Numeric option fields, each with the engine option OptionsMapper emits. */
+  private static final String[][] NUMERIC_FIELDS = {
+      { "editMaxDepth", "r" }, { "editMaxExtDepth", "%e" },
+      { "editMaxSizeHtml", "m" }, { "editMaxSizeOther", "m" },
+      { "editSiteSizeLimit", "M" }, { "editMaxTimeOverall", "E" },
+      { "editMaxTransferRate", "A" }, { "editMaxConnectionsSecond", "%c" },
+      { "editMaxNumberLinks", "#L" }, { "editNumberOfConnections", "c" },
+      { "editTimeout", "T" }, { "editRetries", "R" },
+      { "editMinTransferRate", "J" }, { "editProxyPort", "P" },
+      { "editSingleFileMaxSize", "--single-file-max-size" } };
 
   /* Unit tests run with the app project as working directory. */
-  private static File layoutDir() {
-    for (final String path : new String[] { "src/main/res/layout",
-        "app/src/main/res/layout" }) {
+  private static File resDir() {
+    for (final String path : new String[] { "src/main/res",
+        "app/src/main/res" }) {
       final File dir = new File(path);
       if (dir.isDirectory()) {
         return dir;
       }
     }
-    throw new IllegalStateException("no layout directory below "
+    throw new IllegalStateException("no res directory below "
         + new File(".").getAbsolutePath());
   }
 
+  /* Every layout, qualified variants such as layout-land/ included. */
+  private static Set<File> layouts() {
+    final Set<File> files = new HashSet<File>();
+    for (final File dir : resDir().listFiles()) {
+      if (!dir.isDirectory() || !dir.getName().startsWith("layout")) {
+        continue;
+      }
+      for (final File file : dir.listFiles()) {
+        if (file.getName().endsWith(".xml")) {
+          files.add(file);
+        }
+      }
+    }
+    return files;
+  }
+
+  private static String option(final String id) {
+    for (final String[] field : NUMERIC_FIELDS) {
+      if (field[0].equals(id)) {
+        return field[1];
+      }
+    }
+    return null;
+  }
+
   @Test
-  public void onlyTheConnectionRateFieldAcceptsADecimalPoint()
+  public void numericFieldsOfferADecimalPointOnlyWhereTheEngineTakesOne()
       throws Exception {
     final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
     factory.setNamespaceAware(true);
-    boolean sawDecimalField = false;
-    for (final File layout : layoutDir().listFiles()) {
-      if (!layout.getName().endsWith(".xml")) {
-        continue;
-      }
-      final Document doc = factory.newDocumentBuilder().parse(layout);
-      final NodeList fields = doc.getElementsByTagName("EditText");
-      for (int i = 0; i < fields.getLength(); i++) {
-        final Element field = Element.class.cast(fields.item(i));
-        final String type = field.getAttributeNS(ANDROID_NS, "inputType");
-        if (!type.startsWith("number")) {
+    final DocumentBuilder builder = factory.newDocumentBuilder();
+    final Set<String> seen = new HashSet<String>();
+    for (final File layout : layouts()) {
+      final Document doc = builder.parse(layout);
+      final NodeList nodes = doc.getElementsByTagName("*");
+      for (int i = 0; i < nodes.getLength(); i++) {
+        final Element view = Element.class.cast(nodes.item(i));
+        // AppCompat inflation and custom widgets both lengthen the tag name.
+        final String tag = view.getTagName();
+        if (!tag.endsWith("EditText") && !tag.endsWith("TextView")) {
           continue;
         }
-        final String id =
-            field.getAttributeNS(ANDROID_NS, "id").replace("@+id/", "");
-        final boolean decimal = DECIMAL_FIELD.equals(id);
-        sawDecimalField |= decimal;
-        assertEquals(layout.getName() + ": " + id,
-            decimal ? "numberDecimal" : "number", type);
+        final String id = view.getAttributeNS(ANDROID_NS, "id")
+            .replaceFirst("^@\\+?id/", "");
+        final String option = option(id);
+        if (option == null) {
+          continue;
+        }
+        seen.add(id);
+        final String where = layout.getName() + ": " + id;
+        final String inputType = view.getAttributeNS(ANDROID_NS, "inputType");
+        assertFalse(where + " declares no inputType", inputType.isEmpty());
+        for (final String flag : inputType.split("\\|")) {
+          assertTrue(where + " is not numeric: " + flag,
+              flag.startsWith("number"));
+          // A leading '-' makes the engine reject the whole commandline.
+          assertFalse(where + " accepts a sign", "numberSigned".equals(flag));
+          assertTrue(
+              where + " accepts a decimal point but -" + option + " does not",
+              !"numberDecimal".equals(flag) || option.indexOf('%') != -1);
+        }
       }
     }
-    assertTrue("no numeric field parsed", sawDecimalField);
+    for (final String[] field : NUMERIC_FIELDS) {
+      assertTrue("no layout declares " + field[0], seen.contains(field[0]));
+    }
+    assertEquals(NUMERIC_FIELDS.length, seen.size());
   }
 }

--- a/app/src/test/java/com/httrack/android/NumericFieldInputTypeTest.java
+++ b/app/src/test/java/com/httrack/android/NumericFieldInputTypeTest.java
@@ -1,0 +1,65 @@
+package com.httrack.android;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+/**
+ * The engine's cmdl_opt() reads a '.' inside a '%'-less token such as "-r1.5" as
+ * a URL, so integer option fields must not offer a decimal point.
+ */
+public class NumericFieldInputTypeTest {
+  private static final String ANDROID_NS =
+      "http://schemas.android.com/apk/res/android";
+
+  /** -%c is the only mapped option the engine scans with "%f". */
+  private static final String DECIMAL_FIELD = "editMaxConnectionsSecond";
+
+  /* Unit tests run with the app project as working directory. */
+  private static File layoutDir() {
+    for (final String path : new String[] { "src/main/res/layout",
+        "app/src/main/res/layout" }) {
+      final File dir = new File(path);
+      if (dir.isDirectory()) {
+        return dir;
+      }
+    }
+    throw new IllegalStateException("no layout directory below "
+        + new File(".").getAbsolutePath());
+  }
+
+  @Test
+  public void onlyTheConnectionRateFieldAcceptsADecimalPoint()
+      throws Exception {
+    final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+    factory.setNamespaceAware(true);
+    boolean sawDecimalField = false;
+    for (final File layout : layoutDir().listFiles()) {
+      if (!layout.getName().endsWith(".xml")) {
+        continue;
+      }
+      final Document doc = factory.newDocumentBuilder().parse(layout);
+      final NodeList fields = doc.getElementsByTagName("EditText");
+      for (int i = 0; i < fields.getLength(); i++) {
+        final Element field = Element.class.cast(fields.item(i));
+        final String type = field.getAttributeNS(ANDROID_NS, "inputType");
+        if (!type.startsWith("number")) {
+          continue;
+        }
+        final String id =
+            field.getAttributeNS(ANDROID_NS, "id").replace("@+id/", "");
+        final boolean decimal = DECIMAL_FIELD.equals(id);
+        sawDecimalField |= decimal;
+        assertEquals(layout.getName() + ": " + id,
+            decimal ? "numberDecimal" : "number", type);
+      }
+    }
+    assertTrue("no numeric field parsed", sawDecimalField);
+  }
+}


### PR DESCRIPTION
Thirteen integer option fields in the limits, flow-control and proxy layouts declared `android:inputType="numberDecimal"`, so the soft keyboard offered a decimal point on fields where `cmdl_opt()` reads a `%`-less token holding a `.` as a URL. They are `number` now. `editMaxConnectionsSecond` keeps the decimal type, because `-%c` carries a `%` and the engine scans it with `sscanf("%f")`.

That is a keyboard affordance, not a fix for #100, which I have left open on purpose. All thirteen fields already carry `android:digits="0123456789"`, and `TextView`'s constructor tests the `digits` branch before the `inputType` one, so `setInputType()` never ran on them and the key listener that filters typed and pasted input is the same before and after. The path that does reach the engine with a dot is written up on the issue. A new unit test parses every `res/layout*` file and asserts that a numeric option field declares a decimal point only when its mapped option carries a `%`. `app/build.gradle` registers those XMLs as a test input; drop that stanza and Gradle calls the task up to date, so editing a layout never re-runs it.

Refs #100
