### PR TITLE
Nothing in the app can tell the engine that two hostnames are one site

### DIFF
--- a/app/src/main/java/com/httrack/android/CommandlineTokens.java
+++ b/app/src/main/java/com/httrack/android/CommandlineTokens.java
@@ -38,4 +38,23 @@ public final class CommandlineTokens {
     }
     return out;
   }
+
+  /**
+   * Split a rule-list field value into one rule per engine flag. Whitespace
+   * separates two rules, except beside a ',' or an '=', where it belongs to the
+   * rule and is dropped: the engine rejects a rule that keeps it.
+   */
+  public static List<String> ruleTokens(final String value) {
+    final List<String> out = new ArrayList<String>();
+    if (value == null) {
+      return out;
+    }
+    for (final String rule : value.replaceAll("\\s*([,=])\\s*", "$1").trim()
+        .split("\\s+")) {
+      if (rule.length() != 0) {
+        out.add(rule);
+      }
+    }
+    return out;
+  }
 }

--- a/app/src/main/java/com/httrack/android/CommandlineTokens.java
+++ b/app/src/main/java/com/httrack/android/CommandlineTokens.java
@@ -49,7 +49,7 @@ public final class CommandlineTokens {
     if (value == null) {
       return out;
     }
-    for (final String rule : value.replaceAll("\\s*([,=])\\s*", "$1").trim()
+    for (final String rule : value.replaceAll("\\s*([,=])\\s*", "$1")
         .split("\\s+")) {
       if (rule.length() != 0) {
         out.add(rule);

--- a/app/src/main/java/com/httrack/android/CommandlineTokens.java
+++ b/app/src/main/java/com/httrack/android/CommandlineTokens.java
@@ -41,8 +41,8 @@ public final class CommandlineTokens {
 
   /**
    * Split a rule-list field value into one rule per engine flag. Whitespace
-   * separates two rules, except beside a ',' or an '=', where it belongs to the
-   * rule and is dropped: the engine rejects a rule that keeps it.
+   * separates two rules. Beside a ',' or an '=' it holds one rule together
+   * instead, so it is dropped there rather than splitting the rule in three.
    */
   public static List<String> ruleTokens(final String value) {
     final List<String> out = new ArrayList<String>();

--- a/app/src/main/java/com/httrack/android/OptionsActivity.java
+++ b/app/src/main/java/com/httrack/android/OptionsActivity.java
@@ -246,7 +246,8 @@ public class OptionsActivity extends FragmentActivity implements View.OnClickLis
   @HelpPage("guide.html#droid/opt-experts-only")
   @Fields({ R.id.checkUseCacheForUpdates, R.id.radioPrimaryScanRule,
       R.id.textTravelMode, R.id.radioTravelMode, R.id.radioGlobalTravelMode,
-      R.id.radioRewriteLinks, R.id.editStripQuery, R.id.checkActivateDebugging })
+      R.id.radioRewriteLinks, R.id.editStripQuery, R.id.editHostAlias,
+      R.id.checkActivateDebugging })
   public static class ExpertsOnly extends Tab {
   }
 

--- a/app/src/main/java/com/httrack/android/OptionsMapper.java
+++ b/app/src/main/java/com/httrack/android/OptionsMapper.java
@@ -541,14 +541,12 @@ public class OptionsMapper {
   }
 
   /**
-   * Rule list: emit the option once per rule, the way the engine takes the
-   * options it accumulates.
+   * Rule list: emit the option once per rule, matching how the engine
+   * accumulates repeated flags.
    */
-  public static class RuleListOption implements OptionMapper {
-    protected final String option;
-
+  public static class RuleListOption extends StringSplit {
     public RuleListOption(final String option) {
-      this.option = option;
+      super(option);
     }
 
     @Override

--- a/app/src/main/java/com/httrack/android/OptionsMapper.java
+++ b/app/src/main/java/com/httrack/android/OptionsMapper.java
@@ -180,6 +180,7 @@ public class OptionsMapper {
       new Pair<Integer, String>(R.id.radioGlobalTravelMode, "GlobalTravel"),
       new Pair<Integer, String>(R.id.radioRewriteLinks, "RewriteLinks"),
       new Pair<Integer, String>(R.id.editStripQuery, "StripQuery"),
+      new Pair<Integer, String>(R.id.editHostAlias, "HostAlias"),
       new Pair<Integer, String>(R.id.checkActivateDebugging, "Debugging"), /* FIXME */
 
   };
@@ -343,6 +344,8 @@ public class OptionsMapper {
       new Pair<String, OptionMapper>("CookiesFile", new ArgumentOption("-%K")),
       new Pair<String, OptionMapper>("Pause", new ArgumentOption("-%G")),
       new Pair<String, OptionMapper>("StripQuery", new ArgumentOption("-%g")),
+      new Pair<String, OptionMapper>("HostAlias", new RuleListOption(
+          "--host-alias")),
       new Pair<String, OptionMapper>("KeepWwwPrefix", new SimpleOptionFlag("%j")),
       new Pair<String, OptionMapper>("KeepDoubleSlashes", new SimpleOptionFlag(
           "%o")),
@@ -534,6 +537,26 @@ public class OptionsMapper {
     @Override
     public void emit(final List<String> commandline, final String value) {
       commandline.addAll(CommandlineTokens.urlTokens(value));
+    }
+  }
+
+  /**
+   * Rule list: emit the option once per rule, the way the engine takes the
+   * options it accumulates.
+   */
+  public static class RuleListOption implements OptionMapper {
+    protected final String option;
+
+    public RuleListOption(final String option) {
+      this.option = option;
+    }
+
+    @Override
+    public void emit(final List<String> commandline, final String value) {
+      for (final String rule : CommandlineTokens.ruleTokens(value)) {
+        commandline.add(option);
+        commandline.add(rule);
+      }
     }
   }
 

--- a/app/src/main/res/layout/activity_options_expertsonly.xml
+++ b/app/src/main/res/layout/activity_options_expertsonly.xml
@@ -205,6 +205,19 @@
                 android:inputType="textNoSuggestions" />
         </LinearLayout>
 
+        <TextView
+            android:id="@+id/textHostAlias"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/host_alias" />
+
+        <EditText
+            android:id="@+id/editHostAlias"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/hint_host_alias"
+            android:inputType="textMultiLine|textNoSuggestions" />
+
         <CheckBox
             android:id="@+id/checkActivateDebugging"
             android:layout_width="fill_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -115,7 +115,7 @@
     <string name="hint_pause">2:5</string>
     <string name="strip_query">Strip query keys</string>
     <string name="hint_strip_query">sid,utm_source</string>
-    <string name="host_alias">Other hostnames of this same site (one rule per line)</string>
+    <string name="host_alias">Other hostnames of this same site (one per line)</string>
     <string name="hint_host_alias">www2.example.com,m.example.com=example.com</string>
     <string name="keep_www_prefix">Keep www. prefix (www.x != x)</string>
     <string name="keep_double_slashes">Keep double slashes (//)</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -115,6 +115,8 @@
     <string name="hint_pause">2:5</string>
     <string name="strip_query">Strip query keys</string>
     <string name="hint_strip_query">sid,utm_source</string>
+    <string name="host_alias">Other hostnames of this same site (one rule per line)</string>
+    <string name="hint_host_alias">www2.example.com,m.example.com=example.com</string>
     <string name="keep_www_prefix">Keep www. prefix (www.x != x)</string>
     <string name="keep_double_slashes">Keep double slashes (//)</string>
     <string name="keep_query_order">Keep query-string order (?b&amp;a)</string>

--- a/app/src/test/java/com/httrack/android/OptionsEmissionTest.java
+++ b/app/src/test/java/com/httrack/android/OptionsEmissionTest.java
@@ -16,6 +16,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Random;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.junit.Test;
@@ -289,6 +290,78 @@ public class OptionsEmissionTest {
     }
   }
 
+  private static List<String> emitRules(final String value) {
+    final List<String> cmd = new ArrayList<String>();
+    new OptionsMapper.RuleListOption("--host-alias").emit(cmd, value);
+    return cmd;
+  }
+
+  @Test
+  public void oneHostAliasFlagPerRule() {
+    assertEquals(Arrays.asList("--host-alias", "www2.example.com=example.com",
+        "--host-alias", "https://legacy.example.com=https://example.com"),
+        emitRules("www2.example.com=example.com\n"
+            + "https://legacy.example.com=https://example.com"));
+  }
+
+  @Test
+  public void spacesAroundSeparatorsDoNotStartANewRule() {
+    assertEquals(Arrays.asList("--host-alias", "a.com,b.com=c.com"),
+        emitRules("a.com , b.com = c.com"));
+  }
+
+  @Test
+  public void blankLinesAndAnEmptyFieldEmitNothing() {
+    assertTrue(emitRules("").isEmpty());
+    assertTrue(emitRules("  \n\t\n ").isEmpty());
+    assertEquals(Arrays.asList("--host-alias", "a=b", "--host-alias", "c=d"),
+        emitRules("\n\n a=b \n\n  c=d\n\n"));
+  }
+
+  private static int skipWhile(final String s, int i, final boolean ws) {
+    while (i < s.length() && (" \t\r\n".indexOf(s.charAt(i)) >= 0) == ws) {
+      i++;
+    }
+    return i;
+  }
+
+  /* cat_cmdline_arglist() from the engine's htsserver.c: the character loop the
+     regexp form has to agree with. */
+  private static List<String> arglistOracle(final String value) {
+    final List<String> out = new ArrayList<String>();
+    int p = skipWhile(value, 0, true);
+    while (p < value.length()) {
+      final StringBuilder rule = new StringBuilder();
+      boolean more = true;
+      while (more) {
+        final int end = skipWhile(value, p, false);
+        final int next = skipWhile(value, end, true);
+        rule.append(value, p, end);
+        more = next < value.length()
+            && (value.charAt(next) == ',' || value.charAt(next) == '=' || (end != p && (value
+                .charAt(end - 1) == ',' || value.charAt(end - 1) == '=')));
+        p = next;
+      }
+      out.add("--host-alias");
+      out.add(rule.toString());
+    }
+    return out;
+  }
+
+  @Test
+  public void ruleSplitAgreesWithTheEngineSplitter() {
+    final char alphabet[] = { 'a', 'b', ',', '=', ' ', '\t', '\n' };
+    final java.util.Random random = new Random(20260811L);
+    for (int i = 0; i < 20000; i++) {
+      final StringBuilder value = new StringBuilder();
+      for (int j = random.nextInt(12); j > 0; j--) {
+        value.append(alphabet[random.nextInt(alphabet.length)]);
+      }
+      final String s = value.toString();
+      assertEquals(s, arglistOracle(s), emitRules(s));
+    }
+  }
+
   /* fieldsSerializer fixes the emission order but pulls in R.id, which the stub
      android.jar cannot load, so read the declared order out of the source. */
   private static List<String> serializerKeys() throws IOException {
@@ -317,5 +390,10 @@ public class OptionsEmissionTest {
     assertTrue("CurrentUrl missing", keys.contains("CurrentUrl"));
     assertTrue("-iC* must precede the URL",
         keys.indexOf("CurrentAction") < keys.indexOf("CurrentUrl"));
+  }
+
+  @Test
+  public void hostAliasIsWiredIntoTheProfile() throws IOException {
+    assertTrue("HostAlias missing", serializerKeys().contains("HostAlias"));
   }
 }

--- a/app/src/test/java/com/httrack/android/OptionsEmissionTest.java
+++ b/app/src/test/java/com/httrack/android/OptionsEmissionTest.java
@@ -308,6 +308,8 @@ public class OptionsEmissionTest {
   public void spacesAroundSeparatorsDoNotStartANewRule() {
     assertEquals(Arrays.asList("--host-alias", "a.com,b.com=c.com"),
         emitRules("a.com , b.com = c.com"));
+    assertEquals(Arrays.asList("--host-alias", "a.com,b.com=c.com"),
+        emitRules("a.com,\nb.com=\nc.com"));
   }
 
   @Test
@@ -325,8 +327,8 @@ public class OptionsEmissionTest {
     return i;
   }
 
-  /* cat_cmdline_arglist() from the engine's htsserver.c: the character loop the
-     regexp form has to agree with. */
+  /* cat_cmdline_arglist() from httrack#1166: the character loop WebHTTrack
+     splits its own field with, and the regexp form has to agree with. */
   private static List<String> arglistOracle(final String value) {
     final List<String> out = new ArrayList<String>();
     int p = skipWhile(value, 0, true);
@@ -350,11 +352,12 @@ public class OptionsEmissionTest {
 
   @Test
   public void ruleSplitAgreesWithTheEngineSplitter() {
-    final char alphabet[] = { 'a', 'b', ',', '=', ' ', '\t', '\n' };
-    final java.util.Random random = new Random(20260811L);
+    final char[] alphabet = { 'a', 'B', '.', '+', '-', ',', '=', ' ', '\t',
+        '\n' };
+    final Random random = new Random(20260811L);
     for (int i = 0; i < 20000; i++) {
       final StringBuilder value = new StringBuilder();
-      for (int j = random.nextInt(12); j > 0; j--) {
+      for (int j = random.nextInt(80); j > 0; j--) {
         value.append(alphabet[random.nextInt(alphabet.length)]);
       }
       final String s = value.toString();

--- a/app/src/test/java/com/httrack/android/OptionsEmissionTest.java
+++ b/app/src/test/java/com/httrack/android/OptionsEmissionTest.java
@@ -321,7 +321,7 @@ public class OptionsEmissionTest {
   }
 
   private static int skipWhile(final String s, int i, final boolean ws) {
-    while (i < s.length() && (" \t\r\n".indexOf(s.charAt(i)) >= 0) == ws) {
+    while (i < s.length() && (" \t\r\n\013\f".indexOf(s.charAt(i)) >= 0) == ws) {
       i++;
     }
     return i;
@@ -353,7 +353,7 @@ public class OptionsEmissionTest {
   @Test
   public void ruleSplitAgreesWithTheEngineSplitter() {
     final char[] alphabet = { 'a', 'B', '.', '+', '-', ',', '=', ' ', '\t',
-        '\n' };
+        '\n', '\013', '\f', '\001' };
     final Random random = new Random(20260811L);
     for (int i = 0; i < 20000; i++) {
       final StringBuilder value = new StringBuilder();


### PR DESCRIPTION
Adds a Host aliases field to the Experts only tab, so a site served under several hostnames is folded onto one and saved once instead of once per name. Each rule becomes its own `--host-alias` token. Rules split on whitespace, except beside a `,` or an `=`, where the whitespace holds one rule together and is dropped. That is the splitter WebHTTrack uses (xroche/httrack#1166, still open), so a profile written by one front end reads the same in the other. `profileEncode` already escapes newlines, so the multi-line field still lands on one `HostAlias=` line in `winprofile.ini`.

The option only became reachable with the submodule bump to 3.49.20, since `-%C` landed upstream in xroche/httrack#1156 after our previous pin. No engine source was added or removed over that range, so `Android.mk`'s hand-written list is untouched, and both ABIs' `libhttrack.so` carry the new strings. `versionName` stays `3.50-beta-3` for the beta, but the in-app version line now reports engine 3.49.20.

The splitter is checked against a transcription of that WebHTTrack character loop over 20k random inputs, since the two forms have to agree. A malformed rule is left to the engine, which validates and reports it, rather than being dropped silently here.