### PR TITLE
Host aliases sits three tabs away from the switch that gates it

### DIFF
--- a/app/src/main/java/com/httrack/android/OptionsActivity.java
+++ b/app/src/main/java/com/httrack/android/OptionsActivity.java
@@ -207,7 +207,8 @@ public class OptionsActivity extends FragmentActivity implements View.OnClickLis
   @Fields({ R.id.checkAcceptCookies, R.id.editCookiesFile,
       R.id.radioCheckDocumentType, R.id.checkParseJavaFiles, R.id.radioSpider,
       R.id.checkSitemap, R.id.editSitemapUrl, R.id.checkUpdateHacks,
-      R.id.checkUrlHacks, R.id.checkTolerentRequests, R.id.checkForceHttp10 })
+      R.id.checkUrlHacks, R.id.editHostAlias, R.id.checkTolerentRequests,
+      R.id.checkForceHttp10 })
   public static class Spider extends Tab {
   }
 
@@ -246,8 +247,7 @@ public class OptionsActivity extends FragmentActivity implements View.OnClickLis
   @HelpPage("guide.html#droid/opt-experts-only")
   @Fields({ R.id.checkUseCacheForUpdates, R.id.radioPrimaryScanRule,
       R.id.textTravelMode, R.id.radioTravelMode, R.id.radioGlobalTravelMode,
-      R.id.radioRewriteLinks, R.id.editStripQuery, R.id.editHostAlias,
-      R.id.checkActivateDebugging })
+      R.id.radioRewriteLinks, R.id.editStripQuery, R.id.checkActivateDebugging })
   public static class ExpertsOnly extends Tab {
   }
 

--- a/app/src/main/res/layout/activity_options_expertsonly.xml
+++ b/app/src/main/res/layout/activity_options_expertsonly.xml
@@ -205,19 +205,6 @@
                 android:inputType="textNoSuggestions" />
         </LinearLayout>
 
-        <TextView
-            android:id="@+id/textHostAlias"
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/host_alias" />
-
-        <EditText
-            android:id="@+id/editHostAlias"
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
-            android:hint="@string/hint_host_alias"
-            android:inputType="textMultiLine|textNoSuggestions" />
-
         <CheckBox
             android:id="@+id/checkActivateDebugging"
             android:layout_width="fill_parent"

--- a/app/src/main/res/layout/activity_options_spider.xml
+++ b/app/src/main/res/layout/activity_options_spider.xml
@@ -160,6 +160,19 @@
             android:layout_gravity="end"
             android:text="@string/url_hacks" />
 
+        <TextView
+            android:id="@+id/textHostAlias"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/host_alias" />
+
+        <EditText
+            android:id="@+id/editHostAlias"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/hint_host_alias"
+            android:inputType="textMultiLine|textNoSuggestions" />
+
         <CheckBox
             android:id="@+id/checkTolerentRequests"
             android:layout_width="fill_parent"

--- a/app/src/test/java/com/httrack/android/NumericFieldInputTypeTest.java
+++ b/app/src/test/java/com/httrack/android/NumericFieldInputTypeTest.java
@@ -37,35 +37,6 @@ public class NumericFieldInputTypeTest {
       { "editMinTransferRate", "J" }, { "editProxyPort", "P" },
       { "editSingleFileMaxSize", "--single-file-max-size" } };
 
