### PR TITLE
A decimal left in a saved profile turns a numeric option into an exclusion filter

### DIFF
--- a/app/src/main/java/com/httrack/android/OptionValues.java
+++ b/app/src/main/java/com/httrack/android/OptionValues.java
@@ -33,6 +33,9 @@ public final class OptionValues {
 
   private static final Pattern patternDigits = Pattern.compile("^[0-9]+$");
 
+  private static final Pattern patternDecimal = Pattern
+      .compile("^[0-9]+(\\.[0-9]+)?$");
+
   /**
    * True if the value is a non-empty run of ASCII digits.
    *
@@ -42,6 +45,18 @@ public final class OptionValues {
    */
   public static boolean isDigits(final String value) {
     return value != null && patternDigits.matcher(value).matches();
+  }
+
+  /**
+   * True if the value is a non-negative decimal number, with an optional
+   * fractional part.
+   *
+   * @param value
+   *          The value, possibly null
+   * @return true if the value is a non-negative decimal
+   */
+  public static boolean isDecimal(final String value) {
+    return value != null && patternDecimal.matcher(value).matches();
   }
 
   /**

--- a/app/src/main/java/com/httrack/android/OptionValues.java
+++ b/app/src/main/java/com/httrack/android/OptionValues.java
@@ -48,8 +48,7 @@ public final class OptionValues {
   }
 
   /**
-   * True if the value is a non-negative decimal number, with an optional
-   * fractional part.
+   * True if the value is a non-negative integer or decimal.
    *
    * @param value
    *          The value, possibly null

--- a/app/src/main/java/com/httrack/android/OptionsMapper.java
+++ b/app/src/main/java/com/httrack/android/OptionsMapper.java
@@ -1196,7 +1196,8 @@ public class OptionsMapper {
   }
 
   /**
-   * Simple option (typically one character and an option)
+   * Simple option (typically one character and an option). The fields mapped
+   * this way are all numeric, so a value that is not is dropped.
    */
   public static class SimpleOption implements OptionMapper {
     protected final String option;
@@ -1207,7 +1208,11 @@ public class OptionsMapper {
 
     @Override
     public void emit(final List<String> commandline, final String value) {
-      if (value != null && value.length() != 0) {
+      /* cmdl_opt reads a '.' in a '%'-less token as a URL, so -r1.5 would join
+       * the crawl as an exclusion filter; the '%' forms are parsed with %f. */
+      final boolean accepted = option.indexOf('%') != -1 ? OptionValues
+          .isDecimal(value) : OptionValues.isDigits(value);
+      if (accepted) {
         commandline.add("-" + option + value);
       }
     }

--- a/app/src/main/java/com/httrack/android/OptionsMapper.java
+++ b/app/src/main/java/com/httrack/android/OptionsMapper.java
@@ -274,7 +274,9 @@ public class OptionsMapper {
       new Pair<String, OptionMapper>("MaxAll", new SimpleOption("M")),
       new Pair<String, OptionMapper>("MaxTime", new SimpleOption("E")),
       new Pair<String, OptionMapper>("MaxRate", new SimpleOption("A")),
-      new Pair<String, OptionMapper>("MaxConn", new SimpleOption("%c")),
+      /* the only option the engine scans with %f, so the only one taking a
+         fraction: -%e carries a '%' too but is scanned with %d */
+      new Pair<String, OptionMapper>("MaxConn", new SimpleOption("%c", true)),
       new Pair<String, OptionMapper>("MaxLinks", new SimpleOption("#L")),
       new Pair<String, OptionMapper>("Sockets", new SimpleOption("c")),
       /* keep-alive is -%k; the bare -k is StoreAllInCache. */
@@ -1197,22 +1199,34 @@ public class OptionsMapper {
 
   /**
    * Simple option (typically one character and an option). The fields mapped
-   * this way are all numeric, so a value that is not is dropped.
+   * this way are all numeric; a value that is not is dropped.
    */
   public static class SimpleOption implements OptionMapper {
     protected final String option;
+    protected final boolean fraction;
+
+    /**
+     * @param option
+     *          The engine option
+     * @param fraction
+     *          true if the engine scans this option's value with %f
+     */
+    public SimpleOption(final String option, final boolean fraction) {
+      this.option = option;
+      this.fraction = fraction;
+    }
 
     public SimpleOption(final String option) {
-      this.option = option;
+      this(option, false);
     }
 
     @Override
     public void emit(final List<String> commandline, final String value) {
-      /* cmdl_opt reads a '.' in a '%'-less token as a URL, so -r1.5 would join
-       * the crawl as an exclusion filter; the '%' forms are parsed with %f. */
-      final boolean accepted = option.indexOf('%') != -1 ? OptionValues
-          .isDecimal(value) : OptionValues.isDigits(value);
-      if (accepted) {
+      /* A '.' anywhere else is fatal: an integer option leaves it unconsumed
+       * and the engine panics, and cmdl_opt reads a '%'-less token holding one
+       * as a URL, which turns -r1.5 into an exclusion filter. */
+      if (fraction ? OptionValues.isDecimal(value) : OptionValues
+          .isDigits(value)) {
         commandline.add("-" + option + value);
       }
     }

--- a/app/src/test/java/com/httrack/android/NumericFieldInputTypeTest.java
+++ b/app/src/test/java/com/httrack/android/NumericFieldInputTypeTest.java
@@ -15,13 +15,16 @@ import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 
 /**
- * The engine's cmdl_opt() reads a '.' inside a '%'-less token such as "-r1.5" as
- * a URL and drops the option, so a numeric option field may offer a decimal
- * point only when the option it maps to carries a '%'.
+ * A '.' reaching the engine is either read as a URL by cmdl_opt or left over
+ * for the option walker to abort on, so a numeric option field may offer a
+ * decimal point only for the one option the engine scans with %f.
  */
 public class NumericFieldInputTypeTest {
   private static final String ANDROID_NS =
       "http://schemas.android.com/apk/res/android";
+
+  /** The only option the engine scans with %f (htscoremain.c, case 'c'). */
+  private static final String FLOAT_OPTION = "%c";
 
   /** Numeric option fields, each with the engine option OptionsMapper emits. */
   private static final String[][] NUMERIC_FIELDS = {
@@ -106,7 +109,7 @@ public class NumericFieldInputTypeTest {
           assertFalse(where + " accepts a sign", "numberSigned".equals(flag));
           assertTrue(
               where + " accepts a decimal point but -" + option + " does not",
-              !"numberDecimal".equals(flag) || option.indexOf('%') != -1);
+              !"numberDecimal".equals(flag) || FLOAT_OPTION.equals(option));
         }
       }
     }

--- a/app/src/test/java/com/httrack/android/NumericOptionValueTest.java
+++ b/app/src/test/java/com/httrack/android/NumericOptionValueTest.java
@@ -6,9 +6,14 @@ import static org.junit.Assert.assertTrue;
 
 import com.httrack.android.OptionsMapper.OptionMapper;
 import com.httrack.android.OptionsMapper.SimpleOption;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.junit.Test;
 
 /**
@@ -16,39 +21,76 @@ import org.junit.Test;
  * so the mapper is where the engine-hostile ones get dropped (issue #100).
  */
 public class NumericOptionValueTest {
+  /** The only option the engine scans with %f (htscoremain.c, case 'c'). */
+  private static final String FLOAT_OPTION = "%c";
+
   private static List<String> emit(final OptionMapper mapper, final String value) {
     final List<String> cmd = new ArrayList<String>();
     mapper.emit(cmd, value);
     return cmd;
   }
 
+  /* The mapper table pulls in R.id, which the stub android.jar cannot load, so
+     the declarations are read out of the source. */
+  private static List<String[]> declaredOptions() throws IOException {
+    final String src = new String(Files.readAllBytes(Paths
+        .get("src/main/java/com/httrack/android/OptionsMapper.java")), "UTF-8");
+    final Matcher m = Pattern.compile(
+        "new SimpleOption\\(\\s*\"([^\"]+)\"\\s*(?:,\\s*(true|false)\\s*)?\\)")
+        .matcher(src);
+    final List<String[]> declared = new ArrayList<String[]>();
+    while (m.find()) {
+      declared.add(new String[] { m.group(1), m.group(2) });
+    }
+    assertTrue("no SimpleOption declarations parsed", declared.size() > 10);
+    return declared;
+  }
+
+  /* Guards the whole table, not just the options issue #100 happened to name. */
+  @Test
+  public void onlyTheFloatOptionIsDeclaredToTakeAFraction() throws IOException {
+    for (final String[] declared : declaredOptions()) {
+      final String option = declared[0];
+      final boolean fraction = "true".equals(declared[1]);
+      assertEquals("-" + option + " fraction flag", FLOAT_OPTION.equals(option),
+          fraction);
+      assertEquals("-" + option + " with a fraction", fraction,
+          !emit(new SimpleOption(option, fraction), "1.5").isEmpty());
+    }
+  }
+
   @Test
   public void aDecimalIsDroppedFromAnOptionTheEngineParsesAsAnInteger() {
-    for (final String option : new String[] { "r", "M", "E", "A", "#L", "c",
-        "T", "R", "J" }) {
+    for (final String option : new String[] { "r", "%e", "M", "E", "A", "#L",
+        "c", "T", "R", "J", "u", "s" }) {
       assertTrue("-" + option + " kept a decimal",
           emit(new SimpleOption(option), "1.5").isEmpty());
     }
   }
 
+  /* -%e is the trap: it carries a '%' but the engine scans it with %d, and the
+     leftover '.' then aborts the whole run with "invalid option .". */
   @Test
-  public void aDecimalSurvivesOnTheOptionsParsedWithAFloat() {
-    assertEquals(Arrays.asList("-%c1.5"), emit(new SimpleOption("%c"), "1.5"));
-    assertEquals(Arrays.asList("-%e2.5"), emit(new SimpleOption("%e"), "2.5"));
+  public void aDecimalSurvivesOnTheFloatOptionOnly() {
+    assertEquals(Arrays.asList("-%c1.5"),
+        emit(new SimpleOption("%c", true), "1.5"));
+    assertTrue(emit(new SimpleOption("%e"), "2.5").isEmpty());
   }
 
   @Test
   public void anIntegerStillEmits() {
     assertEquals(Arrays.asList("-r5"), emit(new SimpleOption("r"), "5"));
-    assertEquals(Arrays.asList("-%c8"), emit(new SimpleOption("%c"), "8"));
+    assertEquals(Arrays.asList("-%e2"), emit(new SimpleOption("%e"), "2"));
     assertEquals(Arrays.asList("-#L500"), emit(new SimpleOption("#L"), "500"));
+    assertEquals(Arrays.asList("-%c8"),
+        emit(new SimpleOption("%c", true), "8"));
   }
 
-  /** A leading '-' makes the engine reject the whole commandline. */
+  /** The engine takes a signed value and quietly means something else by it. */
   @Test
   public void aSignedValueIsDropped() {
     assertTrue(emit(new SimpleOption("r"), "-1").isEmpty());
-    assertTrue(emit(new SimpleOption("%c"), "-1.5").isEmpty());
+    assertTrue(emit(new SimpleOption("%c", true), "-1.5").isEmpty());
   }
 
   @Test
@@ -57,8 +99,8 @@ public class NumericOptionValueTest {
         "5 ", "1e3", "0x10", "", null }) {
       assertTrue("-r kept " + value, emit(new SimpleOption("r"), value)
           .isEmpty());
-      assertTrue("-%c kept " + value, emit(new SimpleOption("%c"), value)
-          .isEmpty());
+      assertTrue("-%c kept " + value,
+          emit(new SimpleOption("%c", true), value).isEmpty());
     }
   }
 

--- a/app/src/test/java/com/httrack/android/NumericOptionValueTest.java
+++ b/app/src/test/java/com/httrack/android/NumericOptionValueTest.java
@@ -1,0 +1,72 @@
+package com.httrack.android;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.httrack.android.OptionsMapper.OptionMapper;
+import com.httrack.android.OptionsMapper.SimpleOption;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+
+/**
+ * A value loaded from a saved profile never goes through the keyboard filters,
+ * so the mapper is where the engine-hostile ones get dropped (issue #100).
+ */
+public class NumericOptionValueTest {
+  private static List<String> emit(final OptionMapper mapper, final String value) {
+    final List<String> cmd = new ArrayList<String>();
+    mapper.emit(cmd, value);
+    return cmd;
+  }
+
+  @Test
+  public void aDecimalIsDroppedFromAnOptionTheEngineParsesAsAnInteger() {
+    for (final String option : new String[] { "r", "M", "E", "A", "#L", "c",
+        "T", "R", "J" }) {
+      assertTrue("-" + option + " kept a decimal",
+          emit(new SimpleOption(option), "1.5").isEmpty());
+    }
+  }
+
+  @Test
+  public void aDecimalSurvivesOnTheOptionsParsedWithAFloat() {
+    assertEquals(Arrays.asList("-%c1.5"), emit(new SimpleOption("%c"), "1.5"));
+    assertEquals(Arrays.asList("-%e2.5"), emit(new SimpleOption("%e"), "2.5"));
+  }
+
+  @Test
+  public void anIntegerStillEmits() {
+    assertEquals(Arrays.asList("-r5"), emit(new SimpleOption("r"), "5"));
+    assertEquals(Arrays.asList("-%c8"), emit(new SimpleOption("%c"), "8"));
+    assertEquals(Arrays.asList("-#L500"), emit(new SimpleOption("#L"), "500"));
+  }
+
+  /** A leading '-' makes the engine reject the whole commandline. */
+  @Test
+  public void aSignedValueIsDropped() {
+    assertTrue(emit(new SimpleOption("r"), "-1").isEmpty());
+    assertTrue(emit(new SimpleOption("%c"), "-1.5").isEmpty());
+  }
+
+  @Test
+  public void aMalformedValueIsDropped() {
+    for (final String value : new String[] { "5x", "1.", ".5", "1.2.3", " 5",
+        "5 ", "1e3", "0x10", "", null }) {
+      assertTrue("-r kept " + value, emit(new SimpleOption("r"), value)
+          .isEmpty());
+      assertTrue("-%c kept " + value, emit(new SimpleOption("%c"), value)
+          .isEmpty());
+    }
+  }
+
+  @Test
+  public void isDecimalTakesAFractionAndIsDigitsDoesNot() {
+    assertTrue(OptionValues.isDecimal("1.5"));
+    assertTrue(OptionValues.isDecimal("15"));
+    assertFalse(OptionValues.isDigits("1.5"));
+    assertFalse(OptionValues.isDecimal(null));
+  }
+}


### PR DESCRIPTION
`SimpleOption.emit` passed its value through untouched, so a `1.5` sitting in a saved profile went out as `-r1.5`. The engine's `cmdl_opt` reads a `.` in a `%`-less token as a URL, so the depth was never set and a bogus exclusion filter joined the crawl instead. #103 only fixed which keyboard the IME draws: `setText()` runs before `setFilters()`, and starting an existing project never inflates the field at all, so the mapper is the only place every path meets.

Emission now requires digits, and allows a fraction only on `-%c`, the one option the engine scans with `%f`. `-%e` is the trap: it carries a `%` too but is scanned with `%d`, and the leftover `.` aborts the whole run with `invalid option .`. The test reads the declarations out of the mapper table, so a new option cannot pick the wrong side unnoticed.

Closes #100
