### PR TITLE
Play publish uploads the AAB, then fails on release notes it never checked out

### DIFF
--- a/.github/workflows/play-publish.yml
+++ b/.github/workflows/play-publish.yml
@@ -84,6 +84,13 @@ jobs:
     needs: build
     runs-on: ubuntu-24.04
     steps:
+      # This job holds the Play credential, so it takes the narrowest checkout that
+      # still feeds whatsNewDirectory below. Without it the action uploads the AAB,
+      # then dies scanning for notes that were never in this job's workspace.
+      - uses: actions/checkout@v6
+        with:
+          sparse-checkout: distribution/whatsnew
+          sparse-checkout-cone-mode: false
       - uses: actions/download-artifact@v4
         with:
           name: release-aab


### PR DESCRIPTION
The `publish` job downloads only the AAB artifact, so `whatsNewDirectory` pointed at a `distribution/whatsnew` that was never in its workspace. The action uploaded the bundle and then aborted on `scandir`, which left the Play edit uncommitted and `v3.50-beta-2` unpublished. Sparse-checkout gives the job the notes and nothing else, since it also holds the Play credential.

Broken since #92 added the input for the promote script without exercising the tag path; `v3.50-beta-2` is the first tag publish to reach it.

Closes #110