### PR TITLE
The default HTML footer teaches %s, which breaks any field a user adds

### DIFF
--- a/app/src/main/java/com/httrack/android/OptionsMapper.java
+++ b/app/src/main/java/com/httrack/android/OptionsMapper.java
@@ -234,8 +234,10 @@ public class OptionsMapper {
       new Pair<String, String>("KeepWwwPrefix", "0"),
       new Pair<String, String>("KeepDoubleSlashes", "0"),
       new Pair<String, String>("KeepQueryOrder", "0"),
+      /* A single %s anywhere puts the whole template back on the engine's
+       * legacy positional path, where named fields render verbatim. */
       new Pair<String, String>("Footer",
-          "<!-- Mirrored from %s%s by HTTrack Website Copier/3.x [XR&CO'2026], %s -->"),
+          "<!-- Mirrored from {url} by HTTrack Website Copier/3.x [XR&CO'2026], {date} -->"),
       new Pair<String, String>("AcceptLanguage", "en,*"),
       new Pair<String, String>("OtherHeaders", ""),
       new Pair<String, String>("DefaultReferer", ""),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -121,7 +121,7 @@
     <string name="keep_double_slashes">Keep double slashes (//)</string>
     <string name="keep_query_order">Keep query-string order (?b&amp;a)</string>
     <string name="hint_browser_identity">Mozilla/5.0 (compatible; HTTrack; +https://www.httrack.com/)</string>
-    <string name="hint_footer" formatted="false">&lt;!-- Mirrored from %s%s by HTTrack Website Copier/3.x [XR&amp;CO\'2026], %s --&gt;</string>
+    <string name="hint_footer">&lt;!-- Mirrored from {url} by HTTrack Website Copier/3.x [XR&amp;CO\'2026], {date} --&gt;</string>
     <string name="use_proxy_for_ftp">Use proxy for ftp transfers</string>
     <string name="store_all_files_in_cache">Store ALL files in cache</string>
     <string name="do_not_redownload_locally_erased_files">Do not re-download locally erased files</string>

--- a/app/src/test/java/com/httrack/android/FooterDefaultTest.java
+++ b/app/src/test/java/com/httrack/android/FooterDefaultTest.java
@@ -1,0 +1,54 @@
+package com.httrack.android;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.junit.Test;
+
+/**
+ * The default -%F template must use the engine's named fields: one %s anywhere
+ * selects the legacy positional path, which renders {url} verbatim.
+ */
+public class FooterDefaultTest {
+  private static final Pattern MAPPER_DEFAULT = Pattern.compile(
+      "\"Footer\",\\s*\"(.*?)\"\\)", Pattern.DOTALL);
+
+  private static final Pattern HINT = Pattern
+      .compile("<string name=\"hint_footer\"[^>]*>(.*?)</string>", Pattern.DOTALL);
+
+  private static String group(final Pattern pattern, final String text) {
+    final Matcher m = pattern.matcher(text);
+    assertTrue("no match for " + pattern, m.find());
+    return m.group(1);
+  }
+
+  /** Android string-resource escaping, enough for this one string. */
+  private static String unescape(final String value) {
+    return value.replace("&lt;", "<").replace("&gt;", ">").replace("\\'", "'")
+        .replace("&amp;", "&");
+  }
+
+  private static String mapperDefault() throws IOException {
+    return group(MAPPER_DEFAULT, TestSources.javaSource("OptionsMapper"));
+  }
+
+  @Test
+  public void defaultUsesNamedFields() throws IOException {
+    final String footer = mapperDefault();
+    assertFalse(footer, footer.contains("%s"));
+    assertTrue(footer, footer.contains("{url}"));
+    assertTrue(footer, footer.contains("{date}"));
+  }
+
+  /** The hint shows the field's own default, so it must not teach %s either. */
+  @Test
+  public void hintMatchesTheDefault() throws IOException {
+    final String hint = unescape(group(HINT,
+        TestSources.read(TestSources.resFile("values/strings.xml"))));
+    assertEquals(mapperDefault(), hint);
+  }
+}

--- a/app/src/test/java/com/httrack/android/FooterDefaultTest.java
+++ b/app/src/test/java/com/httrack/android/FooterDefaultTest.java
@@ -44,6 +44,15 @@ public class FooterDefaultTest {
     assertTrue(footer, footer.contains("{date}"));
   }
 
+  /** Both strings agreeing on the wrong text would satisfy the field check. */
+  @Test
+  public void defaultIsAnHttrackComment() throws IOException {
+    final String footer = mapperDefault();
+    assertTrue(footer, footer.startsWith("<!--"));
+    assertTrue(footer, footer.endsWith("-->"));
+    assertTrue(footer, footer.contains("HTTrack Website Copier"));
+  }
+
   /** The hint shows the field's own default, so it must not teach %s either. */
   @Test
   public void hintMatchesTheDefault() throws IOException {

--- a/app/src/test/java/com/httrack/android/TestSources.java
+++ b/app/src/test/java/com/httrack/android/TestSources.java
@@ -46,6 +46,11 @@ final class TestSources {
     return files;
   }
 
+  /** A file below res/, such as "values/strings.xml". */
+  static File resFile(final String name) {
+    return new File(dir("src/main/res"), name);
+  }
+
   static String read(final File file) throws IOException {
     return new String(Files.readAllBytes(file.toPath()), "UTF-8");
   }


### PR DESCRIPTION
The default `-%F` template used the positional `%s%s ... %s` form, and one `%s` anywhere in the string puts the whole template on the engine's legacy positional path. Append `{mime}` to it and the braces reach every saved page verbatim.

Named fields have been the documented model since xroche/httrack#667 and the pinned engine already substitutes them, so nothing here needs a submodule bump. Existing projects keep the footer they saved; only new projects pick up the new default. The hint under the field showed the same positional form, so it moves too, and a test keeps the two from drifting apart.

One visible difference: `{url}` carries the scheme, which the old pair could not, because the engine strips it from the host before substituting positionally. New mirrors read `Mirrored from http://example.com/a/b.html` where they used to read `Mirrored from example.com/a/b.html`. Host, path and date are unchanged.