### PR TITLE
Help is not contextual: every screen opens the doc index

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -117,6 +117,9 @@ dependencies {
     implementation 'androidx.fragment:fragment:1.8.2'
     implementation 'androidx.documentfile:documentfile:1.0.1'
 
+    // Custom Tabs: help pages open over the app, one back tap from the screen that asked for them.
+    implementation 'androidx.browser:browser:1.8.0'
+
     // Loopback HTTP server so a real browser reads scoped-storage mirrors over http://.
     implementation 'org.nanohttpd:nanohttpd:2.3.1'
 

--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -2755,52 +2755,9 @@ public class HTTrackActivity extends FragmentActivity {
     }
   }
 
-  /**
-   * Server for {@code root}, started on first use. Returns null on failure; the caller decides what
-   * to tell the user.
-   */
-  private MirrorServer ensureMirrorServer(final File root) {
-    try {
-      return MirrorServer.forRoot(root);
-    } catch (final IOException e) {
-      Log.w(getClass().getSimpleName(), "mirror server failed to start", e);
-      return null;
-    }
-  }
-
-  /** Browse a crawled mirror file, served from the Websites root over loopback HTTP. */
+  /** Browse a crawled mirror in the browser proper: a whole site wants tabs and bookmarks. */
   private void browse(final File index) {
-    browse(getProjectRootFile(), index);
-  }
-
-  /**
-   * Browse {@code index} over the loopback mirror server rooted at {@code root}. The root is
-   * explicit because bundled docs/license live under the resources cache, not the Websites tree;
-   * server root and relative-path base must be the same dir or the URL 404s.
-   */
-  private void browse(final File root, final File index) {
-    if (index == null || !index.exists()) {
-      return;
-    }
-    try {
-      final MirrorServer server = ensureMirrorServer(root);
-      if (server == null) {
-        showNotification("Could not start the local mirror server");
-        return;
-      }
-      // Canonicalised + confined to root, so symlinks/".." and an out-of-root file cannot leak.
-      final String relative = MirrorServer.relativeUrlPath(root, index);
-      if (relative == null) {
-        showNotification("Cannot browse a file outside the served folder");
-        return;
-      }
-      final String url = server.getBaseUrl() + "/" + relative;
-      final Intent intent = new Intent(Intent.ACTION_VIEW);
-      intent.setData(Uri.parse(url));
-      startActivity(intent);
-    } catch (final Exception e) {
-      showNotification(e.getLocalizedMessage());
-    }
+    Loopback.open(this, getProjectRootFile(), index, null, false);
   }
 
   /**
@@ -2896,22 +2853,6 @@ public class HTTrackActivity extends FragmentActivity {
     // TODO: handle orientation change ?
   }
 
-  /** Doc page for the pane currently shown, so Help lands where the user is. */
-  private String getHelpPage() {
-    switch (pane_id) {
-    case LAYOUT_PROJECT_NAME:
-      return Help.PAGE_PROJECT_NAME;
-    case LAYOUT_PROJECT_SETUP:
-      return Help.PAGE_PROJECT_SETUP;
-    case LAYOUT_MIRROR_PROGRESS:
-      return Help.PAGE_MIRROR_PROGRESS;
-    case LAYOUT_FINISHED:
-      return Help.PAGE_FINISHED;
-    default:
-      return Help.PAGE_START;
-    }
-  }
-
   @Override
   public boolean onOptionsItemSelected(final MenuItem item) {
     // Handle item selection
@@ -2924,8 +2865,8 @@ public class HTTrackActivity extends FragmentActivity {
           .setMessage(about0 + "\n" + about + "\n\n" + aboutLegal).show();
       break;
     case R.id.action_license:
-      browse(getResourceFile(), new File(new File(getResourceFile(), "license"),
-          "gpl-3.0-standalone.html"));
+      Loopback.open(this, getResourceFile(), new File(new File(getResourceFile(), "license"),
+          "gpl-3.0-standalone.html"), null, true);
       break;
     case R.id.action_forum:
       browse(Uri.parse("http://forum.httrack.com/"));
@@ -2934,7 +2875,7 @@ public class HTTrackActivity extends FragmentActivity {
       browse(Uri.parse("http://www.httrack.com/"));
       break;
     case R.id.action_help:
-      Help.show(this, getResourceFile(), getHelpPage());
+      Help.show(this, getResourceFile(), Help.pageForPane(pane_id));
       break;
     case R.id.action_import_mirrors:
       startLegacyMirrorImport();

--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -2481,12 +2481,6 @@ public class HTTrackActivity extends FragmentActivity {
   private static final AtomicBoolean importInProgress = new AtomicBoolean();
   private volatile boolean browseAllInProgress;
 
-  // Serves the mirror over http://127.0.0.1 so a browser can read it despite scoped storage.
-  // Plain thread (NanoHTTPD owns it); reliability while browsing backgrounded relies on us staying
-  // the MRU cached process. A foreground service (needs an Android-14 FGS type) is a future step.
-  private MirrorServer mirrorServer;
-  private File mirrorServerRoot;
-
   /**
    * Copy the picked tree into our Websites directory, entirely off the UI thread: even walking
    * the tree to find "Websites" is one IPC per entry, too much for the main thread. The source
@@ -2762,20 +2756,12 @@ public class HTTrackActivity extends FragmentActivity {
   }
 
   /**
-   * Lazily start (or restart) the mirror server rooted at {@code root}, reusing it while the root is
-   * unchanged. Returns null on failure; the caller decides what to tell the user.
+   * Server for {@code root}, started on first use. Returns null on failure; the caller decides what
+   * to tell the user.
    */
   private MirrorServer ensureMirrorServer(final File root) {
     try {
-      if (mirrorServer != null && !root.equals(mirrorServerRoot)) {
-        mirrorServer.stop();
-        mirrorServer = null;
-      }
-      if (mirrorServer == null) {
-        mirrorServer = MirrorServer.start(root);
-        mirrorServerRoot = root;
-      }
-      return mirrorServer;
+      return MirrorServer.forRoot(root);
     } catch (final IOException e) {
       Log.w(getClass().getSimpleName(), "mirror server failed to start", e);
       return null;
@@ -2910,6 +2896,22 @@ public class HTTrackActivity extends FragmentActivity {
     // TODO: handle orientation change ?
   }
 
+  /** Doc page for the pane currently shown, so Help lands where the user is. */
+  private String getHelpPage() {
+    switch (pane_id) {
+    case LAYOUT_PROJECT_NAME:
+      return Help.PAGE_PROJECT_NAME;
+    case LAYOUT_PROJECT_SETUP:
+      return Help.PAGE_PROJECT_SETUP;
+    case LAYOUT_MIRROR_PROGRESS:
+      return Help.PAGE_MIRROR_PROGRESS;
+    case LAYOUT_FINISHED:
+      return Help.PAGE_FINISHED;
+    default:
+      return Help.PAGE_START;
+    }
+  }
+
   @Override
   public boolean onOptionsItemSelected(final MenuItem item) {
     // Handle item selection
@@ -2932,8 +2934,7 @@ public class HTTrackActivity extends FragmentActivity {
       browse(Uri.parse("http://www.httrack.com/"));
       break;
     case R.id.action_help:
-      browse(getResourceFile(), new File(new File(getResourceFile(), "html"),
-          "index.html"));
+      Help.show(this, getResourceFile(), getHelpPage());
       break;
     case R.id.action_import_mirrors:
       startLegacyMirrorImport();
@@ -3238,9 +3239,6 @@ public class HTTrackActivity extends FragmentActivity {
             .replace("%s", name);
         sendSystemNotification(title, e.getMessage());
       }
-    }
-    if (mirrorServer != null) {
-      mirrorServer.stop();
     }
     super.onDestroy();
   }

--- a/app/src/main/java/com/httrack/android/Help.java
+++ b/app/src/main/java/com/httrack/android/Help.java
@@ -1,0 +1,112 @@
+/*
+HTTrack Android Java Interface.
+
+HTTrack Website Copier, Offline Browser for Windows and Unix
+Copyright (C) Xavier Roche and other contributors
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 3
+of the License, or any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+package com.httrack.android;
+
+import java.io.File;
+import java.io.IOException;
+
+import android.app.Activity;
+import android.net.Uri;
+import android.util.Log;
+import android.widget.Toast;
+
+import androidx.browser.customtabs.CustomTabsIntent;
+
+/**
+ * Contextual help: opens the bundled doc page matching the screen the user asked from, the way
+ * WinHTTrack sends each option tab to its own step9_optN.html.
+ */
+final class Help {
+  // Pages the wizard panes ask for. A bundle without the anchors just opens at the top of the page.
+  static final String PAGE_START = "android.html#start";
+  static final String PAGE_PROJECT_NAME = "android.html#name-the-project";
+  static final String PAGE_PROJECT_SETUP = "android.html#enter-the-address";
+  static final String PAGE_OPTIONS = "android.html#options";
+  static final String PAGE_MIRROR_PROGRESS = "android.html#run-the-mirror";
+  static final String PAGE_FINISHED = "android.html#browse-the-result";
+
+  private Help() {
+  }
+
+  /**
+   * Open bundled doc page {@code page} (a filename, optionally with a "#anchor") in a Custom Tab,
+   * served over the loopback mirror server rooted at the resources cache. A Custom Tab keeps the
+   * user one back tap from the screen they asked from, and renders these desktop-width pages
+   * better than a WebView we would have to own.
+   *
+   * @param activity
+   *          the caller, used to launch the tab and report failures
+   * @param resourceRoot
+   *          the extracted resources cache, parent of the "html" doc directory
+   * @param page
+   *          doc page name relative to "html", with an optional URL fragment
+   */
+  static void show(final Activity activity, final File resourceRoot, final String page) {
+    if (resourceRoot == null) {
+      Log.w(Help.class.getSimpleName(), "no resources bundle, cannot show help");
+      return;
+    }
+    final int fragment = page.indexOf('#');
+    final String name = fragment == -1 ? page : page.substring(0, fragment);
+    final File file = new File(new File(resourceRoot, "html"), name);
+    if (!file.exists()) {
+      Log.w(Help.class.getSimpleName(), "no such help page: " + name);
+      return;
+    }
+    try {
+      final MirrorServer server = MirrorServer.forRoot(resourceRoot);
+      final String url = url(server.getBaseUrl(), resourceRoot, page);
+      if (url == null) {
+        return;
+      }
+      new CustomTabsIntent.Builder().build().launchUrl(activity, Uri.parse(url));
+    } catch (final Exception e) {
+      Log.w(Help.class.getSimpleName(), "could not open help", e);
+      Toast.makeText(activity, e.getLocalizedMessage(), Toast.LENGTH_SHORT).show();
+    }
+  }
+
+  /**
+   * Loopback URL serving doc page {@code page} from {@code resourceRoot}, or null if it resolves
+   * outside the bundle.
+   *
+   * @param baseUrl
+   *          the running server's base URL
+   * @param resourceRoot
+   *          the extracted resources cache, the server's root
+   * @param page
+   *          doc page name relative to "html", with an optional URL fragment
+   * @return the URL to open, or null if the page is not inside the bundle
+   */
+  static String url(final String baseUrl, final File resourceRoot, final String page)
+      throws IOException {
+    final int fragment = page.indexOf('#');
+    final String name = fragment == -1 ? page : page.substring(0, fragment);
+    final String relative = MirrorServer.relativeUrlPath(resourceRoot,
+        new File(new File(resourceRoot, "html"), name));
+    if (relative == null) {
+      return null;
+    }
+    // The fragment is appended raw: relativeUrlPath percent-encodes path segments only.
+    return baseUrl + "/" + relative + (fragment == -1 ? "" : page.substring(fragment));
+  }
+}

--- a/app/src/main/java/com/httrack/android/Help.java
+++ b/app/src/main/java/com/httrack/android/Help.java
@@ -22,39 +22,64 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 package com.httrack.android;
 
 import java.io.File;
-import java.io.IOException;
 
 import android.app.Activity;
-import android.net.Uri;
 import android.util.Log;
-import android.widget.Toast;
-
-import androidx.browser.customtabs.CustomTabsIntent;
 
 /**
- * Contextual help: opens the bundled doc page matching the screen the user asked from, the way
- * WinHTTrack sends each option tab to its own step9_optN.html.
+ * Contextual help: which bundled doc page documents which screen, the way WinHTTrack sends each
+ * option tab to its own help page.
  */
 final class Help {
-  // Pages the wizard panes ask for. A bundle without the anchors just opens at the top of the page.
-  static final String PAGE_START = "android.html#start";
-  static final String PAGE_PROJECT_NAME = "android.html#name-the-project";
-  static final String PAGE_PROJECT_SETUP = "android.html#enter-the-address";
-  static final String PAGE_OPTIONS = "android.html#options";
-  static final String PAGE_MIRROR_PROGRESS = "android.html#run-the-mirror";
-  static final String PAGE_FINISHED = "android.html#browse-the-result";
+  // Sections of the shared GUI guide. "#droid/<id>" is guide.js's scheme: it picks the Android
+  // variant, then scrolls to <id>. Without the "droid/" the guide guesses from the user agent.
+  static final String PAGE_START = "guide.html#droid/step-start";
+  static final String PAGE_PROJECT_NAME = "guide.html#droid/step-project";
+  static final String PAGE_PROJECT_SETUP = "guide.html#droid/step-address";
+  static final String PAGE_OPTIONS = "guide.html#droid/options";
+  static final String PAGE_MIRROR_PROGRESS = "guide.html#droid/step-run";
+  static final String PAGE_FINISHED = "guide.html#droid/step-done";
 
   private Help() {
   }
 
   /**
-   * Open bundled doc page {@code page} (a filename, optionally with a "#anchor") in a Custom Tab,
-   * served over the loopback mirror server rooted at the resources cache. A Custom Tab keeps the
-   * user one back tap from the screen they asked from, and renders these desktop-width pages
-   * better than a WebView we would have to own.
+   * Doc page for the wizard pane at {@code paneId}, one of HTTrackActivity's LAYOUT_* positions.
+   * An unknown pane gets the guide's first step.
+   */
+  static String pageForPane(final int paneId) {
+    switch (paneId) {
+    case HTTrackActivity.LAYOUT_PROJECT_NAME:
+      return PAGE_PROJECT_NAME;
+    case HTTrackActivity.LAYOUT_PROJECT_SETUP:
+      return PAGE_PROJECT_SETUP;
+    case HTTrackActivity.LAYOUT_MIRROR_PROGRESS:
+      return PAGE_MIRROR_PROGRESS;
+    case HTTrackActivity.LAYOUT_FINISHED:
+      return PAGE_FINISHED;
+    default:
+      return PAGE_START;
+    }
+  }
+
+  /**
+   * Doc page for option tab {@code tabClass}, or the options overview when it declares none or no
+   * tab is open.
+   */
+  static String pageForTab(final Class<?> tabClass) {
+    if (tabClass == null) {
+      return PAGE_OPTIONS;
+    }
+    final OptionsActivity.HelpPage page = OptionsActivity.HelpPage.class.cast(tabClass
+        .getAnnotation(OptionsActivity.HelpPage.class));
+    return page != null ? page.value() : PAGE_OPTIONS;
+  }
+
+  /**
+   * Open doc page {@code page} over the app.
    *
    * @param activity
-   *          the caller, used to launch the tab and report failures
+   *          the caller
    * @param resourceRoot
    *          the extracted resources cache, parent of the "html" doc directory
    * @param page
@@ -65,48 +90,10 @@ final class Help {
       Log.w(Help.class.getSimpleName(), "no resources bundle, cannot show help");
       return;
     }
-    final int fragment = page.indexOf('#');
-    final String name = fragment == -1 ? page : page.substring(0, fragment);
-    final File file = new File(new File(resourceRoot, "html"), name);
-    if (!file.exists()) {
-      Log.w(Help.class.getSimpleName(), "no such help page: " + name);
-      return;
-    }
-    try {
-      final MirrorServer server = MirrorServer.forRoot(resourceRoot);
-      final String url = url(server.getBaseUrl(), resourceRoot, page);
-      if (url == null) {
-        return;
-      }
-      new CustomTabsIntent.Builder().build().launchUrl(activity, Uri.parse(url));
-    } catch (final Exception e) {
-      Log.w(Help.class.getSimpleName(), "could not open help", e);
-      Toast.makeText(activity, e.getLocalizedMessage(), Toast.LENGTH_SHORT).show();
-    }
-  }
-
-  /**
-   * Loopback URL serving doc page {@code page} from {@code resourceRoot}, or null if it resolves
-   * outside the bundle.
-   *
-   * @param baseUrl
-   *          the running server's base URL
-   * @param resourceRoot
-   *          the extracted resources cache, the server's root
-   * @param page
-   *          doc page name relative to "html", with an optional URL fragment
-   * @return the URL to open, or null if the page is not inside the bundle
-   */
-  static String url(final String baseUrl, final File resourceRoot, final String page)
-      throws IOException {
-    final int fragment = page.indexOf('#');
-    final String name = fragment == -1 ? page : page.substring(0, fragment);
-    final String relative = MirrorServer.relativeUrlPath(resourceRoot,
-        new File(new File(resourceRoot, "html"), name));
-    if (relative == null) {
-      return null;
-    }
-    // The fragment is appended raw: relativeUrlPath percent-encodes path segments only.
-    return baseUrl + "/" + relative + (fragment == -1 ? "" : page.substring(fragment));
+    final int hash = page.indexOf('#');
+    final String name = hash == -1 ? page : page.substring(0, hash);
+    final String fragment = hash == -1 ? null : page.substring(hash);
+    Loopback.open(activity, resourceRoot, new File(new File(resourceRoot, "html"), name), fragment,
+        true);
   }
 }

--- a/app/src/main/java/com/httrack/android/Loopback.java
+++ b/app/src/main/java/com/httrack/android/Loopback.java
@@ -1,0 +1,111 @@
+/*
+HTTrack Android Java Interface.
+
+HTTrack Website Copier, Offline Browser for Windows and Unix
+Copyright (C) Xavier Roche and other contributors
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 3
+of the License, or any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+package com.httrack.android;
+
+import java.io.File;
+import java.io.IOException;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.net.Uri;
+import android.util.Log;
+import android.widget.Toast;
+
+import androidx.browser.customtabs.CustomTabsIntent;
+
+/** Opens a local file in a browser, served over the loopback mirror server. */
+final class Loopback {
+  private Loopback() {
+  }
+
+  /**
+   * Open {@code file} from the server rooted at {@code root}. A Custom Tab floats over the app,
+   * which suits a doc page; a whole mirrored site belongs in the browser.
+   *
+   * @param activity
+   *          the caller, used to launch the browser and report failures
+   * @param root
+   *          the served tree; {@code file} must be inside it
+   * @param file
+   *          the file to open; ignored when it does not exist
+   * @param fragment
+   *          URL fragment to append, leading "#" included, or null
+   * @param customTab
+   *          open over the app rather than switching to the browser
+   */
+  static void open(final Activity activity, final File root, final File file,
+      final String fragment, final boolean customTab) {
+    if (root == null || file == null || !file.exists()) {
+      Log.w(Loopback.class.getSimpleName(), "nothing to open: " + file);
+      return;
+    }
+    final MirrorServer server;
+    try {
+      server = MirrorServer.forRoot(root);
+    } catch (final IOException e) {
+      Log.w(Loopback.class.getSimpleName(), "mirror server failed to start", e);
+      Toast.makeText(activity, "Could not start the local mirror server", Toast.LENGTH_SHORT)
+          .show();
+      return;
+    }
+    try {
+      final String url = url(server.getBaseUrl(), root, file, fragment);
+      if (url == null) {
+        Toast.makeText(activity, "Cannot browse a file outside the served folder",
+            Toast.LENGTH_SHORT).show();
+        return;
+      }
+      final Uri uri = Uri.parse(url);
+      if (customTab) {
+        new CustomTabsIntent.Builder().build().launchUrl(activity, uri);
+      } else {
+        activity.startActivity(new Intent(Intent.ACTION_VIEW, uri));
+      }
+    } catch (final Exception e) {
+      Log.w(Loopback.class.getSimpleName(), "could not open " + file, e);
+      Toast.makeText(activity, e.getLocalizedMessage(), Toast.LENGTH_SHORT).show();
+    }
+  }
+
+  /**
+   * Loopback URL serving {@code file}, or null if it is not inside {@code root}.
+   *
+   * @param baseUrl
+   *          the running server's base URL
+   * @param root
+   *          the served tree
+   * @param file
+   *          the file to link to
+   * @param fragment
+   *          URL fragment to append, leading "#" included, or null
+   * @return the URL to open, or null if the file is outside root
+   */
+  static String url(final String baseUrl, final File root, final File file, final String fragment)
+      throws IOException {
+    final String relative = MirrorServer.relativeUrlPath(root, file);
+    if (relative == null) {
+      return null;
+    }
+    // The fragment stays raw: relativeUrlPath percent-encodes path segments only.
+    return baseUrl + "/" + relative + (fragment == null ? "" : fragment);
+  }
+}

--- a/app/src/main/java/com/httrack/android/MirrorServer.java
+++ b/app/src/main/java/com/httrack/android/MirrorServer.java
@@ -25,6 +25,8 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.URLEncoder;
+import java.util.HashMap;
+import java.util.Map;
 
 import fi.iki.elonen.NanoHTTPD;
 
@@ -33,11 +35,18 @@ import fi.iki.elonen.NanoHTTPD;
  * browser file:// access to our scoped storage, so the mirror is served over http://127.0.0.1 and
  * read as an ordinary web site. Filenames come from crawled URLs, so path resolution is hostile
  * input and lives in the unit-tested {@link #resolveWithinRoot(File, String)}.
+ *
+ * Plain thread (NanoHTTPD owns it): reliability while browsing backgrounded relies on us staying
+ * the MRU cached process. A foreground service (needs an Android-14 FGS type) is a future step.
  */
 final class MirrorServer extends NanoHTTPD {
   // Ports tried in order; mirrors the engine's htscatchurl.c try_to_listen_to[]. 0 = OS-assigned
   // ephemeral fallback. Privileged (<1024) ports are omitted: Android forbids binding them.
   private static final int[] PORTS = { 8080, 3128, 8081, 3129, 0 };
+
+  // One server per served tree, keyed by canonical path: docs and mirrors live in different trees,
+  // and restarting a shared server on every switch would cut off whatever is reading the other one.
+  private static final Map<String, MirrorServer> servers = new HashMap<String, MirrorServer>();
 
   private final File root;
 
@@ -68,6 +77,27 @@ final class MirrorServer extends NanoHTTPD {
       }
     }
     throw last != null ? last : new IOException("no loopback port available");
+  }
+
+  /**
+   * Started server for {@code root}, reusing the one already serving that tree. Servers outlive the
+   * activity that opened them: the browser reading a mirror is another app, and stopping the server
+   * when our activity goes away would break the page under it.
+   *
+   * @param root
+   *          the served tree; every request is confined to it
+   * @return a started server, valid until the process exits
+   * @throws IOException
+   *           if the tree cannot be canonicalised, or no port could be bound
+   */
+  static synchronized MirrorServer forRoot(final File root) throws IOException {
+    final String key = root.getCanonicalPath();
+    MirrorServer server = servers.get(key);
+    if (server == null) {
+      server = start(root);
+      servers.put(key, server);
+    }
+    return server;
   }
 
   /** Actual bound port, valid once started. */

--- a/app/src/main/java/com/httrack/android/MirrorServer.java
+++ b/app/src/main/java/com/httrack/android/MirrorServer.java
@@ -37,7 +37,8 @@ import fi.iki.elonen.NanoHTTPD;
  * input and lives in the unit-tested {@link #resolveWithinRoot(File, String)}.
  *
  * Plain thread (NanoHTTPD owns it): reliability while browsing backgrounded relies on us staying
- * the MRU cached process. A foreground service (needs an Android-14 FGS type) is a future step.
+ * the most-recently-used cached process. A foreground service (needs an Android-14 type) is a
+ * future step.
  */
 final class MirrorServer extends NanoHTTPD {
   // Ports tried in order; mirrors the engine's htscatchurl.c try_to_listen_to[]. 0 = OS-assigned
@@ -81,8 +82,8 @@ final class MirrorServer extends NanoHTTPD {
 
   /**
    * Started server for {@code root}, reusing the one already serving that tree. Servers outlive the
-   * activity that opened them: the browser reading a mirror is another app, and stopping the server
-   * when our activity goes away would break the page under it.
+   * activity that opened them: the browser reading a mirror is a separate app, and stopping the
+   * server on our onDestroy would break its page.
    *
    * @param root
    *          the served tree; every request is confined to it

--- a/app/src/main/java/com/httrack/android/OptionsActivity.java
+++ b/app/src/main/java/com/httrack/android/OptionsActivity.java
@@ -139,7 +139,7 @@ public class OptionsActivity extends FragmentActivity implements View.OnClickLis
 
   @Title(R.string.scan_rules)
   @ActivityId(R.layout.activity_options_scanrules)
-  @HelpPage("step9_opt4.html")
+  @HelpPage("guide.html#droid/opt-scan-rules")
   @Fields({ R.id.editRules })
   public static class ScanRulesTab extends Tab {
     @Override
@@ -157,7 +157,7 @@ public class OptionsActivity extends FragmentActivity implements View.OnClickLis
 
   @Title(R.string.limits)
   @ActivityId(R.layout.activity_options_limits)
-  @HelpPage("step9_opt2.html")
+  @HelpPage("guide.html#droid/opt-limits")
   @Fields({ R.id.editMaxDepth, R.id.editMaxExtDepth, R.id.editMaxSizeHtml,
       R.id.editMaxSizeOther, R.id.editSiteSizeLimit, R.id.editMaxTimeOverall,
       R.id.editMaxTransferRate, R.id.editMaxConnectionsSecond,
@@ -167,7 +167,7 @@ public class OptionsActivity extends FragmentActivity implements View.OnClickLis
 
   @Title(R.string.flow_control)
   @ActivityId(R.layout.activity_options_flowcontrol)
-  @HelpPage("step9_opt3.html")
+  @HelpPage("guide.html#droid/opt-flow-control")
   @Fields({ R.id.editNumberOfConnections, R.id.checkPersistentConnections,
       R.id.editTimeout, R.id.checkRemoveHostIfTimeout, R.id.editRetries,
       R.id.editMinTransferRate, R.id.checkRemoveHostIfSlow, R.id.editPause })
@@ -176,7 +176,7 @@ public class OptionsActivity extends FragmentActivity implements View.OnClickLis
 
   @Title(R.string.links)
   @ActivityId(R.layout.activity_options_links)
-  @HelpPage("step9_opt1.html")
+  @HelpPage("guide.html#droid/opt-links")
   @Fields({ R.id.checkDetectAllLinks, R.id.checkGetNonHtmlNear,
       R.id.checkTestAllLinks, R.id.checkGetHtmlFirst, R.id.checkKeepWwwPrefix,
       R.id.checkKeepDoubleSlashes, R.id.checkKeepQueryOrder })
@@ -185,7 +185,7 @@ public class OptionsActivity extends FragmentActivity implements View.OnClickLis
 
   @Title(R.string.build)
   @ActivityId(R.layout.activity_options_build)
-  @HelpPage("step9_opt5.html")
+  @HelpPage("guide.html#droid/opt-build")
   @Fields({ R.id.checkDosNames, R.id.checkIso9660, R.id.checkNoErrorPages,
       R.id.checkNoExternalPages, R.id.checkHidePasswords,
       R.id.checkHideQueryStrings, R.id.checkDoNotPurge, R.id.checkSingleFile,
@@ -195,7 +195,7 @@ public class OptionsActivity extends FragmentActivity implements View.OnClickLis
 
   @Title(R.string.browser_id)
   @ActivityId(R.layout.activity_options_browserid)
-  @HelpPage("step9_opt8.html")
+  @HelpPage("guide.html#droid/opt-browser-id")
   @Fields({ R.id.editBrowserIdentity, R.id.editHtmlFooter,
       R.id.editAcceptLanguage, R.id.editOtherHeaders, R.id.editDefaultReferer })
   public static class BrowserId extends Tab {
@@ -203,7 +203,7 @@ public class OptionsActivity extends FragmentActivity implements View.OnClickLis
 
   @Title(R.string.spider)
   @ActivityId(R.layout.activity_options_spider)
-  @HelpPage("step9_opt6.html")
+  @HelpPage("guide.html#droid/opt-spider")
   @Fields({ R.id.checkAcceptCookies, R.id.editCookiesFile,
       R.id.radioCheckDocumentType, R.id.checkParseJavaFiles, R.id.radioSpider,
       R.id.checkSitemap, R.id.editSitemapUrl, R.id.checkUpdateHacks,
@@ -213,7 +213,7 @@ public class OptionsActivity extends FragmentActivity implements View.OnClickLis
 
   @Title(R.string.proxy)
   @ActivityId(R.layout.activity_options_proxy)
-  @HelpPage("step9_opt7.html")
+  @HelpPage("guide.html#droid/opt-proxy")
   @Fields({ R.id.radioProxyProtocol, R.id.editProxy, R.id.editProxyPort,
       R.id.checkUseProxyForFtp })
   public static class Proxy extends Tab {
@@ -221,7 +221,7 @@ public class OptionsActivity extends FragmentActivity implements View.OnClickLis
 
   @Title(R.string.log_index_cache)
   @ActivityId(R.layout.activity_options_logindexcache)
-  @HelpPage("step9_opt9.html")
+  @HelpPage("guide.html#droid/opt-log-index-cache")
   @Fields({ R.id.checkStoreAllFilesInCache,
       R.id.checkDoNotRedownloadLocallErasedFiles, R.id.checkWarc,
       R.id.editWarcFile, R.id.checkChanges, R.id.checkCreateLogFiles,
@@ -232,7 +232,7 @@ public class OptionsActivity extends FragmentActivity implements View.OnClickLis
 
   @Title(R.string.type_mime_associations)
   @ActivityId(R.layout.activity_options_mimetypes)
-  @HelpPage("step9_opt11.html")
+  @HelpPage("guide.html#droid/opt-mime-types")
   @Fields({ R.id.editExtDef1, R.id.editMimeDef1, R.id.editExtDef2,
       R.id.editMimeDef2, R.id.editExtDef3, R.id.editMimeDef3, R.id.editExtDef4,
       R.id.editMimeDef4, R.id.editExtDef5, R.id.editMimeDef5, R.id.editExtDef6,
@@ -243,7 +243,7 @@ public class OptionsActivity extends FragmentActivity implements View.OnClickLis
 
   @Title(R.string.experts_only)
   @ActivityId(R.layout.activity_options_expertsonly)
-  @HelpPage("step9_opt10.html")
+  @HelpPage("guide.html#droid/opt-experts-only")
   @Fields({ R.id.checkUseCacheForUpdates, R.id.radioPrimaryScanRule,
       R.id.textTravelMode, R.id.radioTravelMode, R.id.radioGlobalTravelMode,
       R.id.radioRewriteLinks, R.id.editStripQuery, R.id.checkActivateDebugging })
@@ -633,22 +633,12 @@ public class OptionsActivity extends FragmentActivity implements View.OnClickLis
     return true;
   }
 
-  /** Doc page for the tab currently shown, or the Options overview from the tab list. */
-  private String getHelpPage() {
-    if (activityClass == null) {
-      return Help.PAGE_OPTIONS;
-    }
-    final HelpPage page = HelpPage.class.cast(activityClass
-        .getAnnotation(HelpPage.class));
-    return page != null ? page.value() : Help.PAGE_OPTIONS;
-  }
-
   @Override
   public boolean onOptionsItemSelected(final MenuItem item) {
     // Handle item selection
     switch (item.getItemId()) {
     case R.id.action_help:
-      Help.show(this, resourceFile, getHelpPage());
+      Help.show(this, resourceFile, Help.pageForTab(activityClass));
       break;
     case R.id.action_load_default:
       mapper.loadDefaultPreferences();

--- a/app/src/main/java/com/httrack/android/OptionsActivity.java
+++ b/app/src/main/java/com/httrack/android/OptionsActivity.java
@@ -21,6 +21,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 package com.httrack.android;
 
+import java.io.File;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -70,6 +71,9 @@ public class OptionsActivity extends FragmentActivity implements View.OnClickLis
   // Widget data exchanger
   private final WidgetDataExchange widgetDataExchange = new WidgetDataExchange(
       this);
+
+  // Extracted docs bundle, where the help pages live
+  private File resourceFile;
 
   // Current activity class
   protected Class<?> activityClass;
@@ -124,8 +128,18 @@ public class OptionsActivity extends FragmentActivity implements View.OnClickLis
     int[] value();
   }
 
+  /**
+   * Bundled doc page of a tab class, one page per tab as in WinHTTrack's own help.
+   */
+  @Retention(RetentionPolicy.RUNTIME)
+  @Target(ElementType.TYPE)
+  public static @interface HelpPage {
+    String value();
+  }
+
   @Title(R.string.scan_rules)
   @ActivityId(R.layout.activity_options_scanrules)
+  @HelpPage("step9_opt4.html")
   @Fields({ R.id.editRules })
   public static class ScanRulesTab extends Tab {
     @Override
@@ -143,6 +157,7 @@ public class OptionsActivity extends FragmentActivity implements View.OnClickLis
 
   @Title(R.string.limits)
   @ActivityId(R.layout.activity_options_limits)
+  @HelpPage("step9_opt2.html")
   @Fields({ R.id.editMaxDepth, R.id.editMaxExtDepth, R.id.editMaxSizeHtml,
       R.id.editMaxSizeOther, R.id.editSiteSizeLimit, R.id.editMaxTimeOverall,
       R.id.editMaxTransferRate, R.id.editMaxConnectionsSecond,
@@ -152,6 +167,7 @@ public class OptionsActivity extends FragmentActivity implements View.OnClickLis
 
   @Title(R.string.flow_control)
   @ActivityId(R.layout.activity_options_flowcontrol)
+  @HelpPage("step9_opt3.html")
   @Fields({ R.id.editNumberOfConnections, R.id.checkPersistentConnections,
       R.id.editTimeout, R.id.checkRemoveHostIfTimeout, R.id.editRetries,
       R.id.editMinTransferRate, R.id.checkRemoveHostIfSlow, R.id.editPause })
@@ -160,6 +176,7 @@ public class OptionsActivity extends FragmentActivity implements View.OnClickLis
 
   @Title(R.string.links)
   @ActivityId(R.layout.activity_options_links)
+  @HelpPage("step9_opt1.html")
   @Fields({ R.id.checkDetectAllLinks, R.id.checkGetNonHtmlNear,
       R.id.checkTestAllLinks, R.id.checkGetHtmlFirst, R.id.checkKeepWwwPrefix,
       R.id.checkKeepDoubleSlashes, R.id.checkKeepQueryOrder })
@@ -168,6 +185,7 @@ public class OptionsActivity extends FragmentActivity implements View.OnClickLis
 
   @Title(R.string.build)
   @ActivityId(R.layout.activity_options_build)
+  @HelpPage("step9_opt5.html")
   @Fields({ R.id.checkDosNames, R.id.checkIso9660, R.id.checkNoErrorPages,
       R.id.checkNoExternalPages, R.id.checkHidePasswords,
       R.id.checkHideQueryStrings, R.id.checkDoNotPurge, R.id.checkSingleFile,
@@ -177,6 +195,7 @@ public class OptionsActivity extends FragmentActivity implements View.OnClickLis
 
   @Title(R.string.browser_id)
   @ActivityId(R.layout.activity_options_browserid)
+  @HelpPage("step9_opt8.html")
   @Fields({ R.id.editBrowserIdentity, R.id.editHtmlFooter,
       R.id.editAcceptLanguage, R.id.editOtherHeaders, R.id.editDefaultReferer })
   public static class BrowserId extends Tab {
@@ -184,6 +203,7 @@ public class OptionsActivity extends FragmentActivity implements View.OnClickLis
 
   @Title(R.string.spider)
   @ActivityId(R.layout.activity_options_spider)
+  @HelpPage("step9_opt6.html")
   @Fields({ R.id.checkAcceptCookies, R.id.editCookiesFile,
       R.id.radioCheckDocumentType, R.id.checkParseJavaFiles, R.id.radioSpider,
       R.id.checkSitemap, R.id.editSitemapUrl, R.id.checkUpdateHacks,
@@ -193,6 +213,7 @@ public class OptionsActivity extends FragmentActivity implements View.OnClickLis
 
   @Title(R.string.proxy)
   @ActivityId(R.layout.activity_options_proxy)
+  @HelpPage("step9_opt7.html")
   @Fields({ R.id.radioProxyProtocol, R.id.editProxy, R.id.editProxyPort,
       R.id.checkUseProxyForFtp })
   public static class Proxy extends Tab {
@@ -200,6 +221,7 @@ public class OptionsActivity extends FragmentActivity implements View.OnClickLis
 
   @Title(R.string.log_index_cache)
   @ActivityId(R.layout.activity_options_logindexcache)
+  @HelpPage("step9_opt9.html")
   @Fields({ R.id.checkStoreAllFilesInCache,
       R.id.checkDoNotRedownloadLocallErasedFiles, R.id.checkWarc,
       R.id.editWarcFile, R.id.checkChanges, R.id.checkCreateLogFiles,
@@ -210,6 +232,7 @@ public class OptionsActivity extends FragmentActivity implements View.OnClickLis
 
   @Title(R.string.type_mime_associations)
   @ActivityId(R.layout.activity_options_mimetypes)
+  @HelpPage("step9_opt11.html")
   @Fields({ R.id.editExtDef1, R.id.editMimeDef1, R.id.editExtDef2,
       R.id.editMimeDef2, R.id.editExtDef3, R.id.editMimeDef3, R.id.editExtDef4,
       R.id.editMimeDef4, R.id.editExtDef5, R.id.editMimeDef5, R.id.editExtDef6,
@@ -220,6 +243,7 @@ public class OptionsActivity extends FragmentActivity implements View.OnClickLis
 
   @Title(R.string.experts_only)
   @ActivityId(R.layout.activity_options_expertsonly)
+  @HelpPage("step9_opt10.html")
   @Fields({ R.id.checkUseCacheForUpdates, R.id.radioPrimaryScanRule,
       R.id.textTravelMode, R.id.radioTravelMode, R.id.radioGlobalTravelMode,
       R.id.radioRewriteLinks, R.id.editStripQuery, R.id.checkActivateDebugging })
@@ -355,6 +379,12 @@ public class OptionsActivity extends FragmentActivity implements View.OnClickLis
       Log.d(getClass().getSimpleName(), "tablet mode detected");
     } else {
       Log.d(getClass().getSimpleName(), "phone mode detected");
+    }
+
+    final Bundle extras = getIntent().getExtras();
+    if (extras != null) {
+      resourceFile = File.class.cast(extras
+          .get("com.httrack.android.resourceFile"));
     }
 
     // Set map context
@@ -603,10 +633,23 @@ public class OptionsActivity extends FragmentActivity implements View.OnClickLis
     return true;
   }
 
+  /** Doc page for the tab currently shown, or the Options overview from the tab list. */
+  private String getHelpPage() {
+    if (activityClass == null) {
+      return Help.PAGE_OPTIONS;
+    }
+    final HelpPage page = HelpPage.class.cast(activityClass
+        .getAnnotation(HelpPage.class));
+    return page != null ? page.value() : Help.PAGE_OPTIONS;
+  }
+
   @Override
   public boolean onOptionsItemSelected(final MenuItem item) {
     // Handle item selection
     switch (item.getItemId()) {
+    case R.id.action_help:
+      Help.show(this, resourceFile, getHelpPage());
+      break;
     case R.id.action_load_default:
       mapper.loadDefaultPreferences();
       loadIfNeeded();

--- a/app/src/main/res/menu/options.xml
+++ b/app/src/main/res/menu/options.xml
@@ -12,5 +12,9 @@
         android:id="@+id/action_reset_default"
         android:orderInCategory="100"
         android:title="@string/reset_default"/>
+    <item
+        android:id="@+id/action_help"
+        android:orderInCategory="200"
+        android:title="@string/action_help"/>
 
 </menu>

--- a/app/src/test/java/com/httrack/android/HelpTest.java
+++ b/app/src/test/java/com/httrack/android/HelpTest.java
@@ -1,6 +1,7 @@
 package com.httrack.android;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
 
 import java.io.File;
@@ -10,9 +11,17 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-/** Help.url: where a doc page name lands, and that a page name cannot leave the docs bundle. */
+/** Which page each screen asks for, and where a page name is allowed to land. */
 public class HelpTest {
   private static final String BASE = "http://127.0.0.1:8080";
+
+  /** Stands in for an option tab; the real ones cannot load without the Android framework. */
+  @OptionsActivity.HelpPage("guide.html#droid/opt-limits")
+  private static class AnnotatedTab {
+  }
+
+  private static class BareTab {
+  }
 
   @Rule
   public final TemporaryFolder tmp = new TemporaryFolder();
@@ -25,24 +34,75 @@ public class HelpTest {
     new File(root, "html").mkdirs();
   }
 
+  private String url(final String page) throws Exception {
+    final int hash = page.indexOf('#');
+    final String name = hash == -1 ? page : page.substring(0, hash);
+    return Loopback.url(BASE, root, new File(new File(root, "html"), name),
+        hash == -1 ? null : page.substring(hash));
+  }
+
   @Test
   public void resolvesAnOptionPage() throws Exception {
-    assertEquals(BASE + "/html/step9_opt4.html", Help.url(BASE, root, "step9_opt4.html"));
+    assertEquals(BASE + "/html/guide.html#droid/opt-scan-rules",
+        url("guide.html#droid/opt-scan-rules"));
   }
 
   @Test
-  public void keepsTheAnchorUnencoded() throws Exception {
-    assertEquals(BASE + "/html/android.html#name-the-project",
-        Help.url(BASE, root, Help.PAGE_PROJECT_NAME));
+  public void leavesTheFragmentByteForByte() throws Exception {
+    // A space in the fragment is what tells "appended raw" apart from "percent-encoded".
+    assertEquals(BASE + "/html/a.html#c d", url("a.html#c d"));
   }
 
   @Test
-  public void encodesThePathButLeavesTheAnchorAlone() throws Exception {
-    assertEquals(BASE + "/html/a%20b.html#c-d", Help.url(BASE, root, "a b.html#c-d"));
+  public void encodesThePath() throws Exception {
+    assertEquals(BASE + "/html/a%20b.html", url("a b.html"));
   }
 
   @Test
   public void refusesAPageOutsideTheBundle() throws Exception {
-    assertNull(Help.url(BASE, root, "../../etc/passwd"));
+    assertNull(url("../../etc/passwd"));
+  }
+
+  @Test
+  public void refusesTraversalThatDoesNotStartWithDotDot() throws Exception {
+    // A name-prefix blocklist would pass this one; only canonicalisation catches it.
+    assertNull(url("foo/../../../etc/passwd"));
+  }
+
+  @Test
+  public void everyPaneHasItsOwnSection() {
+    final String[] pages = { Help.pageForPane(HTTrackActivity.LAYOUT_START),
+        Help.pageForPane(HTTrackActivity.LAYOUT_PROJECT_NAME),
+        Help.pageForPane(HTTrackActivity.LAYOUT_PROJECT_SETUP),
+        Help.pageForPane(HTTrackActivity.LAYOUT_MIRROR_PROGRESS),
+        Help.pageForPane(HTTrackActivity.LAYOUT_FINISHED) };
+    for (int i = 0; i < pages.length; i++) {
+      for (int j = i + 1; j < pages.length; j++) {
+        assertNotEquals(pages[i], pages[j]);
+      }
+    }
+  }
+
+  @Test
+  public void panePagesCarryThePlatform() {
+    // Without "#droid/" the guide falls back to sniffing the user agent.
+    assertEquals("guide.html#droid/step-project",
+        Help.pageForPane(HTTrackActivity.LAYOUT_PROJECT_NAME));
+  }
+
+  @Test
+  public void anUnknownPaneFallsBackToTheFirstStep() {
+    assertEquals(Help.PAGE_START, Help.pageForPane(-1));
+  }
+
+  @Test
+  public void readsTheTabAnnotation() {
+    assertEquals("guide.html#droid/opt-limits", Help.pageForTab(AnnotatedTab.class));
+  }
+
+  @Test
+  public void fallsBackToTheOverviewWithoutATab() {
+    assertEquals(Help.PAGE_OPTIONS, Help.pageForTab(null));
+    assertEquals(Help.PAGE_OPTIONS, Help.pageForTab(BareTab.class));
   }
 }

--- a/app/src/test/java/com/httrack/android/HelpTest.java
+++ b/app/src/test/java/com/httrack/android/HelpTest.java
@@ -1,0 +1,48 @@
+package com.httrack.android;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.io.File;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/** Help.url: where a doc page name lands, and that a page name cannot leave the docs bundle. */
+public class HelpTest {
+  private static final String BASE = "http://127.0.0.1:8080";
+
+  @Rule
+  public final TemporaryFolder tmp = new TemporaryFolder();
+
+  private File root;
+
+  @Before
+  public void setUp() throws Exception {
+    root = tmp.newFolder("resources");
+    new File(root, "html").mkdirs();
+  }
+
+  @Test
+  public void resolvesAnOptionPage() throws Exception {
+    assertEquals(BASE + "/html/step9_opt4.html", Help.url(BASE, root, "step9_opt4.html"));
+  }
+
+  @Test
+  public void keepsTheAnchorUnencoded() throws Exception {
+    assertEquals(BASE + "/html/android.html#name-the-project",
+        Help.url(BASE, root, Help.PAGE_PROJECT_NAME));
+  }
+
+  @Test
+  public void encodesThePathButLeavesTheAnchorAlone() throws Exception {
+    assertEquals(BASE + "/html/a%20b.html#c-d", Help.url(BASE, root, "a b.html#c-d"));
+  }
+
+  @Test
+  public void refusesAPageOutsideTheBundle() throws Exception {
+    assertNull(Help.url(BASE, root, "../../etc/passwd"));
+  }
+}

--- a/app/src/test/java/com/httrack/android/MirrorServerTest.java
+++ b/app/src/test/java/com/httrack/android/MirrorServerTest.java
@@ -1,7 +1,10 @@
 package com.httrack.android;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -91,5 +94,21 @@ public class MirrorServerTest {
   public void relativeUrlPathRefusesASiblingSharingRootsNamePrefix() throws Exception {
     final File sibling = tmp.newFolder("Websites-evil");
     assertNull(MirrorServer.relativeUrlPath(root, new File(sibling, "secret.txt")));
+  }
+
+  /** Docs and mirrors are served at once, so each root must keep its own server. */
+  @Test
+  public void forRootKeepsOneServerPerTree() throws Exception {
+    final File resources = tmp.newFolder("resources");
+    final MirrorServer mirrors = MirrorServer.forRoot(root);
+    assertSame(mirrors, MirrorServer.forRoot(root));
+    assertNotSame(mirrors, MirrorServer.forRoot(resources));
+    assertNotEquals(mirrors.getPort(), MirrorServer.forRoot(resources).getPort());
+  }
+
+  /** Keyed by canonical path: "/sdcard" is a symlink on Android, so aliases must not fork servers. */
+  @Test
+  public void forRootFoldsAliasesOfTheSameTree() throws Exception {
+    assertSame(MirrorServer.forRoot(root), MirrorServer.forRoot(new File(root, "html/..")));
   }
 }


### PR DESCRIPTION
Help now opens the page for the screen you asked from. Each option tab points at its own section of the GUI guide through a new `@HelpPage` annotation; the wizard panes point at the matching step. Options had no Help entry at all before this, which was the screen most in need of one.

Targets use `guide.js`'s `#droid/<id>` fragment scheme, so the guide shows the Android variant instead of guessing it from the user agent. Every anchor exists in the pinned engine, so nothing here waits on an upstream change.

Pages open in a Custom Tab, not the system browser or a WebView. `BrowseActivity` was retired in #25 so we would not own a page renderer; a Custom Tab rents one and keeps you a tap from where you started. License moves to the same path, so the two bundled-doc entry points no longer behave differently. A mirrored site still opens in the browser proper, where tabs and bookmarks earn the switch.

`MirrorServer` becomes a per-root registry: docs are served from the resources cache, mirrors from Websites, and the single instance used to stop and restart on every switch between them. Servers now outlive the activity, which also fixes a browse being cut off when the activity was destroyed under it.

Closes #113