-  /* Unit tests run with the app project as working directory. */
-  private static File resDir() {
-    for (final String path : new String[] { "src/main/res",
-        "app/src/main/res" }) {
-      final File dir = new File(path);
-      if (dir.isDirectory()) {
-        return dir;
-      }
-    }
-    throw new IllegalStateException("no res directory below "
-        + new File(".").getAbsolutePath());
-  }
-
-  /* Every layout, qualified variants such as layout-land/ included. */
-  private static Set<File> layouts() {
-    final Set<File> files = new HashSet<File>();
-    for (final File dir : resDir().listFiles()) {
-      if (!dir.isDirectory() || !dir.getName().startsWith("layout")) {
-        continue;
-      }
-      for (final File file : dir.listFiles()) {
-        if (file.getName().endsWith(".xml")) {
-          files.add(file);
-        }
-      }
-    }
-    return files;
-  }
-
   private static String option(final String id) {
     for (final String[] field : NUMERIC_FIELDS) {
       if (field[0].equals(id)) {
@@ -82,7 +53,7 @@ public class NumericFieldInputTypeTest {
     factory.setNamespaceAware(true);
     final DocumentBuilder builder = factory.newDocumentBuilder();
     final Set<String> seen = new HashSet<String>();
-    for (final File layout : layouts()) {
+    for (final File layout : TestSources.layouts()) {
       final Document doc = builder.parse(layout);
       final NodeList nodes = doc.getElementsByTagName("*");
       for (int i = 0; i < nodes.getLength(); i++) {

--- a/app/src/test/java/com/httrack/android/OptionsTabFieldsTest.java
+++ b/app/src/test/java/com/httrack/android/OptionsTabFieldsTest.java
@@ -1,0 +1,92 @@
+package com.httrack.android;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.junit.Test;
+
+/**
+ * A tab looks its declared fields up in its own inflated layout, and
+ * WidgetDataExchange throws on a view it cannot find, so an id left behind by a
+ * field that moved to another tab crashes that tab as soon as it is left.
+ */
+public class OptionsTabFieldsTest {
+  /** @ActivityId + @Fields of one tab, as declared in the source. */
+  private static final Pattern TAB = Pattern.compile(
+      "@ActivityId\\(R\\.layout\\.(\\w+)\\)(.*?)public static class",
+      Pattern.DOTALL);
+
+  private static final Pattern FIELD_ID = Pattern.compile("R\\.id\\.(\\w+)");
+
+  /* Unit tests run with the app project as working directory. */
+  private static File dir(final String path) {
+    for (final String prefix : new String[] { "", "app/" }) {
+      final File dir = new File(prefix + path);
+      if (dir.isDirectory()) {
+        return dir;
+      }
+    }
+    throw new IllegalStateException("no " + path + " below "
+        + new File(".").getAbsolutePath());
+  }
+
+  /* Every qualified variant of LAYOUT, all of which may be inflated. */
+  private static List<File> layouts(final String layout) {
+    final List<File> files = new ArrayList<File>();
+    for (final File res : dir("src/main/res").listFiles()) {
+      if (!res.isDirectory() || !res.getName().startsWith("layout")) {
+        continue;
+      }
+      final File file = new File(res, layout + ".xml");
+      if (file.isFile()) {
+        files.add(file);
+      }
+    }
+    return files;
+  }
+
+  private static Set<String> declaredIds(final File layout) throws IOException {
+    final Set<String> ids = new HashSet<String>();
+    final Matcher m = Pattern.compile("android:id=\"@\\+?id/(\\w+)\"").matcher(
+        new String(Files.readAllBytes(layout.toPath()), "UTF-8"));
+    while (m.find()) {
+      ids.add(m.group(1));
+    }
+    return ids;
+  }
+
+  @Test
+  public void everyTabFieldLivesInThatTabsLayout() throws IOException {
+    final String src = new String(Files.readAllBytes(Paths
+        .get(dir("src/main/java").getPath(),
+            "com/httrack/android/OptionsActivity.java")), "UTF-8");
+    final Matcher tab = TAB.matcher(src);
+    int tabs = 0;
+    int fields = 0;
+    while (tab.find()) {
+      final String layout = tab.group(1);
+      final List<File> files = layouts(layout);
+      assertTrue("no layout named " + layout, !files.isEmpty());
+      final Matcher id = FIELD_ID.matcher(tab.group(2));
+      tabs++;
+      while (id.find()) {
+        fields++;
+        for (final File file : files) {
+          assertTrue(file.getName() + " has no " + id.group(1),
+              declaredIds(file).contains(id.group(1)));
+        }
+      }
+    }
+    assertTrue("parsed " + tabs + " tabs", tabs > 10);
+    assertTrue("parsed " + fields + " fields", fields > 80);
+  }
+}

--- a/app/src/test/java/com/httrack/android/OptionsTabFieldsTest.java
+++ b/app/src/test/java/com/httrack/android/OptionsTabFieldsTest.java
@@ -15,9 +15,8 @@ import java.util.regex.Pattern;
 import org.junit.Test;
 
 /**
- * A tab looks its declared fields up in its own inflated layout, and
- * WidgetDataExchange throws on a view it cannot find, so an id left behind by a
- * field that moved to another tab crashes that tab as soon as it is left.
+ * A tab's declared field must be in that tab's own layout: leaving the tab
+ * looks it up, and WidgetDataExchange throws on a view it cannot find.
  */
 public class OptionsTabFieldsTest {
   /** @ActivityId + @Fields of one tab, as declared in the source. */

--- a/app/src/test/java/com/httrack/android/OptionsTabFieldsTest.java
+++ b/app/src/test/java/com/httrack/android/OptionsTabFieldsTest.java
@@ -1,14 +1,16 @@
 package com.httrack.android;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -26,66 +28,80 @@ public class OptionsTabFieldsTest {
 
   private static final Pattern FIELD_ID = Pattern.compile("R\\.id\\.(\\w+)");
 
-  /* Unit tests run with the app project as working directory. */
-  private static File dir(final String path) {
-    for (final String prefix : new String[] { "", "app/" }) {
-      final File dir = new File(prefix + path);
-      if (dir.isDirectory()) {
-        return dir;
-      }
-    }
-    throw new IllegalStateException("no " + path + " below "
-        + new File(".").getAbsolutePath());
-  }
+  private static final Pattern LAYOUT_ID = Pattern
+      .compile("android:id=\"@\\+?id/(\\w+)\"");
 
-  /* Every qualified variant of LAYOUT, all of which may be inflated. */
-  private static List<File> layouts(final String layout) {
-    final List<File> files = new ArrayList<File>();
-    for (final File res : dir("src/main/res").listFiles()) {
-      if (!res.isDirectory() || !res.getName().startsWith("layout")) {
-        continue;
-      }
-      final File file = new File(res, layout + ".xml");
-      if (file.isFile()) {
-        files.add(file);
-      }
-    }
-    return files;
-  }
-
-  private static Set<String> declaredIds(final File layout) throws IOException {
-    final Set<String> ids = new HashSet<String>();
-    final Matcher m = Pattern.compile("android:id=\"@\\+?id/(\\w+)\"").matcher(
-        new String(Files.readAllBytes(layout.toPath()), "UTF-8"));
+  private static List<String> ids(final Pattern pattern, final String text) {
+    final List<String> ids = new ArrayList<String>();
+    final Matcher m = pattern.matcher(text);
     while (m.find()) {
       ids.add(m.group(1));
     }
     return ids;
   }
 
+  /** Layout of each option tab, with the field ids that tab declares. */
+  private static Map<String, List<String>> tabs() throws IOException {
+    final Map<String, List<String>> tabs = new LinkedHashMap<String, List<String>>();
+    final Matcher tab = TAB.matcher(TestSources.javaSource("OptionsActivity"));
+    while (tab.find()) {
+      final List<String> fields = ids(FIELD_ID, tab.group(2));
+      // An annotation order this pattern cannot read would yield none.
+      assertFalse("no field parsed for " + tab.group(1), fields.isEmpty());
+      assertFalse("twice: " + tab.group(1), tabs.containsKey(tab.group(1)));
+      tabs.put(tab.group(1), fields);
+    }
+    assertTrue("parsed " + tabs.size() + " tabs", tabs.size() > 10);
+    return tabs;
+  }
+
   @Test
   public void everyTabFieldLivesInThatTabsLayout() throws IOException {
-    final String src = new String(Files.readAllBytes(Paths
-        .get(dir("src/main/java").getPath(),
-            "com/httrack/android/OptionsActivity.java")), "UTF-8");
-    final Matcher tab = TAB.matcher(src);
-    int tabs = 0;
-    int fields = 0;
-    while (tab.find()) {
-      final String layout = tab.group(1);
-      final List<File> files = layouts(layout);
-      assertTrue("no layout named " + layout, !files.isEmpty());
-      final Matcher id = FIELD_ID.matcher(tab.group(2));
-      tabs++;
-      while (id.find()) {
-        fields++;
-        for (final File file : files) {
-          assertTrue(file.getName() + " has no " + id.group(1),
-              declaredIds(file).contains(id.group(1)));
+    for (final Map.Entry<String, List<String>> tab : tabs().entrySet()) {
+      final List<File> files = TestSources.layouts(tab.getKey());
+      assertFalse("no layout named " + tab.getKey(), files.isEmpty());
+      for (final File file : files) {
+        final Set<String> declared = new HashSet<String>(ids(LAYOUT_ID,
+            TestSources.read(file)));
+        for (final String field : tab.getValue()) {
+          assertTrue(file.getName() + " has no " + field,
+              declared.contains(field));
         }
       }
     }
-    assertTrue("parsed " + tabs + " tabs", tabs > 10);
-    assertTrue("parsed " + fields + " fields", fields > 80);
+  }
+
+  /* The other direction: a view the mapper knows but no tab claims is never
+     saved, and nothing at runtime says so. */
+  @Test
+  public void everyMappedOptionViewIsClaimedByATab() throws IOException {
+    final Set<String> mapped = new HashSet<String>(ids(FIELD_ID,
+        TestSources.javaSource("OptionsMapper")));
+    assertTrue("parsed " + mapped.size() + " mapped ids", mapped.size() > 80);
+    final Map<String, List<String>> tabs = tabs();
+    int claimed = 0;
+    for (final File file : TestSources.layouts()) {
+      if (!file.getName().startsWith("activity_options_")) {
+        continue;
+      }
+      final String layout = file.getName().replaceFirst("\\.xml$", "");
+      for (final String id : ids(LAYOUT_ID, TestSources.read(file))) {
+        if (!mapped.contains(id)) {
+          continue;
+        }
+        final List<String> owners = new ArrayList<String>();
+        for (final Map.Entry<String, List<String>> tab : tabs.entrySet()) {
+          if (tab.getValue().contains(id)) {
+            owners.add(tab.getKey());
+          }
+        }
+        assertEquals(id + " in " + layout + " claimed by " + owners, 1,
+            owners.size());
+        assertEquals(id + " is claimed by " + owners.get(0), layout,
+            owners.get(0));
+        claimed++;
+      }
+    }
+    assertTrue("checked " + claimed + " views", claimed > 50);
   }
 }

--- a/app/src/test/java/com/httrack/android/TestSources.java
+++ b/app/src/test/java/com/httrack/android/TestSources.java
@@ -1,0 +1,58 @@
+package com.httrack.android;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+
+/** Checked-in sources the tests read; they run with the app project as
+ *  working directory. */
+final class TestSources {
+  private TestSources() {
+  }
+
+  private static File dir(final String path) {
+    for (final String prefix : new String[] { "", "app/" }) {
+      final File dir = new File(prefix + path);
+      if (dir.isDirectory()) {
+        return dir;
+      }
+    }
+    throw new IllegalStateException("no " + path + " below "
+        + new File(".").getAbsolutePath());
+  }
+
+  /** Every layout, qualified variants such as layout-land/ included. */
+  static List<File> layouts() {
+    return layouts(null);
+  }
+
+  /** Every variant of NAME, all of which may be inflated; every layout when
+   *  NAME is null. */
+  static List<File> layouts(final String name) {
+    final List<File> files = new ArrayList<File>();
+    for (final File res : dir("src/main/res").listFiles()) {
+      if (!res.isDirectory() || !res.getName().startsWith("layout")) {
+        continue;
+      }
+      for (final File file : res.listFiles()) {
+        if (name == null ? file.getName().endsWith(".xml")
+            : file.getName().equals(name + ".xml")) {
+          files.add(file);
+        }
+      }
+    }
+    return files;
+  }
+
+  static String read(final File file) throws IOException {
+    return new String(Files.readAllBytes(file.toPath()), "UTF-8");
+  }
+
+  /** Source of the com.httrack.android class NAME. */
+  static String javaSource(final String name) throws IOException {
+    return read(new File(dir("src/main/java"), "com/httrack/android/" + name
+        + ".java"));
+  }
+}


### PR DESCRIPTION
The engine folds a `www.` alias only when URL hacks is on (`hts_host_alias_collapse_www` is `urlhack && !no_www_dedup`), and URL hacks is a Spider option, so Host aliases moves there from Experts only. WinHTTrack puts the field on its Spider pane next to `IDC_urlhack`, WebHTTrack renders it on `option8.html`, and `guide.html` documents it inside the `opt-spider` section, so the tab's Help link now lands on a page that describes the field. Emission is untouched: `fieldsSerializer` still fixes the argv order and the profile key is the same, so saved projects keep working.

A field left in the wrong tab's list crashes that tab when you leave it. The new test reads each tab's ids out of `OptionsActivity.java` and checks them against that tab's layout; leaving the id in the Experts list fails it.
