### PR TITLE
Four option boxes drive the engine the wrong way

### DIFF
--- a/app/src/main/java/com/httrack/android/OptionsMapper.java
+++ b/app/src/main/java/com/httrack/android/OptionsMapper.java
@@ -32,8 +32,10 @@ import java.io.OutputStreamWriter;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.regex.Pattern;
 
 import android.content.Context;
@@ -364,7 +366,10 @@ public class OptionsMapper {
       new Pair<String, OptionMapper>("Index", new SimpleOptionFlag("I0", true)),
       new Pair<String, OptionMapper>("WordIndex", new SimpleOptionFlag("%I")),
       new Pair<String, OptionMapper>("MailIndex", new SimpleOptionFlag("%M")),
-      new Pair<String, OptionMapper>("Cache", new SimpleOptionFlag("C0", true)), /* FIXME */
+      /* Checked is -C2, revalidate before reuse, not the engine's bare default
+         of preferring whatever the cache holds. */
+      new Pair<String, OptionMapper>("Cache", new MultipleChoicesOption(
+          new String[] { "C0", "C2" })),
       new Pair<String, OptionMapper>("PrimaryScan",
           primaryScanHandler.getTypeMapper()),
       new Pair<String, OptionMapper>("Travel", MultipleChoicesOption.TRAVEL),
@@ -406,16 +411,103 @@ public class OptionsMapper {
       new Pair<String, OptionMapper>("MIMEDefsMime8",
           mimeTypesHandlers[7].getMimeMapper()) };
 
-  // Spellings earlier builds wrote; accepted on read, never written back.
-  @SuppressWarnings("unchecked")
-  protected static final Pair<String, String> fieldsLegacyNames[] = new Pair[] {
-      new Pair<String, String>("ProxyProtocol", "ProxyType"),
-      new Pair<String, String>("KeepWwwPrefix", "KeepWww"),
-      new Pair<String, String>("KeepDoubleSlashes", "KeepSlashes") };
+  /**
+   * What a winprofile.ini key means, kept out of the tables above so tests can
+   * reach it: the stub android.jar nulls Pair's fields and throws on
+   * SparseArray.
+   */
+  public static class ProfileFormat {
+    // Spellings earlier builds wrote; accepted on read, never written back.
+    private static final String LEGACY_NAMES[][] = {
+        { "ProxyProtocol", "ProxyType" }, { "KeepWwwPrefix", "KeepWww" },
+        { "KeepDoubleSlashes", "KeepSlashes" } };
 
-  // WinHTTrack packs both name-mangling boxes in Dos; Iso9660 is ours alone.
-  private static final String DOS_KEY = "Dos";
-  private static final String ISO9660_KEY = "Iso9660";
+    // WinHTTrack packs both name-mangling boxes in Dos; Iso9660 is ours alone.
+    static final String DOS_KEY = "Dos";
+    static final String ISO9660_KEY = "Iso9660";
+
+    /** Current spelling of KEY, which is KEY itself unless it was renamed. */
+    static String canonicalName(final String key) {
+      for (final String[] legacy : LEGACY_NAMES) {
+        if (legacy[0].equals(key)) {
+          return legacy[1];
+        }
+      }
+      return key;
+    }
+
+    /** Spelling an earlier build used for KEY, or null if it never changed. */
+    static String legacyName(final String key) {
+      for (final String[] legacy : LEGACY_NAMES) {
+        if (legacy[1].equals(key)) {
+          return legacy[0];
+        }
+      }
+      return null;
+    }
+
+    /**
+     * Pack both name-mangling boxes as WinHTTrack does: bit 0 is Dos, bit 1 is
+     * Iso9660, each "1" when checked.
+     *
+     * @return the packed value
+     */
+    static String pack(final String dos, final String iso9660) {
+      return String.valueOf(("1".equals(dos) ? 1 : 0)
+          | ("1".equals(iso9660) ? 2 : 0));
+    }
+
+    /*
+     * Split a packed value, or null when it holds no number.
+     */
+    private static String[] unpack(final String packed) {
+      final int bits;
+      try {
+        bits = Integer.parseInt(packed.trim());
+      } catch (final NumberFormatException nfe) {
+        return null;
+      }
+      return new String[] { (bits & 1) != 0 ? "1" : "0",
+          (bits & 2) != 0 ? "1" : "0" };
+    }
+
+    /**
+     * Settings the raw key/value pairs of a profile stand for, under their
+     * current names.
+     *
+     * @param raw
+     *          exactly what the file held, so an absent key stays absent
+     * @return the settings, with the Dos bitmask split into its two boxes
+     */
+    static Map<String, String> resolve(final Map<String, String> raw) {
+      final Map<String, String> values = new LinkedHashMap<String, String>();
+      for (final Map.Entry<String, String> entry : raw.entrySet()) {
+        values.put(canonicalName(entry.getKey()), entry.getValue());
+      }
+      // An explicit Iso9660 wins: older profiles wrote Dos as a plain boolean
+      // beside it.
+      if (raw.containsKey(DOS_KEY) && !raw.containsKey(ISO9660_KEY)) {
+        final String[] boxes = unpack(values.get(DOS_KEY));
+        if (boxes != null) {
+          values.put(DOS_KEY, boxes[0]);
+          values.put(ISO9660_KEY, boxes[1]);
+        }
+      }
+      return values;
+    }
+
+    /**
+     * Inverse of {@link #resolve}: what the file holds for these settings.
+     *
+     * @return the pairs to write, Iso9660 folded into Dos and so absent
+     */
+    static Map<String, String> toFile(final Map<String, String> values) {
+      final Map<String, String> file = new LinkedHashMap<String, String>(values);
+      file.put(DOS_KEY, pack(values.get(DOS_KEY), values.get(ISO9660_KEY)));
+      file.remove(ISO9660_KEY);
+      return file;
+    }
+  }
 
   // Name-to-ID hash map
   protected static final HashMap<String, Integer> fieldsNameToId = new HashMap<String, Integer>();
@@ -801,32 +893,6 @@ public class OptionsMapper {
       }
     }
 
