### PR TITLE
The default HTML footer bakes in a year that goes stale

### DIFF
--- a/app/src/main/java/com/httrack/android/OptionsMapper.java
+++ b/app/src/main/java/com/httrack/android/OptionsMapper.java
@@ -237,7 +237,7 @@ public class OptionsMapper {
       /* A single %s anywhere puts the whole template back on the engine's
        * legacy positional path, where named fields render verbatim. */
       new Pair<String, String>("Footer",
-          "<!-- Mirrored from {url} by HTTrack Website Copier/3.x [XR&CO'2026], {date} -->"),
+          "<!-- Mirrored from {url} by HTTrack Website Copier/3.x [XR&CO], {date} -->"),
       new Pair<String, String>("AcceptLanguage", "en,*"),
       new Pair<String, String>("OtherHeaders", ""),
       new Pair<String, String>("DefaultReferer", ""),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -121,7 +121,7 @@
     <string name="keep_double_slashes">Keep double slashes (//)</string>
     <string name="keep_query_order">Keep query-string order (?b&amp;a)</string>
     <string name="hint_browser_identity">Mozilla/5.0 (compatible; HTTrack; +https://www.httrack.com/)</string>
-    <string name="hint_footer">&lt;!-- Mirrored from {url} by HTTrack Website Copier/3.x [XR&amp;CO\'2026], {date} --&gt;</string>
+    <string name="hint_footer">&lt;!-- Mirrored from {url} by HTTrack Website Copier/3.x [XR&amp;CO], {date} --&gt;</string>
     <string name="use_proxy_for_ftp">Use proxy for ftp transfers</string>
     <string name="store_all_files_in_cache">Store ALL files in cache</string>
     <string name="do_not_redownload_locally_erased_files">Do not re-download locally erased files</string>

--- a/app/src/test/java/com/httrack/android/FooterDefaultTest.java
+++ b/app/src/test/java/com/httrack/android/FooterDefaultTest.java
@@ -53,6 +53,13 @@ public class FooterDefaultTest {
     assertTrue(footer, footer.contains("HTTrack Website Copier"));
   }
 
+  /** {date} already dates the footer, so a baked year only goes stale. */
+  @Test
+  public void defaultCarriesNoYear() throws IOException {
+    final String footer = mapperDefault();
+    assertFalse(footer, Pattern.compile("\\d{4}").matcher(footer).find());
+  }
+
   /** The hint shows the field's own default, so it must not teach %s either. */
   @Test
   public void hintMatchesTheDefault() throws IOException {


### PR DESCRIPTION
The -%F default read `[XR&CO'2026]`, and every page it writes already carries its own `{date}`, so the year is redundant the day it stops being current. Engine PR xroche/httrack#1243 drops the year from `HTTRACK_AFF_AUTHORS` for the same reason; this is the hand-kept Android copy following.

Existing projects keep the footer they saved. The hint under the field shows the default, so it moves too, and a test now fails on any four-digit year in it.