### PR TITLE
Finish unpacking the option flags and retire the shared buffer

### DIFF
--- a/app/src/main/java/com/httrack/android/OptionsMapper.java
+++ b/app/src/main/java/com/httrack/android/OptionsMapper.java
@@ -59,9 +59,10 @@ public class OptionsMapper {
       new Pair<Integer, String>(R.id.fieldProjectName, "ProjectName"),
       new Pair<Integer, String>(R.id.fieldProjectCategory, "Category"),
 
-      /* URL */
-      new Pair<Integer, String>(R.id.fieldWebsiteURLs, "CurrentUrl"),
+      /* URL. CurrentAction emits before the URL on purpose: the engine counts
+         URLs positionally, and its -iC* must land ahead of the first one. */
       new Pair<Integer, String>(R.id.radioAction, "CurrentAction"), /* FIXME */
+      new Pair<Integer, String>(R.id.fieldWebsiteURLs, "CurrentUrl"),
 
       /* Scan Rules */
       new Pair<Integer, String>(R.id.editRules, "WildCardFilters"),
@@ -1797,8 +1798,6 @@ public class OptionsMapper {
    * @return The commandline argument(s)
    */
   public List<String> buildCommandline() {
-    // One engine option per token: packing them lets a flag's letter be read as
-    // the next one's two-letter variant (issue #78).
     final List<String> args = new ArrayList<String>();
 
     // Map all options

--- a/app/src/main/java/com/httrack/android/OptionsMapper.java
+++ b/app/src/main/java/com/httrack/android/OptionsMapper.java
@@ -264,7 +264,7 @@ public class OptionsMapper {
       new Pair<String, OptionMapper>("Category", NoOpOption.INSTANCE),
       new Pair<String, OptionMapper>("CurrentUrl", UrlSplit.INSTANCE),
       new Pair<String, OptionMapper>("CurrentAction",
-          new MultipleChoicesOption(new String[] { "iC1", "iC2" }, true)),
+          MultipleChoicesOption.ACTION),
       new Pair<String, OptionMapper>("WildCardFilters", StringSplit.INSTANCE),
       new Pair<String, OptionMapper>("Depth", new SimpleOption("r")),
       new Pair<String, OptionMapper>("ExtDepth", new SimpleOption("%e")),
@@ -356,12 +356,11 @@ public class OptionsMapper {
       new Pair<String, OptionMapper>("Cache", new SimpleOptionFlag("C0", true)), /* FIXME */
       new Pair<String, OptionMapper>("PrimaryScan",
           primaryScanHandler.getTypeMapper()),
-      new Pair<String, OptionMapper>("Travel", new MultipleChoicesOption(
-          new String[] { "S", "D", "U", "B" }, true)),
-      new Pair<String, OptionMapper>("GlobalTravel", new MultipleChoicesOption(
-          new String[] { "a", "d", "l", "e" }, true)),
-      new Pair<String, OptionMapper>("RewriteLinks", new MultipleChoicesOption(
-          new String[] { "K0", "K", "K3", "K4" }, true)),
+      new Pair<String, OptionMapper>("Travel", MultipleChoicesOption.TRAVEL),
+      new Pair<String, OptionMapper>("GlobalTravel",
+          MultipleChoicesOption.GLOBAL_TRAVEL),
+      new Pair<String, OptionMapper>("RewriteLinks",
+          MultipleChoicesOption.REWRITE_LINKS),
       new Pair<String, OptionMapper>("Debugging", new SimpleOptionFlag("%H")),
       new Pair<String, OptionMapper>("MIMEDefsExt1",
           mimeTypesHandlers[0].getExtMapper()),
@@ -427,28 +426,22 @@ public class OptionsMapper {
     public static interface FinishMapper {
       /**
        * FinisExecute post-action
-       * 
-       * @param flags
-       *          the flags array
+       *
        * @param commandline
        *          the commandline array
        */
-      public void finish(final StringBuilder flags,
-          final List<String> commandline);
+      public void finish(final List<String> commandline);
     }
 
     /**
      * Emit the option
-     * 
-     * @param flags
-     *          the flags array
+     *
      * @param commandline
      *          the commandline array
      * @param value
      *          the option value
      */
-    public void emit(final StringBuilder flags, final List<String> commandline,
-        final String value);
+    public void emit(final List<String> commandline, final String value);
   }
 
   /**
@@ -461,8 +454,7 @@ public class OptionsMapper {
     public static final NoOpOption INSTANCE = new NoOpOption();
 
     @Override
-    public void emit(final StringBuilder flags, final List<String> commandline,
-        final String value) {
+    public void emit(final List<String> commandline, final String value) {
     }
   }
 
@@ -511,8 +503,7 @@ public class OptionsMapper {
     }
 
     @Override
-    public void emit(final StringBuilder flags, final List<String> commandline,
-        final String value) {
+    public void emit(final List<String> commandline, final String value) {
       // URLs
       for (String s : cleanupString(value).trim().split(split)) {
         s = s.trim();
@@ -537,8 +528,7 @@ public class OptionsMapper {
     public static final UrlSplit INSTANCE = new UrlSplit();
 
     @Override
-    public void emit(final StringBuilder flags, final List<String> commandline,
-        final String value) {
+    public void emit(final List<String> commandline, final String value) {
       commandline.addAll(CommandlineTokens.urlTokens(value));
     }
   }
@@ -557,17 +547,15 @@ public class OptionsMapper {
      */
     private class Html implements OptionMapper, OptionMapper.FinishMapper {
       @Override
-      public void emit(final StringBuilder flags,
-          final List<String> commandline, final String value) {
+      public void emit(final List<String> commandline, final String value) {
         if (OptionValues.isDigits(value)) {
           MaxSizeHandler.this.maxHtml = OptionValues.parseInt(value);
         }
       }
 
       @Override
-      public void finish(final StringBuilder flags,
-          final List<String> commandline) {
-        MaxSizeHandler.this.finish(flags, commandline);
+      public void finish(final List<String> commandline) {
+        MaxSizeHandler.this.finish(commandline);
       }
     }
 
@@ -576,17 +564,15 @@ public class OptionsMapper {
      */
     private class NonHtml implements OptionMapper, OptionMapper.FinishMapper {
       @Override
-      public void emit(final StringBuilder flags,
-          final List<String> commandline, final String value) {
+      public void emit(final List<String> commandline, final String value) {
         if (OptionValues.isDigits(value)) {
           MaxSizeHandler.this.maxNonHtml = OptionValues.parseInt(value);
         }
       }
 
       @Override
-      public void finish(final StringBuilder flags,
-          final List<String> commandline) {
-        MaxSizeHandler.this.finish(flags, commandline);
+      public void finish(final List<String> commandline) {
+        MaxSizeHandler.this.finish(commandline);
       }
     }
 
@@ -611,8 +597,7 @@ public class OptionsMapper {
     /*
      * Where we really emit the option
      */
-    private void finish(final StringBuilder flags,
-        final List<String> commandline) {
+    private void finish(final List<String> commandline) {
       // mN maximum file length for a non-html file (--max-files[=N])
       // mN,N2 maximum file length for non html (N) and html (N2)
       if (!finished) {
@@ -645,17 +630,15 @@ public class OptionsMapper {
      */
     private class Time implements OptionMapper, OptionMapper.FinishMapper {
       @Override
-      public void emit(final StringBuilder flags,
-          final List<String> commandline, final String value) {
+      public void emit(final List<String> commandline, final String value) {
         if ("1".equals(value)) {
           HostControlHandler.this.flag |= 1;
         }
       }
 
       @Override
-      public void finish(final StringBuilder flags,
-          final List<String> commandline) {
-        HostControlHandler.this.finish(flags, commandline);
+      public void finish(final List<String> commandline) {
+        HostControlHandler.this.finish(commandline);
       }
     }
 
@@ -664,17 +647,15 @@ public class OptionsMapper {
      */
     private class Rate implements OptionMapper, OptionMapper.FinishMapper {
       @Override
-      public void emit(final StringBuilder flags,
-          final List<String> commandline, final String value) {
+      public void emit(final List<String> commandline, final String value) {
         if ("1".equals(value)) {
           HostControlHandler.this.flag |= 2;
         }
       }
 
       @Override
-      public void finish(final StringBuilder flags,
-          final List<String> commandline) {
-        HostControlHandler.this.finish(flags, commandline);
+      public void finish(final List<String> commandline) {
+        HostControlHandler.this.finish(commandline);
       }
     }
 
@@ -699,8 +680,7 @@ public class OptionsMapper {
     /*
      * Where we really emit the option
      */
-    private void finish(final StringBuilder flags,
-        final List<String> commandline) {
+    private void finish(final List<String> commandline) {
       if (!finished) {
         finished = true;
         commandline.add("-H" + flag);
@@ -721,17 +701,15 @@ public class OptionsMapper {
      */
     private class Dos implements OptionMapper, OptionMapper.FinishMapper {
       @Override
-      public void emit(final StringBuilder flags,
-          final List<String> commandline, final String value) {
+      public void emit(final List<String> commandline, final String value) {
         if ("1".equals(value)) {
           DosIso9660Handler.this.dos = true;
         }
       }
 
       @Override
-      public void finish(final StringBuilder flags,
-          final List<String> commandline) {
-        DosIso9660Handler.this.finish(flags, commandline);
+      public void finish(final List<String> commandline) {
+        DosIso9660Handler.this.finish(commandline);
       }
     }
 
@@ -740,17 +718,15 @@ public class OptionsMapper {
      */
     private class Iso9660 implements OptionMapper, OptionMapper.FinishMapper {
       @Override
-      public void emit(final StringBuilder flags,
-          final List<String> commandline, final String value) {
+      public void emit(final List<String> commandline, final String value) {
         if ("1".equals(value)) {
           DosIso9660Handler.this.iso9660 = true;
         }
       }
 
       @Override
-      public void finish(final StringBuilder flags,
-          final List<String> commandline) {
-        DosIso9660Handler.this.finish(flags, commandline);
+      public void finish(final List<String> commandline) {
+        DosIso9660Handler.this.finish(commandline);
       }
     }
 
@@ -775,8 +751,7 @@ public class OptionsMapper {
     /*
      * Where we really emit the option
      */
-    private void finish(final StringBuilder flags,
-        final List<String> commandline) {
+    private void finish(final List<String> commandline) {
       if (!finished) {
         finished = true;
         // Note: same logic (...) as WinHTTrack ; see WinHTTrack/Shell.cpp
@@ -801,17 +776,15 @@ public class OptionsMapper {
      */
     private class Address implements OptionMapper, OptionMapper.FinishMapper {
       @Override
-      public void emit(final StringBuilder flags,
-          final List<String> commandline, final String value) {
+      public void emit(final List<String> commandline, final String value) {
         if (value != null && value.length() != 0) {
           ProxyHandler.this.address = value;
         }
       }
 
       @Override
-      public void finish(final StringBuilder flags,
-          final List<String> commandline) {
-        ProxyHandler.this.finish(flags, commandline);
+      public void finish(final List<String> commandline) {
+        ProxyHandler.this.finish(commandline);
       }
     }
 
@@ -820,17 +793,15 @@ public class OptionsMapper {
      */
     private class Port implements OptionMapper, OptionMapper.FinishMapper {
       @Override
-      public void emit(final StringBuilder flags,
-          final List<String> commandline, final String value) {
+      public void emit(final List<String> commandline, final String value) {
         if (value != null && value.length() != 0) {
           ProxyHandler.this.port = value;
         }
       }
 
       @Override
-      public void finish(final StringBuilder flags,
-          final List<String> commandline) {
-        ProxyHandler.this.finish(flags, commandline);
+      public void finish(final List<String> commandline) {
+        ProxyHandler.this.finish(commandline);
       }
     }
 
@@ -857,17 +828,15 @@ public class OptionsMapper {
      */
     private class Protocol implements OptionMapper, OptionMapper.FinishMapper {
       @Override
-      public void emit(final StringBuilder flags,
-          final List<String> commandline, final String value) {
+      public void emit(final List<String> commandline, final String value) {
         if (value != null && value.length() != 0) {
           ProxyHandler.this.protocol = value;
         }
       }
 
       @Override
-      public void finish(final StringBuilder flags,
-          final List<String> commandline) {
-        ProxyHandler.this.finish(flags, commandline);
+      public void finish(final List<String> commandline) {
+        ProxyHandler.this.finish(commandline);
       }
     }
 
@@ -885,8 +854,7 @@ public class OptionsMapper {
      * only SOCKS5 defaults to port 1080 instead of 8080. Value is the radio
      * index: 0 HTTP, 1 SOCKS5, 2 HTTP CONNECT tunnel.
      */
-    private void finish(final StringBuilder flags,
-        final List<String> commandline) {
+    private void finish(final List<String> commandline) {
       if (!finished) {
         finished = true;
         if (address != null) {
@@ -916,17 +884,15 @@ public class OptionsMapper {
      */
     private class Type implements OptionMapper, OptionMapper.FinishMapper {
       @Override
-      public void emit(final StringBuilder flags,
-          final List<String> commandline, final String value) {
+      public void emit(final List<String> commandline, final String value) {
         if (OptionValues.isDigits(value)) {
           BuildHandler.this.build = Integer.parseInt(value);
         }
       }
 
       @Override
-      public void finish(final StringBuilder flags,
-          final List<String> commandline) {
-        BuildHandler.this.finish(flags, commandline);
+      public void finish(final List<String> commandline) {
+        BuildHandler.this.finish(commandline);
       }
     }
 
@@ -935,17 +901,15 @@ public class OptionsMapper {
      */
     private class Custom implements OptionMapper, OptionMapper.FinishMapper {
       @Override
-      public void emit(final StringBuilder flags,
-          final List<String> commandline, final String value) {
+      public void emit(final List<String> commandline, final String value) {
         if (value != null && value.length() != 0) {
           BuildHandler.this.custom = value;
         }
       }
 
       @Override
-      public void finish(final StringBuilder flags,
-          final List<String> commandline) {
-        BuildHandler.this.finish(flags, commandline);
+      public void finish(final List<String> commandline) {
+        BuildHandler.this.finish(commandline);
       }
     }
 
@@ -974,8 +938,7 @@ public class OptionsMapper {
     /*
      * Where we really emit the option
      */
-    private void finish(final StringBuilder flags,
-        final List<String> commandline) {
+    private void finish(final List<String> commandline) {
       if (!finished) {
         finished = true;
         if (build < mapping.length) {
@@ -1001,17 +964,15 @@ public class OptionsMapper {
      */
     private class Type implements OptionMapper, OptionMapper.FinishMapper {
       @Override
-      public void emit(final StringBuilder flags,
-          final List<String> commandline, final String value) {
+      public void emit(final List<String> commandline, final String value) {
         if (OptionValues.isDigits(value)) {
           LogHandler.this.type = Integer.parseInt(value);
         }
       }
 
       @Override
-      public void finish(final StringBuilder flags,
-          final List<String> commandline) {
-        LogHandler.this.finish(flags, commandline);
+      public void finish(final List<String> commandline) {
+        LogHandler.this.finish(commandline);
       }
     }
 
@@ -1020,17 +981,15 @@ public class OptionsMapper {
      */
     private class Enabled implements OptionMapper, OptionMapper.FinishMapper {
       @Override
-      public void emit(final StringBuilder flags,
-          final List<String> commandline, final String value) {
+      public void emit(final List<String> commandline, final String value) {
         if (value != null && value.length() != 0) {
           LogHandler.this.enabled = "1".equals(value);
         }
       }
 
       @Override
-      public void finish(final StringBuilder flags,
-          final List<String> commandline) {
-        LogHandler.this.finish(flags, commandline);
+      public void finish(final List<String> commandline) {
+        LogHandler.this.finish(commandline);
       }
     }
 
@@ -1055,8 +1014,7 @@ public class OptionsMapper {
     /*
      * Where we really emit the option
      */
-    private void finish(final StringBuilder flags,
-        final List<String> commandline) {
+    private void finish(final List<String> commandline) {
       if (!finished) {
         finished = true;
         if (enabled) {
@@ -1064,14 +1022,14 @@ public class OptionsMapper {
           case 0:
             break;
           case 1:
-            flags.append('z');
+            commandline.add("-z");
             break;
           case 2:
-            flags.append('Z');
+            commandline.add("-Z");
             break;
           }
         } else {
-          flags.append('Q');
+          commandline.add("-Q");
         }
       }
     }
@@ -1090,17 +1048,15 @@ public class OptionsMapper {
      */
     private class Type implements OptionMapper, OptionMapper.FinishMapper {
       @Override
-      public void emit(final StringBuilder flags,
-          final List<String> commandline, final String value) {
+      public void emit(final List<String> commandline, final String value) {
         if (OptionValues.isDigits(value)) {
           PrimaryScanHandler.this.type = Integer.parseInt(value);
         }
       }
 
       @Override
-      public void finish(final StringBuilder flags,
-          final List<String> commandline) {
-        PrimaryScanHandler.this.finish(flags, commandline);
+      public void finish(final List<String> commandline) {
+        PrimaryScanHandler.this.finish(commandline);
       }
     }
 
@@ -1109,17 +1065,15 @@ public class OptionsMapper {
      */
     private class HtmlFirst implements OptionMapper, OptionMapper.FinishMapper {
       @Override
-      public void emit(final StringBuilder flags,
-          final List<String> commandline, final String value) {
+      public void emit(final List<String> commandline, final String value) {
         if (value != null && value.length() != 0) {
           PrimaryScanHandler.this.htmlFirst = "1".equals(value);
         }
       }
 
       @Override
-      public void finish(final StringBuilder flags,
-          final List<String> commandline) {
-        PrimaryScanHandler.this.finish(flags, commandline);
+      public void finish(final List<String> commandline) {
+        PrimaryScanHandler.this.finish(commandline);
       }
     }
 
@@ -1144,28 +1098,20 @@ public class OptionsMapper {
     /*
      * Where we really emit the option
      */
-    private void finish(final StringBuilder flags,
-        final List<String> commandline) {
+    private void finish(final List<String> commandline) {
       if (!finished) {
         finished = true;
         switch (type) {
         case 0:
         case 1:
         case 2:
-          flags.append('p');
-          flags.append(type);
+          commandline.add("-p" + type);
           break;
         case 3:
-          flags.append('p');
-          if (!htmlFirst) {
-            flags.append(type);
-          } else {
-            flags.append('7');
-          }
+          commandline.add(htmlFirst ? "-p7" : "-p" + type);
           break;
         case 4:
-          flags.append('p');
-          flags.append('7');
+          commandline.add("-p7");
           break;
         }
       }
@@ -1185,17 +1131,15 @@ public class OptionsMapper {
      */
     private class Ext implements OptionMapper, OptionMapper.FinishMapper {
       @Override
-      public void emit(final StringBuilder flags,
-          final List<String> commandline, final String value) {
+      public void emit(final List<String> commandline, final String value) {
         if (value != null && value.length() != 0) {
           MimeTypesHandler.this.ext = value.trim();
         }
       }
 
       @Override
-      public void finish(final StringBuilder flags,
-          final List<String> commandline) {
-        MimeTypesHandler.this.finish(flags, commandline);
+      public void finish(final List<String> commandline) {
+        MimeTypesHandler.this.finish(commandline);
       }
     }
 
@@ -1204,17 +1148,15 @@ public class OptionsMapper {
      */
     private class Mime implements OptionMapper, OptionMapper.FinishMapper {
       @Override
-      public void emit(final StringBuilder flags,
-          final List<String> commandline, final String value) {
+      public void emit(final List<String> commandline, final String value) {
         if (value != null && value.length() != 0) {
           MimeTypesHandler.this.mime = value.trim();
         }
       }
 
       @Override
-      public void finish(final StringBuilder flags,
-          final List<String> commandline) {
-        MimeTypesHandler.this.finish(flags, commandline);
+      public void finish(final List<String> commandline) {
+        MimeTypesHandler.this.finish(commandline);
       }
     }
 
@@ -1239,8 +1181,7 @@ public class OptionsMapper {
     /*
      * Where we really emit the option
      */
-    private void finish(final StringBuilder flags,
-        final List<String> commandline) {
+    private void finish(final List<String> commandline) {
       if (!finished) {
         finished = true;
         if (ext != null && mime != null && ext.length() != 0
@@ -1263,8 +1204,7 @@ public class OptionsMapper {
     }
 
     @Override
-    public void emit(final StringBuilder flags, final List<String> commandline,
-        final String value) {
+    public void emit(final List<String> commandline, final String value) {
       if (value != null && value.length() != 0) {
         commandline.add("-" + option + value);
       }
@@ -1283,8 +1223,7 @@ public class OptionsMapper {
     }
 
     @Override
-    public void emit(final StringBuilder flags, final List<String> commandline,
-        final String value) {
+    public void emit(final List<String> commandline, final String value) {
       if (value != null && value.length() != 0) {
         commandline.add(option);
         commandline.add(value);
@@ -1304,8 +1243,7 @@ public class OptionsMapper {
     }
 
     @Override
-    public void emit(final StringBuilder flags, final List<String> commandline,
-        final String value) {
+    public void emit(final List<String> commandline, final String value) {
       if (value != null && value.length() != 0) {
         commandline.add("-" + option + ("0".equals(value) ? "0" : ""));
       }
@@ -1329,8 +1267,7 @@ public class OptionsMapper {
     }
 
     @Override
-    public void emit(final StringBuilder flags, final List<String> commandline,
-        final String value) {
+    public void emit(final List<String> commandline, final String value) {
       if (value != null && value.length() != 0) {
         if ((!reverted && "1".equals(value)) || (reverted && "0".equals(value))) {
           commandline.add("-" + option);
@@ -1340,30 +1277,32 @@ public class OptionsMapper {
   }
 
   /**
-   * Option without any value.
+   * Radio-button option: the selected index picks the engine flag to emit.
    */
   public static class MultipleChoicesOption implements OptionMapper {
-    protected final String[] choices;
-    protected final boolean asFlag;
+    public static final MultipleChoicesOption ACTION =
+        new MultipleChoicesOption(new String[] { "iC1", "iC2" });
+    public static final MultipleChoicesOption TRAVEL =
+        new MultipleChoicesOption(new String[] { "S", "D", "U", "B" });
+    public static final MultipleChoicesOption GLOBAL_TRAVEL =
+        new MultipleChoicesOption(new String[] { "a", "d", "l", "e" });
+    public static final MultipleChoicesOption REWRITE_LINKS =
+        new MultipleChoicesOption(new String[] { "K0", "K", "K3", "K4" });
 
-    public MultipleChoicesOption(final String[] choices, final boolean asFlag) {
+    protected final String[] choices;
+
+    public MultipleChoicesOption(final String[] choices) {
       this.choices = choices;
-      this.asFlag = asFlag;
     }
 
     @Override
-    public void emit(final StringBuilder flags, final List<String> commandline,
-        final String value) {
+    public void emit(final List<String> commandline, final String value) {
       if (OptionValues.isDigits(value)) {
         final int choiceId = Integer.parseInt(value);
         if (choiceId >= 0 && choiceId < choices.length) {
           final String choice = choices[choiceId];
           if (choice != null && choice.length() != 0) {
-            if (asFlag) {
-              flags.append(choice);
-            } else {
-              commandline.add(choice);
-            }
+            commandline.add("-" + choice);
           }
         }
       }
@@ -1857,10 +1796,9 @@ public class OptionsMapper {
    * @return The commandline argument(s)
    */
   public List<String> buildCommandline() {
-    // Leftover compacted token: only options with no two-letter variant may be
-    // packed here, or the next flag's letter is read as that variant (issue #78).
-    final StringBuilder flags = new StringBuilder("-");
-    final List<String> list = new ArrayList<String>();
+    // One engine option per token: packing them lets a flag's letter be read as
+    // the next one's two-letter variant (issue #78).
+    final List<String> args = new ArrayList<String>();
 
     // Map all options
     for (final Pair<Integer, String> field : OptionsMapper.fieldsSerializer) {
@@ -1868,13 +1806,11 @@ public class OptionsMapper {
       final String key = field.second;
       if (value != null) {
         final OptionMapper map = fieldsNameToMapper.get(key);
-        if (map != null) {
-          map.emit(flags, list, value);
-          // Log.v(getClass().getSimpleName(), "option mapped: " + key + "="
-          // + value + " => " + flags);
-        } else {
+        if (map == null) {
           Log.v(getClass().getSimpleName(), "option not mapped: " + key + "="
               + value);
+        } else {
+          map.emit(args, value);
         }
       }
     }
@@ -1882,28 +1818,8 @@ public class OptionsMapper {
     // Call finish for special mappers
     for (final OptionMapper map : fieldsNameToMapper.values()) {
       if (map instanceof OptionMapper.FinishMapper) {
-        final OptionMapper.FinishMapper finish = OptionMapper.FinishMapper.class
-            .cast(map);
-        finish.finish(flags, list);
-        // Log.v(getClass().getSimpleName(), "finish: " +
-        // map.getClass().getName() + " => " + flags);
+        OptionMapper.FinishMapper.class.cast(map).finish(args);
       }
-    }
-
-    // Final args
-    final List<String> args = new ArrayList<String>();
-
-    // First option non-empty ?
-    if (flags.length() > 1) {
-      args.add(flags.toString());
-      Log.v(getClass().getSimpleName(), "flags: " + flags);
-    } else {
-      Log.v(getClass().getSimpleName(), "no flags");
-    }
-
-    // Add all other args
-    for (final String arg : list) {
-      args.add(arg);
     }
 
     // Return final args

--- a/app/src/test/java/com/httrack/android/OptionTokenizationTest.java
+++ b/app/src/test/java/com/httrack/android/OptionTokenizationTest.java
@@ -33,66 +33,47 @@ public class OptionTokenizationTest {
     }
   }
 
-  /* Assemble as buildCommandline() does: leading flags token, then the rest. */
-  private static List<String> argv(final StringBuilder flags,
-      final List<String> commandline) {
-    final List<String> args = new ArrayList<String>();
-    if (flags.length() > 1) {
-      args.add(flags.toString());
-    }
-    args.addAll(commandline);
-    return args;
-  }
-
   private static List<String> emit(final OptionMapper mapper, final String value) {
     final List<String> cmd = new ArrayList<String>();
-    final StringBuilder flags = new StringBuilder("-");
-    mapper.emit(flags, cmd, value);
-    assertEquals("nothing may be packed", "-", flags.toString());
+    mapper.emit(cmd, value);
     return cmd;
   }
 
   private static List<String> finish(final OptionMapper mapper) {
     final List<String> cmd = new ArrayList<String>();
-    final StringBuilder flags = new StringBuilder("-");
-    ((OptionMapper.FinishMapper) mapper).finish(flags, cmd);
-    assertEquals("nothing may be packed", "-", flags.toString());
+    ((OptionMapper.FinishMapper) mapper).finish(cmd);
     return cmd;
   }
 
   /* Reported profile: WARC on, no CheckType to separate it from robots. */
   @Test
   public void warcWithoutCheckTypeKeepsTheCrawlUrl() {
-    final StringBuilder flags = new StringBuilder("-");
     final List<String> cmd = new ArrayList<String>();
-    UrlSplit.INSTANCE.emit(flags, cmd, "http://www.example.com/");
-    new SimpleOptionFlag("X0").emit(flags, cmd, "1"); // NoPurgeOldFiles
-    new SimpleOptionFlag("%r").emit(flags, cmd, "1"); // Warc
-    new SimpleOption("u").emit(flags, cmd, ""); // CheckType, out of range
-    new SimpleOption("s").emit(flags, cmd, "2"); // FollowRobotsTxt
-    new SimpleOptionFlag("%s").emit(flags, cmd, "1"); // UpdateHack
+    UrlSplit.INSTANCE.emit(cmd, "http://www.example.com/");
+    new SimpleOptionFlag("X0").emit(cmd, "1"); // NoPurgeOldFiles
+    new SimpleOptionFlag("%r").emit(cmd, "1"); // Warc
+    new SimpleOption("u").emit(cmd, ""); // CheckType, out of range
+    new SimpleOption("s").emit(cmd, "2"); // FollowRobotsTxt
+    new SimpleOptionFlag("%s").emit(cmd, "1"); // UpdateHack
 
-    final List<String> args = argv(flags, cmd);
-    assertNoArgumentVariant(args);
+    assertNoArgumentVariant(cmd);
     assertEquals(Arrays.asList("http://www.example.com/", "-X0", "-%r", "-s2",
-        "-%s"), args);
+        "-%s"), cmd);
   }
 
   /* Sitemap and single-file have the same shape, and the same neighbours. */
   @Test
   public void sitemapAndSingleFileNeverSpellTheirArgumentVariant() {
-    final StringBuilder flags = new StringBuilder("-");
     final List<String> cmd = new ArrayList<String>();
-    UrlSplit.INSTANCE.emit(flags, cmd, "http://www.example.com/");
-    new SimpleOptionFlag("%m").emit(flags, cmd, "1"); // Sitemap
-    new SimpleOption0("%u").emit(flags, cmd, "1"); // URLHack
-    new SimpleOptionFlag("%Z").emit(flags, cmd, "1"); // SingleFile
-    new SimpleOption("s").emit(flags, cmd, "0"); // FollowRobotsTxt
+    UrlSplit.INSTANCE.emit(cmd, "http://www.example.com/");
+    new SimpleOptionFlag("%m").emit(cmd, "1"); // Sitemap
+    new SimpleOption0("%u").emit(cmd, "1"); // URLHack
+    new SimpleOptionFlag("%Z").emit(cmd, "1"); // SingleFile
+    new SimpleOption("s").emit(cmd, "0"); // FollowRobotsTxt
 
-    final List<String> args = argv(flags, cmd);
-    assertNoArgumentVariant(args);
+    assertNoArgumentVariant(cmd);
     assertEquals(Arrays.asList("http://www.example.com/", "-%m", "-%u", "-%Z",
-        "-s0"), args);
+        "-s0"), cmd);
   }
 
   @Test
@@ -143,13 +124,11 @@ public class OptionTokenizationTest {
   private static List<String> emitMaxSize(final String html,
       final String nonHtml) {
     final MaxSizeHandler handler = new MaxSizeHandler();
-    final StringBuilder flags = new StringBuilder("-");
     final List<String> cmd = new ArrayList<String>();
-    handler.getHtml().emit(flags, cmd, html);
+    handler.getHtml().emit(cmd, html);
     final OptionMapper nonHtmlMapper = handler.getNonHtml();
-    nonHtmlMapper.emit(flags, cmd, nonHtml);
-    ((OptionMapper.FinishMapper) nonHtmlMapper).finish(flags, cmd);
-    assertEquals("nothing may be packed", "-", flags.toString());
+    nonHtmlMapper.emit(cmd, nonHtml);
+    ((OptionMapper.FinishMapper) nonHtmlMapper).finish(cmd);
     return cmd;
   }
 
@@ -170,24 +149,21 @@ public class OptionTokenizationTest {
   public void maxSizeEmitsOnce() {
     final MaxSizeHandler handler = new MaxSizeHandler();
     final OptionMapper mapper = handler.getHtml();
-    final StringBuilder flags = new StringBuilder("-");
     final List<String> cmd = new ArrayList<String>();
-    mapper.emit(flags, cmd, "1000");
-    ((OptionMapper.FinishMapper) mapper).finish(flags, cmd);
-    ((OptionMapper.FinishMapper) handler.getNonHtml()).finish(flags, cmd);
+    mapper.emit(cmd, "1000");
+    ((OptionMapper.FinishMapper) mapper).finish(cmd);
+    ((OptionMapper.FinishMapper) handler.getNonHtml()).finish(cmd);
     assertEquals(Arrays.asList("-m,1000"), cmd);
   }
 
   private static List<String> emitHostControl(final String time,
       final String rate) {
     final HostControlHandler handler = new HostControlHandler();
-    final StringBuilder flags = new StringBuilder("-");
     final List<String> cmd = new ArrayList<String>();
-    handler.getTimeMapper().emit(flags, cmd, time);
+    handler.getTimeMapper().emit(cmd, time);
     final OptionMapper rateMapper = handler.getRateMapper();
-    rateMapper.emit(flags, cmd, rate);
-    ((OptionMapper.FinishMapper) rateMapper).finish(flags, cmd);
-    assertEquals("nothing may be packed", "-", flags.toString());
+    rateMapper.emit(cmd, rate);
+    ((OptionMapper.FinishMapper) rateMapper).finish(cmd);
     return cmd;
   }
 
@@ -203,20 +179,17 @@ public class OptionTokenizationTest {
   public void hostControlEmitsOnce() {
     final HostControlHandler handler = new HostControlHandler();
     final List<String> cmd = finish(handler.getTimeMapper());
-    ((OptionMapper.FinishMapper) handler.getRateMapper()).finish(
-        new StringBuilder("-"), cmd);
+    ((OptionMapper.FinishMapper) handler.getRateMapper()).finish(cmd);
     assertEquals(Arrays.asList("-H0"), cmd);
   }
 
   private static List<String> emitDosIso(final String dos, final String iso) {
     final DosIso9660Handler handler = new DosIso9660Handler();
-    final StringBuilder flags = new StringBuilder("-");
     final List<String> cmd = new ArrayList<String>();
-    handler.getDosMapper().emit(flags, cmd, dos);
+    handler.getDosMapper().emit(cmd, dos);
     final OptionMapper isoMapper = handler.getIso9660Mapper();
-    isoMapper.emit(flags, cmd, iso);
-    ((OptionMapper.FinishMapper) isoMapper).finish(flags, cmd);
-    assertEquals("nothing may be packed", "-", flags.toString());
+    isoMapper.emit(cmd, iso);
+    ((OptionMapper.FinishMapper) isoMapper).finish(cmd);
     return cmd;
   }
 
@@ -232,23 +205,20 @@ public class OptionTokenizationTest {
   public void dosIso9660EmitsOnce() {
     final DosIso9660Handler handler = new DosIso9660Handler();
     final OptionMapper mapper = handler.getDosMapper();
-    final StringBuilder flags = new StringBuilder("-");
     final List<String> cmd = new ArrayList<String>();
-    mapper.emit(flags, cmd, "1");
-    ((OptionMapper.FinishMapper) mapper).finish(flags, cmd);
-    ((OptionMapper.FinishMapper) handler.getIso9660Mapper()).finish(flags, cmd);
+    mapper.emit(cmd, "1");
+    ((OptionMapper.FinishMapper) mapper).finish(cmd);
+    ((OptionMapper.FinishMapper) handler.getIso9660Mapper()).finish(cmd);
     assertEquals(Arrays.asList("-L0"), cmd);
   }
 
   private static List<String> emitBuild(final String type, final String custom) {
     final BuildHandler handler = new BuildHandler();
-    final StringBuilder flags = new StringBuilder("-");
     final List<String> cmd = new ArrayList<String>();
-    handler.getCustomMapper().emit(flags, cmd, custom);
+    handler.getCustomMapper().emit(cmd, custom);
     final OptionMapper typeMapper = handler.getTypeMapper();
-    typeMapper.emit(flags, cmd, type);
-    ((OptionMapper.FinishMapper) typeMapper).finish(flags, cmd);
-    assertEquals("nothing may be packed", "-", flags.toString());
+    typeMapper.emit(cmd, type);
+    ((OptionMapper.FinishMapper) typeMapper).finish(cmd);
     return cmd;
   }
 
@@ -267,11 +237,10 @@ public class OptionTokenizationTest {
   public void buildEmitsOnce() {
     final BuildHandler handler = new BuildHandler();
     final OptionMapper mapper = handler.getTypeMapper();
-    final StringBuilder flags = new StringBuilder("-");
     final List<String> cmd = new ArrayList<String>();
-    mapper.emit(flags, cmd, "6");
-    ((OptionMapper.FinishMapper) mapper).finish(flags, cmd);
-    ((OptionMapper.FinishMapper) handler.getCustomMapper()).finish(flags, cmd);
+    mapper.emit(cmd, "6");
+    ((OptionMapper.FinishMapper) mapper).finish(cmd);
+    ((OptionMapper.FinishMapper) handler.getCustomMapper()).finish(cmd);
     assertEquals(Arrays.asList("-N100"), cmd);
   }
 }

--- a/app/src/test/java/com/httrack/android/OptionsEmissionTest.java
+++ b/app/src/test/java/com/httrack/android/OptionsEmissionTest.java
@@ -4,10 +4,14 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import com.httrack.android.OptionsMapper.ArgumentOption;
+import com.httrack.android.OptionsMapper.LogHandler;
+import com.httrack.android.OptionsMapper.MultipleChoicesOption;
 import com.httrack.android.OptionsMapper.OptionMapper;
+import com.httrack.android.OptionsMapper.PrimaryScanHandler;
 import com.httrack.android.OptionsMapper.ProxyHandler;
 import com.httrack.android.OptionsMapper.SimpleOptionFlag;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import org.junit.Test;
 
@@ -17,13 +21,12 @@ public class OptionsEmissionTest {
   private static List<String> emitProxy(final String protocol,
       final String address, final String port) {
     final ProxyHandler handler = new ProxyHandler();
-    final StringBuilder flags = new StringBuilder();
     final List<String> cmd = new ArrayList<String>();
-    handler.getProtocolMapper().emit(flags, cmd, protocol);
-    handler.getAddressMapper().emit(flags, cmd, address);
+    handler.getProtocolMapper().emit(cmd, protocol);
+    handler.getAddressMapper().emit(cmd, address);
     final OptionMapper portMapper = handler.getPortMapper();
-    portMapper.emit(flags, cmd, port);
-    ((OptionMapper.FinishMapper) portMapper).finish(flags, cmd);
+    portMapper.emit(cmd, port);
+    ((OptionMapper.FinishMapper) portMapper).finish(cmd);
     return cmd;
   }
 
@@ -56,7 +59,7 @@ public class OptionsEmissionTest {
   @Test
   public void valueOptionEmitsFlagAndArgumentWhenSet() {
     final List<String> cmd = new ArrayList<String>();
-    new ArgumentOption("-%K").emit(new StringBuilder(), cmd, "cookies.txt");
+    new ArgumentOption("-%K").emit(cmd, "cookies.txt");
     assertEquals("-%K", cmd.get(0));
     assertEquals("cookies.txt", cmd.get(1));
   }
@@ -64,7 +67,7 @@ public class OptionsEmissionTest {
   @Test
   public void valueOptionStaysSilentWhenEmpty() {
     final List<String> cmd = new ArrayList<String>();
-    new ArgumentOption("-%K").emit(new StringBuilder(), cmd, "");
+    new ArgumentOption("-%K").emit(cmd, "");
     assertTrue(cmd.isEmpty());
   }
 
@@ -72,14 +75,14 @@ public class OptionsEmissionTest {
   @Test
   public void keepToggleEmitsFlagWhenChecked() {
     final List<String> cmd = new ArrayList<String>();
-    new SimpleOptionFlag("%j").emit(new StringBuilder("-"), cmd, "1");
+    new SimpleOptionFlag("%j").emit(cmd, "1");
     assertEquals("-%j", cmd.get(0));
   }
 
   @Test
   public void keepToggleEmitsNothingWhenUnchecked() {
     final List<String> cmd = new ArrayList<String>();
-    new SimpleOptionFlag("%j").emit(new StringBuilder("-"), cmd, "0");
+    new SimpleOptionFlag("%j").emit(cmd, "0");
     assertTrue(cmd.isEmpty());
   }
 
@@ -87,14 +90,14 @@ public class OptionsEmissionTest {
   @Test
   public void warcToggleEmitsFlagWhenChecked() {
     final List<String> cmd = new ArrayList<String>();
-    new SimpleOptionFlag("%r").emit(new StringBuilder("-"), cmd, "1");
+    new SimpleOptionFlag("%r").emit(cmd, "1");
     assertEquals("-%r", cmd.get(0));
   }
 
   @Test
   public void warcToggleEmitsNothingWhenUnchecked() {
     final List<String> cmd = new ArrayList<String>();
-    new SimpleOptionFlag("%r").emit(new StringBuilder("-"), cmd, "0");
+    new SimpleOptionFlag("%r").emit(cmd, "0");
     assertTrue(cmd.isEmpty());
   }
 
@@ -104,23 +107,19 @@ public class OptionsEmissionTest {
     final String[][] cases = { { "%m", "-%m" }, { "%Z", "-%Z" },
         { "%d", "-%d" } };
     for (final String[] c : cases) {
-      final StringBuilder flags = new StringBuilder("-");
       final List<String> cmd = new ArrayList<String>();
-      new SimpleOptionFlag(c[0]).emit(flags, cmd, "1");
+      new SimpleOptionFlag(c[0]).emit(cmd, "1");
       assertEquals(1, cmd.size());
       assertEquals(c[1], cmd.get(0));
-      assertEquals("-", flags.toString());
     }
   }
 
   @Test
   public void spiderToggleStaysSilentWhenUncheckedOrUnset() {
     for (final String value : new String[] { "0", "2", "", null }) {
-      final StringBuilder flags = new StringBuilder("-");
       final List<String> cmd = new ArrayList<String>();
-      new SimpleOptionFlag("%Z").emit(flags, cmd, value);
+      new SimpleOptionFlag("%Z").emit(cmd, value);
       assertTrue(cmd.isEmpty());
-      assertEquals("-", flags.toString());
     }
   }
 
@@ -131,13 +130,11 @@ public class OptionsEmissionTest {
   @Test
   public void companionEmitsItsOwnTokenPairWhenSet() {
     for (final String option : COMPANIONS) {
-      final StringBuilder flags = new StringBuilder("-");
       final List<String> cmd = new ArrayList<String>();
-      new ArgumentOption(option).emit(flags, cmd, "value");
+      new ArgumentOption(option).emit(cmd, "value");
       assertEquals(2, cmd.size());
       assertEquals(option, cmd.get(0));
       assertEquals("value", cmd.get(1));
-      assertEquals("-", flags.toString());
     }
   }
 
@@ -146,11 +143,9 @@ public class OptionsEmissionTest {
   public void companionStaysSilentWhenEmptyOrUnset() {
     for (final String option : COMPANIONS) {
       for (final String value : new String[] { "", null }) {
-        final StringBuilder flags = new StringBuilder("-");
         final List<String> cmd = new ArrayList<String>();
-        new ArgumentOption(option).emit(flags, cmd, value);
+        new ArgumentOption(option).emit(cmd, value);
         assertTrue(cmd.isEmpty());
-        assertEquals("-", flags.toString());
       }
     }
   }
@@ -161,9 +156,110 @@ public class OptionsEmissionTest {
     final OptionMapper mapper = new SimpleOptionFlag("%d");
     final List<String> first = new ArrayList<String>();
     final List<String> second = new ArrayList<String>();
-    mapper.emit(new StringBuilder("-"), first, "1");
-    mapper.emit(new StringBuilder("-"), second, "1");
+    mapper.emit(first, "1");
+    mapper.emit(second, "1");
     assertEquals(first, second);
     assertEquals("-%d", second.get(0));
+  }
+
+  private static List<String> emitLog(final String enabled, final String type) {
+    final LogHandler handler = new LogHandler();
+    final List<String> cmd = new ArrayList<String>();
+    handler.getEnabledMapper().emit(cmd, enabled);
+    final OptionMapper typeMapper = handler.getTypeMapper();
+    typeMapper.emit(cmd, type);
+    ((OptionMapper.FinishMapper) typeMapper).finish(cmd);
+    return cmd;
+  }
+
+  /* Verbosity radio: quiet, -z, -Z; unticked logging is -Q whatever the radio. */
+  @Test
+  public void logVerbosityIsItsOwnToken() {
+    assertTrue(emitLog("1", "0").isEmpty());
+    assertEquals(Arrays.asList("-z"), emitLog("1", "1"));
+    assertEquals(Arrays.asList("-Z"), emitLog("1", "2"));
+    assertEquals(Arrays.asList("-Q"), emitLog("0", "0"));
+    assertEquals(Arrays.asList("-Q"), emitLog("0", "2"));
+  }
+
+  @Test
+  public void logEmitsOnce() {
+    final LogHandler handler = new LogHandler();
+    final OptionMapper typeMapper = handler.getTypeMapper();
+    final List<String> cmd = new ArrayList<String>();
+    handler.getEnabledMapper().emit(cmd, "1");
+    typeMapper.emit(cmd, "2");
+    ((OptionMapper.FinishMapper) typeMapper).finish(cmd);
+    ((OptionMapper.FinishMapper) handler.getEnabledMapper()).finish(cmd);
+    assertEquals(Arrays.asList("-Z"), cmd);
+  }
+
+  private static List<String> emitPrimaryScan(final String type,
+      final String htmlFirst) {
+    final PrimaryScanHandler handler = new PrimaryScanHandler();
+    final List<String> cmd = new ArrayList<String>();
+    handler.getHtmlFirstMapper().emit(cmd, htmlFirst);
+    final OptionMapper typeMapper = handler.getTypeMapper();
+    typeMapper.emit(cmd, type);
+    ((OptionMapper.FinishMapper) typeMapper).finish(cmd);
+    return cmd;
+  }
+
+  /* Scan radio 0..2 map straight to -pN; 3 and 4 fold "html first" into -p7. */
+  @Test
+  public void primaryScanModeIsItsOwnToken() {
+    assertEquals(Arrays.asList("-p0"), emitPrimaryScan("0", "0"));
+    assertEquals(Arrays.asList("-p1"), emitPrimaryScan("1", "0"));
+    assertEquals(Arrays.asList("-p2"), emitPrimaryScan("2", "1"));
+    assertEquals(Arrays.asList("-p3"), emitPrimaryScan("3", "0"));
+    assertEquals(Arrays.asList("-p7"), emitPrimaryScan("3", "1"));
+    assertEquals(Arrays.asList("-p7"), emitPrimaryScan("4", "0"));
+    assertTrue(emitPrimaryScan("5", "0").isEmpty());
+  }
+
+  @Test
+  public void primaryScanEmitsOnce() {
+    final PrimaryScanHandler handler = new PrimaryScanHandler();
+    final OptionMapper typeMapper = handler.getTypeMapper();
+    final List<String> cmd = new ArrayList<String>();
+    typeMapper.emit(cmd, "1");
+    ((OptionMapper.FinishMapper) typeMapper).finish(cmd);
+    ((OptionMapper.FinishMapper) handler.getHtmlFirstMapper()).finish(cmd);
+    assertEquals(Arrays.asList("-p1"), cmd);
+  }
+
+  private static List<String> emitChoice(final MultipleChoicesOption mapper,
+      final String value) {
+    final List<String> cmd = new ArrayList<String>();
+    mapper.emit(cmd, value);
+    return cmd;
+  }
+
+  /* Pins the shipped radio tables, not a copy of them. */
+  @Test
+  public void radioChoiceIsItsOwnToken() {
+    assertEquals(Arrays.asList("-iC1"),
+        emitChoice(MultipleChoicesOption.ACTION, "0"));
+    assertEquals(Arrays.asList("-iC2"),
+        emitChoice(MultipleChoicesOption.ACTION, "1"));
+    final String[] travel = { "-S", "-D", "-U", "-B" };
+    final String[] globalTravel = { "-a", "-d", "-l", "-e" };
+    final String[] rewriteLinks = { "-K0", "-K", "-K3", "-K4" };
+    for (int i = 0; i < 4; i++) {
+      final String index = String.valueOf(i);
+      assertEquals(Arrays.asList(travel[i]),
+          emitChoice(MultipleChoicesOption.TRAVEL, index));
+      assertEquals(Arrays.asList(globalTravel[i]),
+          emitChoice(MultipleChoicesOption.GLOBAL_TRAVEL, index));
+      assertEquals(Arrays.asList(rewriteLinks[i]),
+          emitChoice(MultipleChoicesOption.REWRITE_LINKS, index));
+    }
+  }
+
+  @Test
+  public void radioChoiceStaysSilentOutOfRange() {
+    for (final String value : new String[] { "4", "-1", "", null, "x" }) {
+      assertTrue(emitChoice(MultipleChoicesOption.TRAVEL, value).isEmpty());
+    }
   }
 }

--- a/app/src/test/java/com/httrack/android/OptionsEmissionTest.java
+++ b/app/src/test/java/com/httrack/android/OptionsEmissionTest.java
@@ -10,9 +10,14 @@ import com.httrack.android.OptionsMapper.OptionMapper;
 import com.httrack.android.OptionsMapper.PrimaryScanHandler;
 import com.httrack.android.OptionsMapper.ProxyHandler;
 import com.httrack.android.OptionsMapper.SimpleOptionFlag;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.junit.Test;
 
 /** Guards the argv emitted for the engine options exposed by issue #6. */
@@ -162,12 +167,22 @@ public class OptionsEmissionTest {
     assertEquals("-%d", second.get(0));
   }
 
-  private static List<String> emitLog(final String enabled, final String type) {
+  /* Neither field may decide alone, so emit() has to stay silent: a mapper the
+     user left unset is skipped entirely, and would finish on partial state. */
+  private static List<String> emitLog(final String enabled, final String type,
+      final boolean typeFirst) {
     final LogHandler handler = new LogHandler();
-    final List<String> cmd = new ArrayList<String>();
-    handler.getEnabledMapper().emit(cmd, enabled);
+    final OptionMapper enabledMapper = handler.getEnabledMapper();
     final OptionMapper typeMapper = handler.getTypeMapper();
-    typeMapper.emit(cmd, type);
+    final List<String> cmd = new ArrayList<String>();
+    if (typeFirst) {
+      typeMapper.emit(cmd, type);
+      enabledMapper.emit(cmd, enabled);
+    } else {
+      enabledMapper.emit(cmd, enabled);
+      typeMapper.emit(cmd, type);
+    }
+    assertTrue("emit() must not emit; finish() does", cmd.isEmpty());
     ((OptionMapper.FinishMapper) typeMapper).finish(cmd);
     return cmd;
   }
@@ -175,11 +190,13 @@ public class OptionsEmissionTest {
   /* Verbosity radio: quiet, -z, -Z; unticked logging is -Q whatever the radio. */
   @Test
   public void logVerbosityIsItsOwnToken() {
-    assertTrue(emitLog("1", "0").isEmpty());
-    assertEquals(Arrays.asList("-z"), emitLog("1", "1"));
-    assertEquals(Arrays.asList("-Z"), emitLog("1", "2"));
-    assertEquals(Arrays.asList("-Q"), emitLog("0", "0"));
-    assertEquals(Arrays.asList("-Q"), emitLog("0", "2"));
+    for (final boolean typeFirst : new boolean[] { false, true }) {
+      assertTrue(emitLog("1", "0", typeFirst).isEmpty());
+      assertEquals(Arrays.asList("-z"), emitLog("1", "1", typeFirst));
+      assertEquals(Arrays.asList("-Z"), emitLog("1", "2", typeFirst));
+      assertEquals(Arrays.asList("-Q"), emitLog("0", "0", typeFirst));
+      assertEquals(Arrays.asList("-Q"), emitLog("0", "2", typeFirst));
+    }
   }
 
   @Test
@@ -195,12 +212,19 @@ public class OptionsEmissionTest {
   }
 
   private static List<String> emitPrimaryScan(final String type,
-      final String htmlFirst) {
+      final String htmlFirst, final boolean typeFirst) {
     final PrimaryScanHandler handler = new PrimaryScanHandler();
-    final List<String> cmd = new ArrayList<String>();
-    handler.getHtmlFirstMapper().emit(cmd, htmlFirst);
+    final OptionMapper htmlFirstMapper = handler.getHtmlFirstMapper();
     final OptionMapper typeMapper = handler.getTypeMapper();
-    typeMapper.emit(cmd, type);
+    final List<String> cmd = new ArrayList<String>();
+    if (typeFirst) {
+      typeMapper.emit(cmd, type);
+      htmlFirstMapper.emit(cmd, htmlFirst);
+    } else {
+      htmlFirstMapper.emit(cmd, htmlFirst);
+      typeMapper.emit(cmd, type);
+    }
+    assertTrue("emit() must not emit; finish() does", cmd.isEmpty());
     ((OptionMapper.FinishMapper) typeMapper).finish(cmd);
     return cmd;
   }
@@ -208,13 +232,15 @@ public class OptionsEmissionTest {
   /* Scan radio 0..2 map straight to -pN; 3 and 4 fold "html first" into -p7. */
   @Test
   public void primaryScanModeIsItsOwnToken() {
-    assertEquals(Arrays.asList("-p0"), emitPrimaryScan("0", "0"));
-    assertEquals(Arrays.asList("-p1"), emitPrimaryScan("1", "0"));
-    assertEquals(Arrays.asList("-p2"), emitPrimaryScan("2", "1"));
-    assertEquals(Arrays.asList("-p3"), emitPrimaryScan("3", "0"));
-    assertEquals(Arrays.asList("-p7"), emitPrimaryScan("3", "1"));
-    assertEquals(Arrays.asList("-p7"), emitPrimaryScan("4", "0"));
-    assertTrue(emitPrimaryScan("5", "0").isEmpty());
+    for (final boolean typeFirst : new boolean[] { false, true }) {
+      assertEquals(Arrays.asList("-p0"), emitPrimaryScan("0", "0", typeFirst));
+      assertEquals(Arrays.asList("-p1"), emitPrimaryScan("1", "0", typeFirst));
+      assertEquals(Arrays.asList("-p2"), emitPrimaryScan("2", "1", typeFirst));
+      assertEquals(Arrays.asList("-p3"), emitPrimaryScan("3", "0", typeFirst));
+      assertEquals(Arrays.asList("-p7"), emitPrimaryScan("3", "1", typeFirst));
+      assertEquals(Arrays.asList("-p7"), emitPrimaryScan("4", "0", typeFirst));
+      assertTrue(emitPrimaryScan("5", "0", typeFirst).isEmpty());
+    }
   }
 
   @Test
@@ -261,5 +287,35 @@ public class OptionsEmissionTest {
     for (final String value : new String[] { "4", "-1", "", null, "x" }) {
       assertTrue(emitChoice(MultipleChoicesOption.TRAVEL, value).isEmpty());
     }
+  }
+
+  /* fieldsSerializer fixes the emission order but pulls in R.id, which the stub
+     android.jar cannot load, so read the declared order out of the source. */
+  private static List<String> serializerKeys() throws IOException {
+    final String src = new String(Files.readAllBytes(Paths
+        .get("src/main/java/com/httrack/android/OptionsMapper.java")), "UTF-8");
+    final int from = src.indexOf("fieldsSerializer[] = new Pair[] {");
+    final int to = src.indexOf("\n  };", from);
+    assertTrue("fieldsSerializer not found", from != -1 && to > from);
+    final Matcher m = Pattern.compile(", \"(\\w+)\"\\)").matcher(
+        src.substring(from, to));
+    final List<String> keys = new ArrayList<String>();
+    while (m.find()) {
+      keys.add(m.group(1));
+    }
+    assertTrue("no keys parsed", keys.size() > 80);
+    return keys;
+  }
+
+  /* The engine counts URLs positionally and -iC* carries its 'i': behind the
+     URL it clears the count instead of leaving it at one, which switches the
+     crawl onto the doit.log recovery path. */
+  @Test
+  public void currentActionIsEmittedBeforeTheUrl() throws IOException {
+    final List<String> keys = serializerKeys();
+    assertTrue("CurrentAction missing", keys.contains("CurrentAction"));
+    assertTrue("CurrentUrl missing", keys.contains("CurrentUrl"));
+    assertTrue("-iC* must precede the URL",
+        keys.indexOf("CurrentAction") < keys.indexOf("CurrentUrl"));
   }
 }


### PR DESCRIPTION
Finishes the unpacking #78 started. `LogHandler`, `PrimaryScanHandler` and the radio-button `MultipleChoicesOption` were still appending into the shared `flags` StringBuilder, so the engine kept receiving one packed leading token. They now emit `-z`/`-Z`/`-Q`, `-p<digit>` and one token per radio choice, and with the last three writers gone the `flags` parameter comes out of `OptionMapper.emit` and `finish` altogether. The packing hazard is now unrepresentable rather than merely absent by luck of which letters those choice strings happen to hold.

Unpacking moves those flags from the head of argv down to wherever their field sits, which is safe because the engine parses each token on its own. One exception, caught in review: `-iC1`/`-iC2` carry the engine's `i`, and the positional pre-pass in `htscoremain.c` uses it to reset the URL count, so behind the URL they leave `argv_url` at 0 instead of 1 and send the crawl down the `hts-cache/doit.log` recovery path. CurrentAction is emitted before CurrentUrl now. That order is inert for profile I/O, which reads every field by key.

Behaviour is otherwise unchanged. I diffed argv over 4540 profiles on both token order and the modelled pre-pass result: the pre-fix ordering trips it on 204 of them, this version on none. `-a`/`-d`/`-l`/`-e` do now follow `-t` rather than preceding it, which the engine reads the same either way since it re-adds `HTS_TRAVEL_TEST_ALL` when it assigns travel. The four radio tables became public constants so the added tests pin the shipped strings rather than a copy.

Closes #101