-    /**
-     * Pack both boxes the way WinHTTrack stores them: bit 0 DOS names, bit 1
-     * ISO 9660, each box "1" when checked.
-     */
-    public static String pack(final String dos, final String iso9660) {
-      return String.valueOf(("1".equals(dos) ? 1 : 0)
-          | ("1".equals(iso9660) ? 2 : 0));
-    }
-
-    /**
-     * Split a packed value into { dos, iso9660 }, or null when it holds no
-     * number, which leaves both boxes on their defaults.
-     */
-    public static String[] unpack(final String packed) {
-      if (packed == null) {
-        return null;
-      }
-      final int bits;
-      try {
-        bits = Integer.parseInt(packed.trim());
-      } catch (final NumberFormatException nfe) {
-        return null;
-      }
-      return new String[] { (bits & 1) != 0 ? "1" : "0",
-          (bits & 2) != 0 ? "1" : "0" };
-    }
   }
 
   /**
@@ -1406,38 +1472,6 @@ public class OptionsMapper {
       }
       fieldsNameToId.put(fkey, id);
     }
-    for (final Pair<String, String> legacy : fieldsLegacyNames) {
-      final Integer id = fieldsNameToId.get(legacy.second);
-      if (id == null) {
-        throw new RuntimeException("unexpected internal error with "
-            + legacy.second);
-      }
-      fieldsNameToId.put(legacy.first, id);
-    }
-  }
-
-  /*
-   * The spelling an earlier build used for this key, or null if unchanged.
-   */
-  private static String legacyNameOf(final String key) {
-    for (final Pair<String, String> legacy : fieldsLegacyNames) {
-      if (legacy.second.equals(key)) {
-        return legacy.first;
-      }
-    }
-    return null;
-  }
-
-  /*
-   * Expand a stored Dos bitmask into the two boxes it packs.
-   */
-  private static void splitDosBitmask(final SparseArray<String> map) {
-    final String[] boxes = DosIso9660Handler.unpack(map.get(fieldsNameToId
-        .get(DOS_KEY)));
-    if (boxes != null) {
-      map.put(fieldsNameToId.get(DOS_KEY), boxes[0]);
-      map.put(fieldsNameToId.get(ISO9660_KEY), boxes[1]);
-    }
   }
 
   /*
@@ -1705,9 +1739,7 @@ public class OptionsMapper {
     final FileReader reader = new FileReader(profile);
     final BufferedReader lreader = new BufferedReader(reader);
     try {
-      // An explicit Iso9660 wins: older profiles of ours wrote Dos as a plain
-      // boolean beside it.
-      boolean hasIso9660 = false;
+      final Map<String, String> raw = new LinkedHashMap<String, String>();
       String rawline;
       while ((rawline = lreader.readLine()) != null) {
         final String line = rawline.trim();
@@ -1716,18 +1748,16 @@ public class OptionsMapper {
         }
         final int sep = line.indexOf('=');
         if (sep != -1) {
-          final String key = line.substring(0, sep);
-          final String value = OptionsMapper.profileDecode(line
-              .substring(sep + 1));
-          final Integer id = OptionsMapper.fieldsNameToId.get(key);
-          if (id != null) {
-            map.put(id, value);
-            hasIso9660 |= ISO9660_KEY.equals(key);
-          }
+          raw.put(line.substring(0, sep),
+              OptionsMapper.profileDecode(line.substring(sep + 1)));
         }
       }
-      if (!hasIso9660) {
-        splitDosBitmask(map);
+      for (final Map.Entry<String, String> field : ProfileFormat.resolve(raw)
+          .entrySet()) {
+        final Integer id = OptionsMapper.fieldsNameToId.get(field.getKey());
+        if (id != null) {
+          map.put(id, field.getValue());
+        }
       }
       lreader.close();
     } finally {
@@ -1759,14 +1789,17 @@ public class OptionsMapper {
     final OutputStreamWriter writer = new OutputStreamWriter(fos);
     final BufferedWriter lwriter = new BufferedWriter(writer);
     try {
+      final Map<String, String> values = new LinkedHashMap<String, String>();
+      for (final Pair<Integer, String> field : OptionsMapper.fieldsSerializer) {
+        values.put(field.second, getMap(field.first));
+      }
+      final Map<String, String> file = ProfileFormat.toFile(values);
       for (final Pair<Integer, String> field : OptionsMapper.fieldsSerializer) {
         final String key = field.second;
-        if (ISO9660_KEY.equals(key)) {
-          continue; // folded into Dos
+        if (!file.containsKey(key)) {
+          continue;
         }
-        final String value = DOS_KEY.equals(key) ? DosIso9660Handler.pack(
-            getMap(field.first), getMap(fieldsNameToId.get(ISO9660_KEY)))
-            : getMap(field.first);
+        final String value = file.get(key);
         lwriter.write(key);
         lwriter.write("=");
         if (value != null) {
@@ -1873,7 +1906,7 @@ public class OptionsMapper {
         final String key = field.second;
         String value = settings.getString(key, null);
         if (value == null) {
-          final String legacy = legacyNameOf(key);
+          final String legacy = ProfileFormat.legacyName(key);
           if (legacy != null) {
             value = settings.getString(legacy, null);
           }
@@ -1905,6 +1938,11 @@ public class OptionsMapper {
         final String value = getMap(field.first);
         final String key = field.second;
         editor.putString(key, value);
+        // Make the rename one-way, so a stale copy can never win a later read.
+        final String legacy = ProfileFormat.legacyName(key);
+        if (legacy != null) {
+          editor.remove(legacy);
+        }
       }
       editor.commit();
     }

--- a/app/src/main/java/com/httrack/android/OptionsMapper.java
+++ b/app/src/main/java/com/httrack/android/OptionsMapper.java
@@ -461,6 +461,9 @@ public class OptionsMapper {
      * Split a packed value, or null when it holds no number.
      */
     private static String[] unpack(final String packed) {
+      if (packed == null) {
+        return null;
+      }
       final int bits;
       try {
         bits = Integer.parseInt(packed.trim());
@@ -1448,7 +1451,8 @@ public class OptionsMapper {
     @Override
     public void emit(final List<String> commandline, final String value) {
       if (OptionValues.isDigits(value)) {
-        final int choiceId = Integer.parseInt(value);
+        // All digits still overflows: a hand-edited profile reaches this.
+        final int choiceId = OptionValues.parseInt(value, -1);
         if (choiceId >= 0 && choiceId < choices.length) {
           final String choice = choices[choiceId];
           if (choice != null && choice.length() != 0) {

--- a/app/src/main/java/com/httrack/android/OptionsMapper.java
+++ b/app/src/main/java/com/httrack/android/OptionsMapper.java
@@ -93,8 +93,8 @@ public class OptionsMapper {
       new Pair<Integer, String>(R.id.checkGetNonHtmlNear, "Near"),
       new Pair<Integer, String>(R.id.checkTestAllLinks, "Test"),
       new Pair<Integer, String>(R.id.checkGetHtmlFirst, "HTMLFirst"),
-      new Pair<Integer, String>(R.id.checkKeepWwwPrefix, "KeepWwwPrefix"),
-      new Pair<Integer, String>(R.id.checkKeepDoubleSlashes, "KeepDoubleSlashes"),
+      new Pair<Integer, String>(R.id.checkKeepWwwPrefix, "KeepWww"),
+      new Pair<Integer, String>(R.id.checkKeepDoubleSlashes, "KeepSlashes"),
       new Pair<Integer, String>(R.id.checkKeepQueryOrder, "KeepQueryOrder"),
 
       /* Build */
@@ -134,7 +134,7 @@ public class OptionsMapper {
       new Pair<Integer, String>(R.id.checkForceHttp10, "HTTP10"),
 
       /* Proxy */
-      new Pair<Integer, String>(R.id.radioProxyProtocol, "ProxyProtocol"),
+      new Pair<Integer, String>(R.id.radioProxyProtocol, "ProxyType"),
       new Pair<Integer, String>(R.id.editProxy, "Proxy"),
       new Pair<Integer, String>(R.id.editProxyPort, "Port"),
       new Pair<Integer, String>(R.id.checkUseProxyForFtp, "UseHTTPProxyForFTP"),
@@ -230,9 +230,9 @@ public class OptionsMapper {
       new Pair<String, String>("BuildString", "%h%p/%n%q.%t"),
       // Empty: no -F, so the engine supplies its own current versioned User-Agent.
       new Pair<String, String>("UserID", ""),
-      new Pair<String, String>("ProxyProtocol", "0"),
-      new Pair<String, String>("KeepWwwPrefix", "0"),
-      new Pair<String, String>("KeepDoubleSlashes", "0"),
+      new Pair<String, String>("ProxyType", "0"),
+      new Pair<String, String>("KeepWww", "0"),
+      new Pair<String, String>("KeepSlashes", "0"),
       new Pair<String, String>("KeepQueryOrder", "0"),
       /* A single %s anywhere puts the whole template back on the engine's
        * legacy positional path, where named fields render verbatim. */
@@ -301,9 +301,10 @@ public class OptionsMapper {
           dosIso9660Handler.getIso9660Mapper()),
       new Pair<String, OptionMapper>("NoErrorPages", new SimpleOptionFlag("o0")),
       new Pair<String, OptionMapper>("NoExternalPages", new SimpleOptionFlag(
-          "x", true)),
+          "x")),
       new Pair<String, OptionMapper>("NoPwdInPages", new SimpleOptionFlag("%x")),
-      new Pair<String, OptionMapper>("NoQueryStrings", new SimpleOption0("%q")),
+      new Pair<String, OptionMapper>("NoQueryStrings", new SimpleOptionFlag(
+          "%q0")),
       new Pair<String, OptionMapper>("NoPurgeOldFiles", new SimpleOptionFlag(
           "X0")),
       new Pair<String, OptionMapper>("Warc", new SimpleOptionFlag("%r")),
@@ -331,7 +332,8 @@ public class OptionsMapper {
       new Pair<String, OptionMapper>("Cookies",
           new SimpleOptionFlag("b0", true)),
       new Pair<String, OptionMapper>("CheckType", new SimpleOption("u")),
-      new Pair<String, OptionMapper>("ParseJava", new SimpleOptionFlag("j",
+      /* Bare -j only re-asserts the engine default; switching it off needs -j0. */
+      new Pair<String, OptionMapper>("ParseJava", new SimpleOptionFlag("j0",
           true)),
       new Pair<String, OptionMapper>("FollowRobotsTxt", new SimpleOption("s")),
       new Pair<String, OptionMapper>("UpdateHack", new SimpleOptionFlag("%s")),
@@ -339,7 +341,7 @@ public class OptionsMapper {
       new Pair<String, OptionMapper>("TolerantRequests", new SimpleOptionFlag(
           "%B")),
       new Pair<String, OptionMapper>("HTTP10", new SimpleOptionFlag("%h")),
-      new Pair<String, OptionMapper>("ProxyProtocol",
+      new Pair<String, OptionMapper>("ProxyType",
           proxyHandler.getProtocolMapper()),
       new Pair<String, OptionMapper>("Proxy", proxyHandler.getAddressMapper()),
       new Pair<String, OptionMapper>("Port", proxyHandler.getPortMapper()),
@@ -348,8 +350,8 @@ public class OptionsMapper {
       new Pair<String, OptionMapper>("StripQuery", new ArgumentOption("-%g")),
       new Pair<String, OptionMapper>("HostAlias", new RuleListOption(
           "--host-alias")),
-      new Pair<String, OptionMapper>("KeepWwwPrefix", new SimpleOptionFlag("%j")),
-      new Pair<String, OptionMapper>("KeepDoubleSlashes", new SimpleOptionFlag(
+      new Pair<String, OptionMapper>("KeepWww", new SimpleOptionFlag("%j")),
+      new Pair<String, OptionMapper>("KeepSlashes", new SimpleOptionFlag(
           "%o")),
       new Pair<String, OptionMapper>("KeepQueryOrder", new SimpleOptionFlag("%y")),
       new Pair<String, OptionMapper>("UseHTTPProxyForFTP", new SimpleOption0(
@@ -403,6 +405,17 @@ public class OptionsMapper {
           mimeTypesHandlers[7].getExtMapper()),
       new Pair<String, OptionMapper>("MIMEDefsMime8",
           mimeTypesHandlers[7].getMimeMapper()) };
+
+  // Spellings earlier builds wrote; accepted on read, never written back.
+  @SuppressWarnings("unchecked")
+  protected static final Pair<String, String> fieldsLegacyNames[] = new Pair[] {
+      new Pair<String, String>("ProxyProtocol", "ProxyType"),
+      new Pair<String, String>("KeepWwwPrefix", "KeepWww"),
+      new Pair<String, String>("KeepDoubleSlashes", "KeepSlashes") };
+
+  // WinHTTrack packs both name-mangling boxes in Dos; Iso9660 is ours alone.
+  private static final String DOS_KEY = "Dos";
+  private static final String ISO9660_KEY = "Iso9660";
 
   // Name-to-ID hash map
   protected static final HashMap<String, Integer> fieldsNameToId = new HashMap<String, Integer>();
@@ -786,6 +799,33 @@ public class OptionsMapper {
           commandline.add(dos ? "-L0" : "-L2");
         }
       }
+    }
+
+    /**
+     * Pack both boxes the way WinHTTrack stores them: bit 0 DOS names, bit 1
+     * ISO 9660, each box "1" when checked.
+     */
+    public static String pack(final String dos, final String iso9660) {
+      return String.valueOf(("1".equals(dos) ? 1 : 0)
+          | ("1".equals(iso9660) ? 2 : 0));
+    }
+
+    /**
+     * Split a packed value into { dos, iso9660 }, or null when it holds no
+     * number, which leaves both boxes on their defaults.
+     */
+    public static String[] unpack(final String packed) {
+      if (packed == null) {
+        return null;
+      }
+      final int bits;
+      try {
+        bits = Integer.parseInt(packed.trim());
+      } catch (final NumberFormatException nfe) {
+        return null;
+      }
+      return new String[] { (bits & 1) != 0 ? "1" : "0",
+          (bits & 2) != 0 ? "1" : "0" };
     }
   }
 
@@ -1366,6 +1406,38 @@ public class OptionsMapper {
       }
       fieldsNameToId.put(fkey, id);
     }
+    for (final Pair<String, String> legacy : fieldsLegacyNames) {
+      final Integer id = fieldsNameToId.get(legacy.second);
+      if (id == null) {
+        throw new RuntimeException("unexpected internal error with "
+            + legacy.second);
+      }
+      fieldsNameToId.put(legacy.first, id);
+    }
+  }
+
+  /*
+   * The spelling an earlier build used for this key, or null if unchanged.
+   */
+  private static String legacyNameOf(final String key) {
+    for (final Pair<String, String> legacy : fieldsLegacyNames) {
+      if (legacy.second.equals(key)) {
+        return legacy.first;
+      }
+    }
+    return null;
+  }
+
+  /*
+   * Expand a stored Dos bitmask into the two boxes it packs.
+   */
+  private static void splitDosBitmask(final SparseArray<String> map) {
+    final String[] boxes = DosIso9660Handler.unpack(map.get(fieldsNameToId
+        .get(DOS_KEY)));
+    if (boxes != null) {
+      map.put(fieldsNameToId.get(DOS_KEY), boxes[0]);
+      map.put(fieldsNameToId.get(ISO9660_KEY), boxes[1]);
+    }
   }
 
   /*
@@ -1633,6 +1705,9 @@ public class OptionsMapper {
     final FileReader reader = new FileReader(profile);
     final BufferedReader lreader = new BufferedReader(reader);
     try {
+      // An explicit Iso9660 wins: older profiles of ours wrote Dos as a plain
+      // boolean beside it.
+      boolean hasIso9660 = false;
       String rawline;
       while ((rawline = lreader.readLine()) != null) {
         final String line = rawline.trim();
@@ -1647,8 +1722,12 @@ public class OptionsMapper {
           final Integer id = OptionsMapper.fieldsNameToId.get(key);
           if (id != null) {
             map.put(id, value);
+            hasIso9660 |= ISO9660_KEY.equals(key);
           }
         }
+      }
+      if (!hasIso9660) {
+        splitDosBitmask(map);
       }
       lreader.close();
     } finally {
@@ -1681,8 +1760,13 @@ public class OptionsMapper {
     final BufferedWriter lwriter = new BufferedWriter(writer);
     try {
       for (final Pair<Integer, String> field : OptionsMapper.fieldsSerializer) {
-        final String value = getMap(field.first);
         final String key = field.second;
+        if (ISO9660_KEY.equals(key)) {
+          continue; // folded into Dos
+        }
+        final String value = DOS_KEY.equals(key) ? DosIso9660Handler.pack(
+            getMap(field.first), getMap(fieldsNameToId.get(ISO9660_KEY)))
+            : getMap(field.first);
         lwriter.write(key);
         lwriter.write("=");
         if (value != null) {
@@ -1787,7 +1871,13 @@ public class OptionsMapper {
           continue;
         }
         final String key = field.second;
-        final String value = settings.getString(key, null);
+        String value = settings.getString(key, null);
+        if (value == null) {
+          final String legacy = legacyNameOf(key);
+          if (legacy != null) {
+            value = settings.getString(legacy, null);
+          }
+        }
         if (value != null) {
           setMap(field.first, value);
         }

--- a/app/src/test/java/com/httrack/android/WinProfileParityTest.java
+++ b/app/src/test/java/com/httrack/android/WinProfileParityTest.java
@@ -1,0 +1,178 @@
+package com.httrack.android;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import com.httrack.android.OptionsMapper.DosIso9660Handler;
+import com.httrack.android.OptionsMapper.OptionMapper;
+import com.httrack.android.OptionsMapper.SimpleOptionFlag;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.junit.Test;
+
+/** Holds winprofile.ini storage and option emission to WinHTTrack's conventions. */
+public class WinProfileParityTest {
+  private static List<String> emit(final OptionMapper mapper, final String value) {
+    final List<String> cmd = new ArrayList<String>();
+    mapper.emit(cmd, value);
+    return cmd;
+  }
+
+  /* The mapper table pulls in R.id, which the stub android.jar cannot load, so
+     the declarations are read out of the source. */
+  private static Map<String, String> mapperTable() throws IOException {
+    final String src = TestSources.javaSource("OptionsMapper");
+    final Matcher m = Pattern.compile(
+        "new Pair<String, OptionMapper>\\(\"([^\"]+)\",\\s*"
+            + "(new \\w+\\([^)]*\\)|[\\w.]+\\(\\))").matcher(src);
+    final Map<String, String> table = new HashMap<String, String>();
+    while (m.find()) {
+      table.put(m.group(1), m.group(2).replaceAll("\\s+", " "));
+    }
+    assertTrue("no mapper declarations parsed", table.size() > 50);
+    return table;
+  }
+
+  private static List<String> serializerKeys() throws IOException {
+    final String src = TestSources.javaSource("OptionsMapper");
+    final Matcher m = Pattern.compile(
+        "new Pair<Integer, String>\\(R\\.id\\.\\w+,\\s*\"([^\"]+)\"\\)")
+        .matcher(src);
+    final List<String> keys = new ArrayList<String>();
+    while (m.find()) {
+      keys.add(m.group(1));
+    }
+    assertTrue("no serializer keys parsed", keys.size() > 50);
+    return keys;
+  }
+
+  /* -x turns external links into error pages, and the engine defaults it off. */
+  @Test
+  public void noExternalPagesEmitsWhenChecked() throws IOException {
+    assertEquals("new SimpleOptionFlag( \"x\")",
+        mapperTable().get("NoExternalPages"));
+    assertEquals(Arrays.asList("-x"), emit(new SimpleOptionFlag("x"), "1"));
+    assertTrue(emit(new SimpleOptionFlag("x"), "0").isEmpty());
+  }
+
+  /* -%q includes query strings and -%q0 drops them; the box hides them. */
+  @Test
+  public void hideQueryStringsEmitsTheDisablingForm() throws IOException {
+    assertEquals("new SimpleOptionFlag( \"%q0\")",
+        mapperTable().get("NoQueryStrings"));
+    assertEquals(Arrays.asList("-%q0"), emit(new SimpleOptionFlag("%q0"), "1"));
+    assertTrue(emit(new SimpleOptionFlag("%q0"), "0").isEmpty());
+  }
+
+  /* Bare -j re-asserts the engine default, so unticking the box needs -j0. */
+  @Test
+  public void parseJavaTurnsOffWithTheZeroForm() throws IOException {
+    assertEquals("new SimpleOptionFlag(\"j0\", true)",
+        mapperTable().get("ParseJava"));
+    assertEquals(Arrays.asList("-j0"),
+        emit(new SimpleOptionFlag("j0", true), "0"));
+    assertTrue(emit(new SimpleOptionFlag("j0", true), "1").isEmpty());
+  }
+
+  /* No flag body may re-assert an engine default to express "off". */
+  @Test
+  public void noRevertedFlagEmitsABareEnablingForm() throws IOException {
+    final Matcher m = Pattern.compile(
+        "new SimpleOptionFlag\\(\\s*\"([^\"]+)\",\\s*true\\s*\\)").matcher(
+        TestSources.javaSource("OptionsMapper"));
+    int seen = 0;
+    while (m.find()) {
+      seen++;
+      assertTrue("-" + m.group(1) + " must carry its 0 form", m.group(1)
+          .endsWith("0"));
+    }
+    assertTrue("no reverted flags parsed", seen > 0);
+  }
+
+  @Test
+  public void keysUseTheWinHttrackSpelling() throws IOException {
+    final List<String> keys = serializerKeys();
+    for (final String key : new String[] { "ProxyType", "KeepWww",
+        "KeepSlashes" }) {
+      assertTrue(key + " missing", keys.contains(key));
+    }
+    for (final String legacy : new String[] { "ProxyProtocol",
+        "KeepWwwPrefix", "KeepDoubleSlashes" }) {
+      assertFalse(legacy + " still written", keys.contains(legacy));
+    }
+  }
+
+  /* Renaming a key would silently reset it on every profile already saved. */
+  @Test
+  public void everyRenamedKeyKeepsItsOldSpellingReadable() throws IOException {
+    final String src = TestSources.javaSource("OptionsMapper");
+    final Matcher m = Pattern.compile(
+        "new Pair<String, String>\\(\"(ProxyProtocol|KeepWwwPrefix"
+            + "|KeepDoubleSlashes)\",\\s*\"(\\w+)\"\\)").matcher(src);
+    final Map<String, String> aliases = new HashMap<String, String>();
+    while (m.find()) {
+      aliases.put(m.group(1), m.group(2));
+    }
+    assertEquals("ProxyType", aliases.get("ProxyProtocol"));
+    assertEquals("KeepWww", aliases.get("KeepWwwPrefix"));
+    assertEquals("KeepSlashes", aliases.get("KeepDoubleSlashes"));
+  }
+
+  /* Dos is a two-bit field on the desktop, not a checkbox. */
+  @Test
+  public void dosPacksBothBoxes() {
+    assertEquals("0", DosIso9660Handler.pack("0", "0"));
+    assertEquals("1", DosIso9660Handler.pack("1", "0"));
+    assertEquals("2", DosIso9660Handler.pack("0", "1"));
+    assertEquals("3", DosIso9660Handler.pack("1", "1"));
+    assertEquals("0", DosIso9660Handler.pack(null, null));
+  }
+
+  @Test
+  public void dosUnpacksBothBoxes() {
+    assertArrayEquals(new String[] { "0", "0" }, DosIso9660Handler.unpack("0"));
+    assertArrayEquals(new String[] { "1", "0" }, DosIso9660Handler.unpack("1"));
+    assertArrayEquals(new String[] { "0", "1" }, DosIso9660Handler.unpack("2"));
+    assertArrayEquals(new String[] { "1", "1" }, DosIso9660Handler.unpack("3"));
+  }
+
+  /* A WinHTTrack project with both boxes ticked used to open with neither. */
+  @Test
+  public void dosRoundTripsEveryCombination() {
+    for (final String dos : new String[] { "0", "1" }) {
+      for (final String iso9660 : new String[] { "0", "1" }) {
+        assertArrayEquals(dos + "/" + iso9660, new String[] { dos, iso9660 },
+            DosIso9660Handler.unpack(DosIso9660Handler.pack(dos, iso9660)));
+      }
+    }
+  }
+
+  @Test
+  public void dosLeavesTheBoxesAloneWhenItHoldsNoNumber() {
+    assertNull(DosIso9660Handler.unpack(null));
+    assertNull(DosIso9660Handler.unpack(""));
+    assertNull(DosIso9660Handler.unpack("yes"));
+  }
+
+  /* Bit 0 wins when both are set, matching the -L0 the desktop emits. */
+  @Test
+  public void bothBoxesEmitDosNames() {
+    final DosIso9660Handler handler = new DosIso9660Handler();
+    final List<String> cmd = new ArrayList<String>();
+    final String[] boxes = DosIso9660Handler.unpack("3");
+    handler.getDosMapper().emit(cmd, boxes[0]);
+    final OptionMapper iso = handler.getIso9660Mapper();
+    iso.emit(cmd, boxes[1]);
+    ((OptionMapper.FinishMapper) iso).finish(cmd);
+    assertEquals(Arrays.asList("-L0"), cmd);
+  }
+}

--- a/app/src/test/java/com/httrack/android/WinProfileParityTest.java
+++ b/app/src/test/java/com/httrack/android/WinProfileParityTest.java
@@ -1,25 +1,26 @@
 package com.httrack.android;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-import com.httrack.android.OptionsMapper.DosIso9660Handler;
+import com.httrack.android.OptionsMapper.MultipleChoicesOption;
 import com.httrack.android.OptionsMapper.OptionMapper;
+import com.httrack.android.OptionsMapper.ProfileFormat;
 import com.httrack.android.OptionsMapper.SimpleOptionFlag;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.junit.Test;
 
-/** Holds winprofile.ini storage and option emission to WinHTTrack's conventions. */
+/** Checks winprofile.ini storage and option emission against WinHTTrack's conventions. */
 public class WinProfileParityTest {
   private static List<String> emit(final OptionMapper mapper, final String value) {
     final List<String> cmd = new ArrayList<String>();
@@ -27,152 +28,180 @@ public class WinProfileParityTest {
     return cmd;
   }
 
-  /* The mapper table pulls in R.id, which the stub android.jar cannot load, so
-     the declarations are read out of the source. */
-  private static Map<String, String> mapperTable() throws IOException {
-    final String src = TestSources.javaSource("OptionsMapper");
-    final Matcher m = Pattern.compile(
-        "new Pair<String, OptionMapper>\\(\"([^\"]+)\",\\s*"
-            + "(new \\w+\\([^)]*\\)|[\\w.]+\\(\\))").matcher(src);
-    final Map<String, String> table = new HashMap<String, String>();
-    while (m.find()) {
-      table.put(m.group(1), m.group(2).replaceAll("\\s+", " "));
+  /* A profile file, in the order its lines appear. */
+  private static Map<String, String> file(final String... pairs) {
+    final Map<String, String> raw = new LinkedHashMap<String, String>();
+    for (int i = 0; i < pairs.length; i += 2) {
+      raw.put(pairs[i], pairs[i + 1]);
     }
-    assertTrue("no mapper declarations parsed", table.size() > 50);
-    return table;
+    return raw;
   }
 
-  private static List<String> serializerKeys() throws IOException {
-    final String src = TestSources.javaSource("OptionsMapper");
-    final Matcher m = Pattern.compile(
-        "new Pair<Integer, String>\\(R\\.id\\.\\w+,\\s*\"([^\"]+)\"\\)")
-        .matcher(src);
-    final List<String> keys = new ArrayList<String>();
-    while (m.find()) {
-      keys.add(m.group(1));
-    }
-    assertTrue("no serializer keys parsed", keys.size() > 50);
-    return keys;
+  private static String[] boxes(final Map<String, String> values) {
+    return new String[] { values.get("Dos"), values.get("Iso9660") };
   }
 
   /* -x turns external links into error pages, and the engine defaults it off. */
   @Test
-  public void noExternalPagesEmitsWhenChecked() throws IOException {
-    assertEquals("new SimpleOptionFlag( \"x\")",
-        mapperTable().get("NoExternalPages"));
+  public void noExternalPagesEmitsWhenChecked() {
     assertEquals(Arrays.asList("-x"), emit(new SimpleOptionFlag("x"), "1"));
     assertTrue(emit(new SimpleOptionFlag("x"), "0").isEmpty());
   }
 
   /* -%q includes query strings and -%q0 drops them; the box hides them. */
   @Test
-  public void hideQueryStringsEmitsTheDisablingForm() throws IOException {
-    assertEquals("new SimpleOptionFlag( \"%q0\")",
-        mapperTable().get("NoQueryStrings"));
+  public void hideQueryStringsEmitsTheDisablingForm() {
     assertEquals(Arrays.asList("-%q0"), emit(new SimpleOptionFlag("%q0"), "1"));
     assertTrue(emit(new SimpleOptionFlag("%q0"), "0").isEmpty());
   }
 
   /* Bare -j re-asserts the engine default, so unticking the box needs -j0. */
   @Test
-  public void parseJavaTurnsOffWithTheZeroForm() throws IOException {
-    assertEquals("new SimpleOptionFlag(\"j0\", true)",
-        mapperTable().get("ParseJava"));
+  public void parseJavaTurnsOffWithTheZeroForm() {
     assertEquals(Arrays.asList("-j0"),
         emit(new SimpleOptionFlag("j0", true), "0"));
     assertTrue(emit(new SimpleOptionFlag("j0", true), "1").isEmpty());
   }
 
-  /* No flag body may re-assert an engine default to express "off". */
+  /* Checked must revalidate, which is -C2; the engine's own default is -C1. */
   @Test
-  public void noRevertedFlagEmitsABareEnablingForm() throws IOException {
-    final Matcher m = Pattern.compile(
-        "new SimpleOptionFlag\\(\\s*\"([^\"]+)\",\\s*true\\s*\\)").matcher(
-        TestSources.javaSource("OptionsMapper"));
-    int seen = 0;
-    while (m.find()) {
-      seen++;
-      assertTrue("-" + m.group(1) + " must carry its 0 form", m.group(1)
-          .endsWith("0"));
+  public void cacheChecksForUpdatesWhenChecked() {
+    final OptionMapper cache = new MultipleChoicesOption(new String[] { "C0",
+        "C2" });
+    assertEquals(Arrays.asList("-C2"), emit(cache, "1"));
+    assertEquals(Arrays.asList("-C0"), emit(cache, "0"));
+  }
+
+  @Test
+  public void winHttrackProfileOpensWithBothBoxes() {
+    assertArrayEquals(new String[] { "0", "0" },
+        boxes(ProfileFormat.resolve(file("Dos", "0"))));
+    assertArrayEquals(new String[] { "1", "0" },
+        boxes(ProfileFormat.resolve(file("Dos", "1"))));
+    assertArrayEquals(new String[] { "0", "1" },
+        boxes(ProfileFormat.resolve(file("Dos", "2"))));
+    assertArrayEquals(new String[] { "1", "1" },
+        boxes(ProfileFormat.resolve(file("Dos", "3"))));
+  }
+
+  /* Our own older profiles wrote Dos as a plain boolean beside an Iso9660. */
+  @Test
+  public void olderProfileKeepsEveryRenamedSetting() {
+    final Map<String, String> values = ProfileFormat.resolve(file("Dos", "1",
+        "Iso9660", "1", "ProxyProtocol", "1", "KeepWwwPrefix", "1",
+        "KeepDoubleSlashes", "1"));
+    assertArrayEquals(new String[] { "1", "1" }, boxes(values));
+    assertEquals("1", values.get("ProxyType"));
+    assertEquals("1", values.get("KeepWww"));
+    assertEquals("1", values.get("KeepSlashes"));
+    assertFalse(values.containsKey("ProxyProtocol"));
+  }
+
+  /* The split must read the file, not the map it is filling: a profile with no
+     Dos line would otherwise clear a saved Iso9660. */
+  @Test
+  public void profileWithoutDosLeavesBothBoxesAlone() {
+    final Map<String, String> values = ProfileFormat.resolve(file("ProxyType",
+        "1"));
+    assertFalse(values.containsKey("Dos"));
+    assertFalse(values.containsKey("Iso9660"));
+  }
+
+  @Test
+  public void unreadableDosLeavesTheBoxesAlone() {
+    assertEquals("yes", ProfileFormat.resolve(file("Dos", "yes")).get("Dos"));
+    assertNull(ProfileFormat.resolve(file("Dos", "yes")).get("Iso9660"));
+    assertEquals("", ProfileFormat.resolve(file("Dos", "")).get("Dos"));
+  }
+
+  @Test
+  public void dosPacksBothBoxes() {
+    assertEquals("0", ProfileFormat.pack("0", "0"));
+    assertEquals("1", ProfileFormat.pack("1", "0"));
+    assertEquals("2", ProfileFormat.pack("0", "1"));
+    assertEquals("3", ProfileFormat.pack("1", "1"));
+    assertEquals("0", ProfileFormat.pack(null, null));
+  }
+
+  /* WinHTTrack has no Iso9660 key, so ours must not survive into the file. */
+  @Test
+  public void writtenProfileFoldsIso9660IntoDos() {
+    final Map<String, String> written = ProfileFormat.toFile(file("Dos", "0",
+        "Iso9660", "1", "ProxyType", "1"));
+    assertEquals("2", written.get("Dos"));
+    assertFalse(written.containsKey("Iso9660"));
+    assertEquals("1", written.get("ProxyType"));
+  }
+
+  @Test
+  public void everyBoxCombinationSurvivesAWriteAndRead() {
+    for (final String dos : new String[] { "0", "1" }) {
+      for (final String iso9660 : new String[] { "0", "1" }) {
+        final Map<String, String> values = ProfileFormat.resolve(ProfileFormat
+            .toFile(file("Dos", dos, "Iso9660", iso9660)));
+        assertArrayEquals(dos + "/" + iso9660,
+            new String[] { dos, iso9660 }, boxes(values));
+      }
     }
-    assertTrue("no reverted flags parsed", seen > 0);
+  }
+
+  @Test
+  public void renamedKeysMapBothWays() {
+    assertEquals("ProxyType", ProfileFormat.canonicalName("ProxyProtocol"));
+    assertEquals("ProxyProtocol", ProfileFormat.legacyName("ProxyType"));
+    assertEquals("KeepWww", ProfileFormat.canonicalName("KeepWwwPrefix"));
+    assertEquals("KeepSlashes",
+        ProfileFormat.canonicalName("KeepDoubleSlashes"));
+    assertEquals("Near", ProfileFormat.canonicalName("Near"));
+    assertNull(ProfileFormat.legacyName("Near"));
+  }
+
+  /* The table pulls in R.id, so the declarations are read out of the source. */
+  private static String mapperTable() throws IOException {
+    return TestSources.javaSource("OptionsMapper");
   }
 
   @Test
   public void keysUseTheWinHttrackSpelling() throws IOException {
-    final List<String> keys = serializerKeys();
-    for (final String key : new String[] { "ProxyType", "KeepWww",
-        "KeepSlashes" }) {
-      assertTrue(key + " missing", keys.contains(key));
+    final Matcher m = Pattern.compile(
+        "new Pair<Integer, String>\\(R\\.id\\.\\w+,\\s*\"([^\"]+)\"\\)")
+        .matcher(mapperTable());
+    final List<String> keys = new ArrayList<String>();
+    while (m.find()) {
+      keys.add(m.group(1));
     }
+    assertEquals("serializer keys parsed", 94, keys.size());
+    assertTrue(keys.containsAll(Arrays.asList("ProxyType", "KeepWww",
+        "KeepSlashes")));
     for (final String legacy : new String[] { "ProxyProtocol",
         "KeepWwwPrefix", "KeepDoubleSlashes" }) {
       assertFalse(legacy + " still written", keys.contains(legacy));
     }
   }
 
-  /* Renaming a key would silently reset it on every profile already saved. */
+  /* No flag may re-assert an engine default to mean "off", whichever primitive
+     spells it: the -%q bug wore SimpleOption0 rather than a reverted flag. */
   @Test
-  public void everyRenamedKeyKeepsItsOldSpellingReadable() throws IOException {
-    final String src = TestSources.javaSource("OptionsMapper");
+  public void noOffSwitchEmitsABareEnablingForm() throws IOException {
     final Matcher m = Pattern.compile(
-        "new Pair<String, String>\\(\"(ProxyProtocol|KeepWwwPrefix"
-            + "|KeepDoubleSlashes)\",\\s*\"(\\w+)\"\\)").matcher(src);
-    final Map<String, String> aliases = new HashMap<String, String>();
+        "new (SimpleOptionFlag|SimpleOption0)\\(\\s*\"([^\"]+)\""
+            + "(?:\\s*,\\s*(?:/\\*[^*]*\\*/\\s*)?(true|false))?\\s*\\)")
+        .matcher(mapperTable());
+    int reverted = 0;
+    int tristate = 0;
     while (m.find()) {
-      aliases.put(m.group(1), m.group(2));
-    }
-    assertEquals("ProxyType", aliases.get("ProxyProtocol"));
-    assertEquals("KeepWww", aliases.get("KeepWwwPrefix"));
-    assertEquals("KeepSlashes", aliases.get("KeepDoubleSlashes"));
-  }
-
-  /* Dos is a two-bit field on the desktop, not a checkbox. */
-  @Test
-  public void dosPacksBothBoxes() {
-    assertEquals("0", DosIso9660Handler.pack("0", "0"));
-    assertEquals("1", DosIso9660Handler.pack("1", "0"));
-    assertEquals("2", DosIso9660Handler.pack("0", "1"));
-    assertEquals("3", DosIso9660Handler.pack("1", "1"));
-    assertEquals("0", DosIso9660Handler.pack(null, null));
-  }
-
-  @Test
-  public void dosUnpacksBothBoxes() {
-    assertArrayEquals(new String[] { "0", "0" }, DosIso9660Handler.unpack("0"));
-    assertArrayEquals(new String[] { "1", "0" }, DosIso9660Handler.unpack("1"));
-    assertArrayEquals(new String[] { "0", "1" }, DosIso9660Handler.unpack("2"));
-    assertArrayEquals(new String[] { "1", "1" }, DosIso9660Handler.unpack("3"));
-  }
-
-  /* A WinHTTrack project with both boxes ticked used to open with neither. */
-  @Test
-  public void dosRoundTripsEveryCombination() {
-    for (final String dos : new String[] { "0", "1" }) {
-      for (final String iso9660 : new String[] { "0", "1" }) {
-        assertArrayEquals(dos + "/" + iso9660, new String[] { dos, iso9660 },
-            DosIso9660Handler.unpack(DosIso9660Handler.pack(dos, iso9660)));
+      final boolean isFlag = "SimpleOptionFlag".equals(m.group(1));
+      if (isFlag && "true".equals(m.group(3))) {
+        reverted++;
+        assertTrue("-" + m.group(2) + " must carry its 0 form", m.group(2)
+            .endsWith("0"));
+      } else if (!isFlag) {
+        tristate++;
+        assertFalse("-" + m.group(2) + " emits both forms, so it may not be "
+            + "spelled as its own off switch", m.group(2).endsWith("0"));
       }
     }
-  }
-
-  @Test
-  public void dosLeavesTheBoxesAloneWhenItHoldsNoNumber() {
-    assertNull(DosIso9660Handler.unpack(null));
-    assertNull(DosIso9660Handler.unpack(""));
-    assertNull(DosIso9660Handler.unpack("yes"));
-  }
-
-  /* Bit 0 wins when both are set, matching the -L0 the desktop emits. */
-  @Test
-  public void bothBoxesEmitDosNames() {
-    final DosIso9660Handler handler = new DosIso9660Handler();
-    final List<String> cmd = new ArrayList<String>();
-    final String[] boxes = DosIso9660Handler.unpack("3");
-    handler.getDosMapper().emit(cmd, boxes[0]);
-    final OptionMapper iso = handler.getIso9660Mapper();
-    iso.emit(cmd, boxes[1]);
-    ((OptionMapper.FinishMapper) iso).finish(cmd);
-    assertEquals(Arrays.asList("-L0"), cmd);
+    assertEquals("reverted flags parsed", 3, reverted);
+    assertEquals("tri-state options parsed", 4, tristate);
   }
 }

--- a/app/src/test/java/com/httrack/android/WinProfileParityTest.java
+++ b/app/src/test/java/com/httrack/android/WinProfileParityTest.java
@@ -108,6 +108,13 @@ public class WinProfileParityTest {
   }
 
   @Test
+  public void aDosWithNoValueAtAllLeavesTheBoxesAlone() {
+    final Map<String, String> values = ProfileFormat.resolve(file("Dos", null));
+    assertNull(values.get("Dos"));
+    assertFalse(values.containsKey("Iso9660"));
+  }
+
+  @Test
   public void unreadableDosLeavesTheBoxesAlone() {
     assertEquals("yes", ProfileFormat.resolve(file("Dos", "yes")).get("Dos"));
     assertNull(ProfileFormat.resolve(file("Dos", "yes")).get("Iso9660"));
@@ -161,8 +168,7 @@ public class WinProfileParityTest {
     return TestSources.javaSource("OptionsMapper");
   }
 
-  @Test
-  public void keysUseTheWinHttrackSpelling() throws IOException {
+  private static List<String> serializerKeys() throws IOException {
     final Matcher m = Pattern.compile(
         "new Pair<Integer, String>\\(R\\.id\\.\\w+,\\s*\"([^\"]+)\"\\)")
         .matcher(mapperTable());
@@ -171,11 +177,46 @@ public class WinProfileParityTest {
       keys.add(m.group(1));
     }
     assertEquals("serializer keys parsed", 94, keys.size());
+    return keys;
+  }
+
+  @Test
+  public void keysUseTheWinHttrackSpelling() throws IOException {
+    final List<String> keys = serializerKeys();
     assertTrue(keys.containsAll(Arrays.asList("ProxyType", "KeepWww",
         "KeepSlashes")));
     for (final String legacy : new String[] { "ProxyProtocol",
         "KeepWwwPrefix", "KeepDoubleSlashes" }) {
       assertFalse(legacy + " still written", keys.contains(legacy));
+    }
+  }
+
+  /* A rename that leaves canonicalName pointing at no field drops the setting
+     in silence, so the targets have to stay real keys. */
+  @Test
+  public void everyRenameTargetIsAStoredKey() throws IOException {
+    final List<String> keys = serializerKeys();
+    for (final String key : keys) {
+      final String legacy = ProfileFormat.legacyName(key);
+      if (legacy != null) {
+        assertEquals(key, ProfileFormat.canonicalName(legacy));
+      }
+    }
+    for (final String legacy : new String[] { "ProxyProtocol",
+        "KeepWwwPrefix", "KeepDoubleSlashes" }) {
+      assertTrue(legacy + " resolves to no stored key",
+          keys.contains(ProfileFormat.canonicalName(legacy)));
+    }
+  }
+
+  /* A hand-edited profile reaches the radio mappers with anything at all. */
+  @Test
+  public void aChoiceOutsideTheTableEmitsNothing() {
+    final OptionMapper cache = new MultipleChoicesOption(new String[] { "C0",
+        "C2" });
+    for (final String value : new String[] { "2", "99999999999", "", "abc",
+        null }) {
+      assertTrue("value " + value, emit(cache, value).isEmpty());
     }
   }
 


### PR DESCRIPTION
Four option boxes drove the engine the wrong way. `NoExternalPages` emitted `-x` when it was clear rather than when it was ticked, and `NoQueryStrings` asked for `-%q` where the box says hide; both default to 0, so a project nobody had touched the options on replaced external links with error pages and dropped query strings. `ParseJava` said "off" with a bare `-j`, which only re-asserts the engine default. `Cache` said "on" by emitting nothing, leaving the engine preferring whatever the cache holds where WinHTTrack emits `-C2` and revalidates first.

The winprofile.ini side diverged as well. `Dos` is a two-bit field on the desktop and we read it as a boolean, and three keys carried our own spelling of a name WinHTTrack already had. Old spellings are still read, from the profile and from the saved defaults, so nothing already saved resets.

The second commit is worth reading separately. A review pass found that the first commit's tests read the option tables as source text rather than running them, which let eight mutants through, including `fieldsLegacyNames` declared but never wired up. It also found a real defect: the Dos split read the map it was filling instead of the file, so a profile carrying neither key cleared a saved `Iso9660`. Both have the same fix, `ProfileFormat`, which holds the format contract clear of `android.util.Pair` and `SparseArray` so it can actually be exercised.

Thirteen of sixteen mutants die now. Two known gaps, both deliberate: the `SharedPreferences` fallback is wiring around a tested decision and needs Robolectric to reach, and renaming any of the other 91 keys would still pass, which wants a frozen key list better owned by the engine than by each front end.
