### PR TITLE
Saving a project writes back settings nobody chose

### DIFF
--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -23,6 +23,7 @@ package com.httrack.android;
 
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -1405,7 +1406,7 @@ public class HTTrackActivity extends FragmentActivity {
             "starting engine: " + HTTrackActivity.printArray(cargs));
 
         // Serialize settings
-        parent.serialize(outLock);
+        parent.serialize(profile, outLock);
 
         // Progress info for slow phones
         setProgressLines(new String[] { string_starting_mirror });
@@ -1910,14 +1911,26 @@ public class HTTrackActivity extends FragmentActivity {
   }
 
   /**
-   * Serialize current profile to an existing OutputStream.
-   * 
+   * Serialize the current profile through an already-open, locked stream,
+   * replacing what the file held.
+   *
+   * @param profile
+   *          the file that stream writes to
+   * @param os
+   *          the locked stream, opened in append mode
    * @throws IOException
    *           Upon I/O error.
    */
-  protected synchronized void serialize(final OutputStream os)
-      throws IOException {
-    mapper.serialize(os);
+  protected synchronized void serialize(final File profile,
+      final FileOutputStream os) throws IOException {
+    // The reader takes the last line for a key, so a key left out of this write
+    // would keep whatever an earlier block said. Build it first, so that a
+    // failure cannot leave the profile empty.
+    mapper.rememberProfileKeys(profile);
+    final ByteArrayOutputStream settings = new ByteArrayOutputStream();
+    mapper.serialize(settings);
+    os.getChannel().truncate(0);
+    os.write(settings.toByteArray());
     os.flush();
   }
 

--- a/app/src/main/java/com/httrack/android/OptionsMapper.java
+++ b/app/src/main/java/com/httrack/android/OptionsMapper.java
@@ -32,11 +32,13 @@ import java.io.OutputStreamWriter;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 import android.content.Context;
@@ -500,9 +502,53 @@ public class OptionsMapper {
       return values;
     }
 
-    /* A key nobody chose: it holds no value, or still holds the seeded one. */
-    private static boolean isUnset(final String value, final String seeded) {
-      return value == null || value.equals(seeded != null ? seeded : "");
+    /**
+     * The file view of these settings, Iso9660 folded into Dos and so absent.
+     *
+     * @param values
+     *          the settings, under their current names
+     * @return the pairs a file stands for, before any are left out
+     */
+    static Map<String, String> packed(final Map<String, String> values) {
+      final Map<String, String> file = new LinkedHashMap<String, String>(values);
+      file.put(DOS_KEY, pack(values.get(DOS_KEY), values.get(ISO9660_KEY)));
+      file.remove(ISO9660_KEY);
+      return file;
+    }
+
+    /**
+     * What the next load puts back for a key the file leaves out, which is the
+     * only thing that says whether leaving it out is safe. Comparing against
+     * the built-in default table instead is unsound wherever a second layer of
+     * defaults exists, since the key reloads through that layer.
+     */
+    static final class Baseline {
+      private final Map<String, String> seeded;
+      private final Set<String> held;
+
+      /**
+       * @param seeded
+       *          the file view of the settings a load starts from, before the
+       *          profile is laid over them
+       * @param held
+       *          keys the loaded profile carried, which stay in the file
+       *          whatever they hold, so that saving never drops someone else's
+       *          line
+       */
+      Baseline(final Map<String, String> seeded, final Set<String> held) {
+        this.seeded = seeded;
+        this.held = held;
+      }
+
+      boolean holds(final String key) {
+        return held.contains(key);
+      }
+
+      /* Absent and empty read alike, so an unseeded key matches an empty one. */
+      boolean reloadsAs(final String key, final String value) {
+        final String reloaded = seeded.get(key);
+        return value.equals(reloaded != null ? reloaded : "");
+      }
     }
 
     /**
@@ -510,22 +556,21 @@ public class OptionsMapper {
      *
      * @param values
      *          the settings, under their current names
-     * @param defaults
-     *          what a project with no profile of its own starts from
-     * @return the pairs to write, none of them null, Iso9660 folded into Dos
-     *         and so absent, and every key still holding its default left out
-     *         so that a reader keeps applying its own
+     * @param baseline
+     *          what a load reconstructs, and what the profile already held
+     * @return the pairs to write, none of them null, and none the next load
+     *         would put back by itself
      */
     static Map<String, String> toFile(final Map<String, String> values,
-        final Map<String, String> defaults) {
-      final Map<String, String> file = new LinkedHashMap<String, String>(values);
-      file.put(DOS_KEY, pack(values.get(DOS_KEY), values.get(ISO9660_KEY)));
-      file.remove(ISO9660_KEY);
+        final Baseline baseline) {
+      final Map<String, String> file = packed(values);
       final Iterator<Map.Entry<String, String>> entries = file.entrySet()
           .iterator();
       while (entries.hasNext()) {
         final Map.Entry<String, String> entry = entries.next();
-        if (isUnset(entry.getValue(), defaults.get(entry.getKey()))) {
+        final String value = entry.getValue();
+        if (value == null || (!baseline.holds(entry.getKey()) && baseline
+            .reloadsAs(entry.getKey(), value))) {
           entries.remove();
         }
       }
@@ -541,6 +586,11 @@ public class OptionsMapper {
 
   // The options mapping
   protected final SparseArraySerializable map = new SparseArraySerializable();
+
+  // What a load puts back on its own, and which keys the profile carried.
+  // Empty means nothing is known, so serialize() writes every key it holds.
+  private Map<String, String> seededState = new LinkedHashMap<String, String>();
+  private final Set<String> heldKeys = new HashSet<String>();
 
   // Is the map dirty ?
   protected boolean dirty;
@@ -1513,13 +1563,7 @@ public class OptionsMapper {
     }
   }
 
-  /**
-   * What a project with no profile of its own starts from. Also the baseline
-   * {@link #serialize(OutputStream)} leaves out of the file, so the two must
-   * stay the same set of values.
-   *
-   * @return the defaults, by profile key
-   */
+  /* What a project with no profile of its own starts from, by profile key. */
   private Map<String, String> seededDefaults() {
     final Map<String, String> defaults = new LinkedHashMap<String, String>();
     for (final Pair<String, String> field : fieldsDefaults) {
@@ -1547,6 +1591,21 @@ public class OptionsMapper {
       }
       map.put(id, field.getValue());
     }
+  }
+
+  /* Every stored setting, by profile key, null where nothing is set. */
+  private Map<String, String> valuesByKey() {
+    final Map<String, String> values = new LinkedHashMap<String, String>();
+    for (final Pair<Integer, String> field : OptionsMapper.fieldsSerializer) {
+      values.put(field.second, getMap(field.first));
+    }
+    return values;
+  }
+
+  /* Record what a load would put back, once the map holds it and no further. */
+  private void snapshotSeeded() {
+    seededState = ProfileFormat.packed(valuesByKey());
+    heldKeys.clear();
   }
 
   /**
@@ -1586,6 +1645,7 @@ public class OptionsMapper {
 
     // Initialize default values for map
     initializeMap();
+    snapshotSeeded();
   }
 
   /**
@@ -1632,6 +1692,9 @@ public class OptionsMapper {
 
     // Load default preferences if any
     loadDefaultPreferences();
+
+    // The preferences are part of what a load rebuilds, so snapshot after them
+    snapshotSeeded();
 
     dirty = false;
   }
@@ -1752,11 +1815,13 @@ public class OptionsMapper {
    *          The profile file (winprofile.ini)
    * @param map
    *          The map to be filled
-   * 
+   * @return the keys the file carried, under their current names; a caller
+   *         that only wants the settings can ignore them
+   *
    * @throws IOException
    *           Upon I/O error.
    */
-  public static void unserialize(final File profile,
+  public static Set<String> unserialize(final File profile,
       final SparseArray<String> map) throws IOException {
     // Write settings
     if (!profile.exists()) {
@@ -1778,6 +1843,10 @@ public class OptionsMapper {
               OptionsMapper.profileDecode(line.substring(sep + 1)));
         }
       }
+      final Set<String> held = new HashSet<String>();
+      for (final String key : raw.keySet()) {
+        held.add(ProfileFormat.canonicalName(key));
+      }
       for (final Map.Entry<String, String> field : ProfileFormat.resolve(raw)
           .entrySet()) {
         final Integer id = OptionsMapper.fieldsNameToId.get(field.getKey());
@@ -1786,6 +1855,7 @@ public class OptionsMapper {
         }
       }
       lreader.close();
+      return held;
     } finally {
       reader.close();
     }
@@ -1815,12 +1885,8 @@ public class OptionsMapper {
     final OutputStreamWriter writer = new OutputStreamWriter(fos);
     final BufferedWriter lwriter = new BufferedWriter(writer);
     try {
-      final Map<String, String> values = new LinkedHashMap<String, String>();
-      for (final Pair<Integer, String> field : OptionsMapper.fieldsSerializer) {
-        values.put(field.second, getMap(field.first));
-      }
-      final Map<String, String> file = ProfileFormat.toFile(values,
-          seededDefaults());
+      final Map<String, String> file = ProfileFormat.toFile(valuesByKey(),
+          new ProfileFormat.Baseline(seededState, heldKeys));
       for (final Pair<Integer, String> field : OptionsMapper.fieldsSerializer) {
         final String key = field.second;
         if (!file.containsKey(key)) {
@@ -1854,6 +1920,15 @@ public class OptionsMapper {
    */
   public void serialize(final File profile)
       throws UnsupportedEncodingException, IOException {
+    // The file outlives an activity restart that leaves the map with no record
+    // of the keys it carried, and opening it below truncates it.
+    if (profile.exists()) {
+      try {
+        heldKeys.addAll(unserialize(profile, new SparseArraySerializable()));
+      } catch (final IOException e) {
+        Log.d(getClass().getSimpleName(), "unreadable profile: " + e);
+      }
+    }
     final FileOutputStream fos = new FileOutputStream(profile);
     try {
       serialize(fos);
@@ -1878,7 +1953,7 @@ public class OptionsMapper {
    *           Upon I/O error.
    */
   protected void unserialize(final File profile) throws IOException {
-    unserialize(profile, map);
+    heldKeys.addAll(unserialize(profile, map));
     if (dirty) {
       dirty = false;
       Log.d(getClass().getSimpleName(),

--- a/app/src/main/java/com/httrack/android/OptionsMapper.java
+++ b/app/src/main/java/com/httrack/android/OptionsMapper.java
@@ -32,6 +32,7 @@ import java.io.OutputStreamWriter;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -499,15 +500,35 @@ public class OptionsMapper {
       return values;
     }
 
+    /* A key nobody chose: it holds no value, or still holds the seeded one. */
+    private static boolean isUnset(final String value, final String seeded) {
+      return value == null || value.equals(seeded != null ? seeded : "");
+    }
+
     /**
      * Inverse of {@link #resolve}: what the file holds for these settings.
      *
-     * @return the pairs to write, Iso9660 folded into Dos and so absent
+     * @param values
+     *          the settings, under their current names
+     * @param defaults
+     *          what a project with no profile of its own starts from
+     * @return the pairs to write, none of them null, Iso9660 folded into Dos
+     *         and so absent, and every key still holding its default left out
+     *         so that a reader keeps applying its own
      */
-    static Map<String, String> toFile(final Map<String, String> values) {
+    static Map<String, String> toFile(final Map<String, String> values,
+        final Map<String, String> defaults) {
       final Map<String, String> file = new LinkedHashMap<String, String>(values);
       file.put(DOS_KEY, pack(values.get(DOS_KEY), values.get(ISO9660_KEY)));
       file.remove(ISO9660_KEY);
+      final Iterator<Map.Entry<String, String>> entries = file.entrySet()
+          .iterator();
+      while (entries.hasNext()) {
+        final Map.Entry<String, String> entry = entries.next();
+        if (isUnset(entry.getValue(), defaults.get(entry.getKey()))) {
+          entries.remove();
+        }
+      }
       return file;
     }
   }
@@ -1492,39 +1513,40 @@ public class OptionsMapper {
     }
   }
 
-  /*
-   * Map special values, depending on the context.
+  /**
+   * What a project with no profile of its own starts from. Also the baseline
+   * {@link #serialize(OutputStream)} leaves out of the file, so the two must
+   * stay the same set of values.
+   *
+   * @return the defaults, by profile key
    */
-  private void setDynamicDefaults() {
+  private Map<String, String> seededDefaults() {
+    final Map<String, String> defaults = new LinkedHashMap<String, String>();
+    for (final Pair<String, String> field : fieldsDefaults) {
+      defaults.put(field.first, field.second);
+    }
     if (context != null) {
       // Derive the ISO code from the runtime locale, not a build-time placeholder.
       final String iso = Locale.getDefault().getLanguage();
-      map.put(fieldsNameToId.get("AcceptLanguage"),
-          (iso == null || iso.isEmpty() ? "en" : iso) + ",*");
+      defaults.put("AcceptLanguage", (iso == null || iso.isEmpty() ? "en"
+          : iso) + ",*");
     }
-  }
-
-  /*
-   * Fill the map with default values
-   */
-  protected static void initializeMap(final SparseArraySerializable map) {
-    map.clear();
-    for (final Pair<String, String> field : fieldsDefaults) {
-      final Integer id = fieldsNameToId.get(field.first);
-      if (id == null) {
-        throw new RuntimeException("unexpecter error: unknown key "
-            + field.first);
-      }
-      map.put(id, field.second);
-    }
+    return defaults;
   }
 
   /*
    * Fill the map with default values
    */
   public void initializeMap() {
-    initializeMap(map);
-    setDynamicDefaults();
+    map.clear();
+    for (final Map.Entry<String, String> field : seededDefaults().entrySet()) {
+      final Integer id = fieldsNameToId.get(field.getKey());
+      if (id == null) {
+        throw new RuntimeException("unexpecter error: unknown key "
+            + field.getKey());
+      }
+      map.put(id, field.getValue());
+    }
   }
 
   /**
@@ -1797,18 +1819,16 @@ public class OptionsMapper {
       for (final Pair<Integer, String> field : OptionsMapper.fieldsSerializer) {
         values.put(field.second, getMap(field.first));
       }
-      final Map<String, String> file = ProfileFormat.toFile(values);
+      final Map<String, String> file = ProfileFormat.toFile(values,
+          seededDefaults());
       for (final Pair<Integer, String> field : OptionsMapper.fieldsSerializer) {
         final String key = field.second;
         if (!file.containsKey(key)) {
           continue;
         }
-        final String value = file.get(key);
         lwriter.write(key);
         lwriter.write("=");
-        if (value != null) {
-          lwriter.write(OptionsMapper.profileEncode(value));
-        }
+        lwriter.write(OptionsMapper.profileEncode(file.get(key)));
         lwriter.write("\n");
       }
       lwriter.close();

--- a/app/src/main/java/com/httrack/android/OptionsMapper.java
+++ b/app/src/main/java/com/httrack/android/OptionsMapper.java
@@ -31,6 +31,7 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -587,10 +588,12 @@ public class OptionsMapper {
   // The options mapping
   protected final SparseArraySerializable map = new SparseArraySerializable();
 
-  // What a load puts back on its own, and which keys the profile carried.
-  // Empty means nothing is known, so serialize() writes every key it holds.
-  private Map<String, String> seededState = new LinkedHashMap<String, String>();
-  private final Set<String> heldKeys = new HashSet<String>();
+  // Keys that always get a line: those the loaded profile carried, and those a
+  // load rebuilds from the device rather than from a fixed default, whose value
+  // at save time would otherwise be lost when the device changes.
+  private static final String environmentKeys[] = { "AcceptLanguage" };
+  private final Set<String> heldKeys = new HashSet<String>(
+      Arrays.asList(environmentKeys));
 
   // Is the map dirty ?
   protected boolean dirty;
@@ -1602,11 +1605,6 @@ public class OptionsMapper {
     return values;
   }
 
-  /* Record what a load would put back, once the map holds it and no further. */
-  private void snapshotSeeded() {
-    seededState = ProfileFormat.packed(valuesByKey());
-    heldKeys.clear();
-  }
 
   /**
    * Cleanup a space-separated string.
@@ -1645,7 +1643,6 @@ public class OptionsMapper {
 
     // Initialize default values for map
     initializeMap();
-    snapshotSeeded();
   }
 
   /**
@@ -1693,8 +1690,9 @@ public class OptionsMapper {
     // Load default preferences if any
     loadDefaultPreferences();
 
-    // The preferences are part of what a load rebuilds, so snapshot after them
-    snapshotSeeded();
+    // Another project carries its own keys
+    heldKeys.clear();
+    heldKeys.addAll(Arrays.asList(environmentKeys));
 
     dirty = false;
   }
@@ -1886,7 +1884,8 @@ public class OptionsMapper {
     final BufferedWriter lwriter = new BufferedWriter(writer);
     try {
       final Map<String, String> file = ProfileFormat.toFile(valuesByKey(),
-          new ProfileFormat.Baseline(seededState, heldKeys));
+          new ProfileFormat.Baseline(ProfileFormat.packed(baselineValues()),
+              heldKeys));
       for (final Pair<Integer, String> field : OptionsMapper.fieldsSerializer) {
         final String key = field.second;
         if (!file.containsKey(key)) {
@@ -1909,8 +1908,27 @@ public class OptionsMapper {
   }
 
   /**
+   * Keep the keys a profile already carries, so that writing it back cannot
+   * drop someone else's line. Call before overwriting: an activity restart
+   * leaves the map with no record of what it loaded.
+   *
+   * @param profile
+   *          The profile file, which need not exist
+   */
+  public void rememberProfileKeys(final File profile) {
+    if (!profile.exists()) {
+      return;
+    }
+    try {
+      heldKeys.addAll(unserialize(profile, new SparseArraySerializable()));
+    } catch (final IOException e) {
+      Log.d(getClass().getSimpleName(), "unreadable profile: " + e);
+    }
+  }
+
+  /**
    * Serialize settings on disk.
-   * 
+   *
    * @param profile
    *          The profile file.
    * @throws UnsupportedEncodingException
@@ -1920,15 +1938,7 @@ public class OptionsMapper {
    */
   public void serialize(final File profile)
       throws UnsupportedEncodingException, IOException {
-    // The file outlives an activity restart that leaves the map with no record
-    // of the keys it carried, and opening it below truncates it.
-    if (profile.exists()) {
-      try {
-        heldKeys.addAll(unserialize(profile, new SparseArraySerializable()));
-      } catch (final IOException e) {
-        Log.d(getClass().getSimpleName(), "unreadable profile: " + e);
-      }
-    }
+    rememberProfileKeys(profile);
     final FileOutputStream fos = new FileOutputStream(profile);
     try {
       serialize(fos);
@@ -1984,35 +1994,55 @@ public class OptionsMapper {
     return false;
   }
 
+  /**
+   * What a load rebuilds for a project with no profile of its own: the defaults
+   * with the saved default options over them. Derived on each call rather than
+   * remembered, so that changing the saved options cannot leave a stale copy
+   * behind; {@link OptionsActivity} holds its own mapper, and its changes reach
+   * this one only through the preferences.
+   *
+   * @return the values, by profile key, project identity excluded
+   */
+  private Map<String, String> baselineValues() {
+    final Map<String, String> values = seededDefaults();
+    if (context == null) {
+      return values;
+    }
+    final SharedPreferences settings = context.getSharedPreferences(PREFS_NAME,
+        0);
+    for (final Pair<Integer, String> field : OptionsMapper.fieldsSerializer) {
+      // A stale saved default must not resurrect a wrong project identity.
+      if (isIdentityField(field.first)) {
+        continue;
+      }
+      final String key = field.second;
+      String value = settings.getString(key, null);
+      if (value == null) {
+        final String legacy = ProfileFormat.legacyName(key);
+        if (legacy != null) {
+          value = settings.getString(legacy, null);
+        }
+      }
+      if (value != null) {
+        values.put(key, value);
+      }
+    }
+    return values;
+  }
+
   /*
    * Load default preferences.
    */
   public void loadDefaultPreferences() {
     if (context != null) {
-      final SharedPreferences settings = context.getSharedPreferences(
-          PREFS_NAME, 0);
       // Snapshot the current project identity before the map reset wipes it.
       final SparseArray<String> identity = new SparseArray<String>();
       for (final int id : OptionsMapper.identityFields) {
         identity.put(id, getMap(id));
       }
       initializeMap();
-      for (final Pair<Integer, String> field : OptionsMapper.fieldsSerializer) {
-        // A stale saved default must not resurrect a wrong project identity.
-        if (isIdentityField(field.first)) {
-          continue;
-        }
-        final String key = field.second;
-        String value = settings.getString(key, null);
-        if (value == null) {
-          final String legacy = ProfileFormat.legacyName(key);
-          if (legacy != null) {
-            value = settings.getString(legacy, null);
-          }
-        }
-        if (value != null) {
-          setMap(field.first, value);
-        }
+      for (final Map.Entry<String, String> field : baselineValues().entrySet()) {
+        setMap(fieldsNameToId.get(field.getKey()), field.getValue());
       }
       // Restore the project identity the default options must not touch.
       for (int i = 0; i < identity.size(); i++) {

--- a/app/src/test/java/com/httrack/android/WinProfileParityTest.java
+++ b/app/src/test/java/com/httrack/android/WinProfileParityTest.java
@@ -130,11 +130,16 @@ public class WinProfileParityTest {
     assertEquals("0", ProfileFormat.pack(null, null));
   }
 
+  /* A project seeded with nothing, so every value written stands out. */
+  private static Map<String, String> noDefaults() {
+    return new LinkedHashMap<String, String>();
+  }
+
   /* WinHTTrack has no Iso9660 key, so ours must not survive into the file. */
   @Test
   public void writtenProfileFoldsIso9660IntoDos() {
     final Map<String, String> written = ProfileFormat.toFile(file("Dos", "0",
-        "Iso9660", "1", "ProxyType", "1"));
+        "Iso9660", "1", "ProxyType", "1"), noDefaults());
     assertEquals("2", written.get("Dos"));
     assertFalse(written.containsKey("Iso9660"));
     assertEquals("1", written.get("ProxyType"));
@@ -145,10 +150,67 @@ public class WinProfileParityTest {
     for (final String dos : new String[] { "0", "1" }) {
       for (final String iso9660 : new String[] { "0", "1" }) {
         final Map<String, String> values = ProfileFormat.resolve(ProfileFormat
-            .toFile(file("Dos", dos, "Iso9660", iso9660)));
+            .toFile(file("Dos", dos, "Iso9660", iso9660), noDefaults()));
         assertArrayEquals(dos + "/" + iso9660,
             new String[] { dos, iso9660 }, boxes(values));
       }
+    }
+  }
+
+  /* A key the file never had must not come back set, or the front end that
+     wrote the file stops applying its own default for it. */
+  @Test
+  public void aSettingNobodyChoseStaysOutOfTheFile() {
+    final Map<String, String> defaults = file("Footer", "ours", "UserID", "",
+        "Dos", "0");
+    final Map<String, String> written = ProfileFormat.toFile(
+        file("Footer", "ours", "UserID", "", "Sockets", null, "TimeOut", "",
+            "Dos", "0", "Iso9660", "0"), defaults);
+    assertFalse("default still held", written.containsKey("Footer"));
+    assertFalse("default is the empty string", written.containsKey("UserID"));
+    assertFalse("no value at all", written.containsKey("Sockets"));
+    assertFalse("no default and nothing typed",
+        written.containsKey("TimeOut"));
+    assertFalse("both boxes off", written.containsKey("Dos"));
+  }
+
+  @Test
+  public void aSettingThatDiffersIsWritten() {
+    final Map<String, String> defaults = file("Footer", "ours", "Dos", "0");
+    final Map<String, String> written = ProfileFormat.toFile(
+        file("Footer", "theirs", "Sockets", "8", "Dos", "0", "Iso9660", "1"),
+        defaults);
+    assertEquals("theirs", written.get("Footer"));
+    assertEquals("8", written.get("Sockets"));
+    assertEquals("2", written.get("Dos"));
+  }
+
+  /* Clearing a field is a choice, and the empty line is how it is recorded. */
+  @Test
+  public void aFieldTheUserClearedKeepsItsEmptyLine() {
+    final Map<String, String> written = ProfileFormat.toFile(
+        file("Footer", ""), file("Footer", "ours"));
+    assertTrue(written.containsKey("Footer"));
+    assertEquals("", written.get("Footer"));
+  }
+
+  /* Leaving a key out must not change what the project means, since the same
+     defaults are seeded again on the next load. */
+  @Test
+  public void droppingDefaultsLeavesTheProjectUnchanged() {
+    final Map<String, String> defaults = file("Footer", "ours", "UserID", "",
+        "MaxRate", "25000", "Dos", "0");
+    final Map<String, String> values = file("Footer", "theirs", "UserID", "",
+        "MaxRate", "25000", "Sockets", "8", "Dos", "1", "Iso9660", "0");
+    final Map<String, String> reloaded = new LinkedHashMap<String, String>(
+        defaults);
+    reloaded.putAll(ProfileFormat.resolve(ProfileFormat.toFile(values,
+        defaults)));
+    for (final Map.Entry<String, String> setting : values.entrySet()) {
+      final String was = setting.getValue();
+      final String now = reloaded.get(setting.getKey());
+      assertEquals(setting.getKey(), was == null ? "" : was, now == null ? ""
+          : now);
     }
   }
 

--- a/app/src/test/java/com/httrack/android/WinProfileParityTest.java
+++ b/app/src/test/java/com/httrack/android/WinProfileParityTest.java
@@ -17,6 +17,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.junit.Test;
@@ -250,6 +251,31 @@ public class WinProfileParityTest {
       assertEquals(setting.getKey(), was == null ? "" : was, now == null ? ""
           : now);
     }
+  }
+
+  /* A default read off the device cannot be left out of the file, since the
+     device can change before the next load. seededDefaults overrides the table
+     for exactly those keys, so the two lists must name the same ones. */
+  @Test
+  public void everyDeviceDerivedDefaultIsAlwaysWritten() throws IOException {
+    final String source = TestSources.javaSource("OptionsMapper");
+    final Matcher declared = Pattern.compile(
+        "environmentKeys\\[\\] = \\{([^}]*)\\}").matcher(source);
+    assertTrue("environmentKeys parsed", declared.find());
+    final Set<String> always = new HashSet<String>();
+    final Matcher name = Pattern.compile("\"([^\"]+)\"").matcher(
+        declared.group(1));
+    while (name.find()) {
+      always.add(name.group(1));
+    }
+    final Set<String> derived = new HashSet<String>();
+    final Matcher put = Pattern.compile("defaults\\.put\\(\"([^\"]+)\"")
+        .matcher(source);
+    while (put.find()) {
+      derived.add(put.group(1));
+    }
+    assertEquals("device-derived defaults parsed", 1, derived.size());
+    assertEquals(derived, always);
   }
 
   @Test

--- a/app/src/test/java/com/httrack/android/WinProfileParityTest.java
+++ b/app/src/test/java/com/httrack/android/WinProfileParityTest.java
@@ -13,6 +13,7 @@ import com.httrack.android.OptionsMapper.SimpleOptionFlag;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -130,27 +131,44 @@ public class WinProfileParityTest {
     assertEquals("0", ProfileFormat.pack(null, null));
   }
 
-  /* A project seeded with nothing, so every value written stands out. */
-  private static Map<String, String> noDefaults() {
-    return new LinkedHashMap<String, String>();
+  /* A load that rebuilds SEEDED, from a profile that carried HELD. */
+  private static ProfileFormat.Baseline after(final Map<String, String> seeded,
+      final String... held) {
+    return new ProfileFormat.Baseline(ProfileFormat.packed(seeded),
+        new HashSet<String>(Arrays.asList(held)));
+  }
+
+  /* A mapper that has loaded nothing, so it can leave nothing out. */
+  private static ProfileFormat.Baseline nothingLoaded() {
+    return after(file());
   }
 
   /* WinHTTrack has no Iso9660 key, so ours must not survive into the file. */
   @Test
   public void writtenProfileFoldsIso9660IntoDos() {
     final Map<String, String> written = ProfileFormat.toFile(file("Dos", "0",
-        "Iso9660", "1", "ProxyType", "1"), noDefaults());
+        "Iso9660", "1", "ProxyType", "1"), nothingLoaded());
     assertEquals("2", written.get("Dos"));
     assertFalse(written.containsKey("Iso9660"));
     assertEquals("1", written.get("ProxyType"));
   }
 
+  /* What the next load holds: what it rebuilds, then the file over the top. */
+  private static Map<String, String> reload(final Map<String, String> seeded,
+      final Map<String, String> written) {
+    final Map<String, String> values = new LinkedHashMap<String, String>(
+        seeded);
+    values.putAll(ProfileFormat.resolve(written));
+    return values;
+  }
+
   @Test
   public void everyBoxCombinationSurvivesAWriteAndRead() {
+    final Map<String, String> seeded = file("Dos", "0", "Iso9660", "0");
     for (final String dos : new String[] { "0", "1" }) {
       for (final String iso9660 : new String[] { "0", "1" }) {
-        final Map<String, String> values = ProfileFormat.resolve(ProfileFormat
-            .toFile(file("Dos", dos, "Iso9660", iso9660), noDefaults()));
+        final Map<String, String> values = reload(seeded, ProfileFormat.toFile(
+            file("Dos", dos, "Iso9660", iso9660), after(seeded)));
         assertArrayEquals(dos + "/" + iso9660,
             new String[] { dos, iso9660 }, boxes(values));
       }
@@ -161,25 +179,24 @@ public class WinProfileParityTest {
      wrote the file stops applying its own default for it. */
   @Test
   public void aSettingNobodyChoseStaysOutOfTheFile() {
-    final Map<String, String> defaults = file("Footer", "ours", "UserID", "",
-        "Dos", "0");
     final Map<String, String> written = ProfileFormat.toFile(
         file("Footer", "ours", "UserID", "", "Sockets", null, "TimeOut", "",
-            "Dos", "0", "Iso9660", "0"), defaults);
-    assertFalse("default still held", written.containsKey("Footer"));
-    assertFalse("default is the empty string", written.containsKey("UserID"));
+            "Dos", "0", "Iso9660", "0"),
+        after(file("Footer", "ours", "UserID", "", "Dos", "0")));
+    assertFalse("seeded value still held", written.containsKey("Footer"));
+    assertFalse("seeded value is the empty string",
+        written.containsKey("UserID"));
     assertFalse("no value at all", written.containsKey("Sockets"));
-    assertFalse("no default and nothing typed",
+    assertFalse("nothing seeded and nothing typed",
         written.containsKey("TimeOut"));
     assertFalse("both boxes off", written.containsKey("Dos"));
   }
 
   @Test
   public void aSettingThatDiffersIsWritten() {
-    final Map<String, String> defaults = file("Footer", "ours", "Dos", "0");
     final Map<String, String> written = ProfileFormat.toFile(
         file("Footer", "theirs", "Sockets", "8", "Dos", "0", "Iso9660", "1"),
-        defaults);
+        after(file("Footer", "ours", "Dos", "0")));
     assertEquals("theirs", written.get("Footer"));
     assertEquals("8", written.get("Sockets"));
     assertEquals("2", written.get("Dos"));
@@ -188,24 +205,45 @@ public class WinProfileParityTest {
   /* Clearing a field is a choice, and the empty line is how it is recorded. */
   @Test
   public void aFieldTheUserClearedKeepsItsEmptyLine() {
-    final Map<String, String> written = ProfileFormat.toFile(
-        file("Footer", ""), file("Footer", "ours"));
+    final Map<String, String> written = ProfileFormat.toFile(file("Footer", ""),
+        after(file("Footer", "ours")));
     assertTrue(written.containsKey("Footer"));
     assertEquals("", written.get("Footer"));
   }
 
-  /* Leaving a key out must not change what the project means, since the same
-     defaults are seeded again on the next load. */
+  /* The baseline is what a load rebuilds, NOT the built-in default table. A
+     saved default option sits between the two, so a value matching the table
+     while the load rebuilds something else must still reach the file. */
   @Test
-  public void droppingDefaultsLeavesTheProjectUnchanged() {
-    final Map<String, String> defaults = file("Footer", "ours", "UserID", "",
-        "MaxRate", "25000", "Dos", "0");
+  public void aValueTheLoadWouldNotRebuildIsWritten() {
+    final Map<String, String> written = ProfileFormat.toFile(
+        file("MaxRate", "25000"), after(file("MaxRate", "5000")));
+    assertEquals("25000", written.get("MaxRate"));
+  }
+
+  /* Saving must not strip a line another front end put there, whatever it
+     holds, or its reader falls back on a default we just took away. */
+  @Test
+  public void aKeyTheProfileCarriedSurvivesASave() {
+    final Map<String, String> written = ProfileFormat.toFile(
+        file("Footer", "ours", "UserID", "", "Dos", "0", "Iso9660", "0"),
+        after(file("Footer", "ours", "UserID", "", "Dos", "0"), "Footer",
+            "UserID", "Dos"));
+    assertEquals("ours", written.get("Footer"));
+    assertEquals("", written.get("UserID"));
+    assertEquals("0", written.get("Dos"));
+  }
+
+  /* Leaving a key out must not change what the project means, since the load
+     rebuilds the same baseline. */
+  @Test
+  public void droppingSeededValuesLeavesTheProjectUnchanged() {
+    final Map<String, String> seeded = file("Footer", "ours", "UserID", "",
+        "MaxRate", "5000", "Dos", "0", "Iso9660", "0");
     final Map<String, String> values = file("Footer", "theirs", "UserID", "",
         "MaxRate", "25000", "Sockets", "8", "Dos", "1", "Iso9660", "0");
-    final Map<String, String> reloaded = new LinkedHashMap<String, String>(
-        defaults);
-    reloaded.putAll(ProfileFormat.resolve(ProfileFormat.toFile(values,
-        defaults)));
+    final Map<String, String> reloaded = reload(seeded,
+        ProfileFormat.toFile(values, after(seeded)));
     for (final Map.Entry<String, String> setting : values.entrySet()) {
       final String was = setting.getValue();
       final String now = reloaded.get(setting.getKey());


### PR DESCRIPTION
Loading a project seeds Android's defaults, then lays the profile on top. `serialize()` wrote a line for every key it knows, using an empty value where the map held nothing, so every key came back present after a save.

Absent and empty are different things across front ends: WinHTTrack applies its own default for a missing key and takes an empty one literally. Opening a WinHTTrack project on the phone, changing nothing and saving was enough to leave our footer template and filter list in the file. The next desktop crawl then used them.

A key is now written only when the next load would not put it back by itself. The baseline for that is the map snapshotted once `resetMap()` has finished, not the built-in `fieldsDefaults` table: what refills an absent key is `initializeMap()` **plus** `loadDefaultPreferences()`, so a user with saved default options would otherwise lose settings. The first version of this branch made exactly that mistake, and the second commit is the fix. Any key the loaded profile carried is kept whatever it holds, so saving can only stop adding keys and never start removing someone else's line.

One consequence worth naming: a key left at the value the load rebuilds is no longer pinned in the file, so a project follows a later change to that baseline instead of holding the old value. For `Footer` that is what #122 wanted anyway.

Closes #126