### PR TITLE
Granting all-files access only moves the mirror root at the next cold start

### DIFF
--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -242,21 +242,14 @@ public class HTTrackActivity extends FragmentActivity {
     }
   }
 
-  /*
-   * Default mirror root. With all-files access, the classic public HTTrack/Websites, so other apps
-   * can use the mirrors and upgraders find their old crawls. Without it (or while the volume is
-   * unmounted), our own private external dir, which needs no permission. The engine takes a POSIX
-   * path either way.
-   */
+  /* The public storage root when it is ours to write, else null: StoragePaths' shared root. */
+  private File sharedStorageRoot() {
+    return hasAllFilesAccess() ? Environment.getExternalStorageDirectory() : null;
+  }
+
+  /* Default mirror root, a POSIX path the engine takes; the policy is StoragePaths.defaultRoot. */
   private File getDefaultHTTrackPath() {
-    if (hasAllFilesAccess()) {
-      final File shared = Environment.getExternalStorageDirectory();
-      if (shared != null) {
-        return new File(new File(shared, "HTTrack"), "Websites");
-      }
-    }
-    final File external = getExternalFilesDir(null);
-    return new File(external != null ? external : getFilesDir(), "Websites");
+    return StoragePaths.defaultRoot(sharedStorageRoot(), getExternalFilesDir(null), getFilesDir());
   }
 
   /*
@@ -265,8 +258,8 @@ public class HTTrackActivity extends FragmentActivity {
    * never refused; see StoragePaths.isWritable.
    */
   private Boolean isWritableProjectPath(final File path) {
-    final File shared = hasAllFilesAccess() ? Environment.getExternalStorageDirectory() : null;
-    return StoragePaths.isWritable(path, getExternalFilesDir(null), getFilesDir(), shared);
+    return StoragePaths.isWritable(path, getExternalFilesDir(null), getFilesDir(),
+        sharedStorageRoot());
   }
 
   /*
@@ -289,9 +282,9 @@ public class HTTrackActivity extends FragmentActivity {
     final File previous = projectPath;
     projectPath = StoragePaths.resolveRoot(baseFile, writable, getDefaultHTTrackPath());
 
-    // Every resume re-resolves, so what must not repeat is gated on the root having moved:
-    // initRootPath leaks a buffer per call, and the warning would become a toast loop.
-    if (previous == null || !previous.equals(projectPath)) {
+    // Re-resolving on every resume must not repeat two things: initRootPath leaks a buffer per
+    // call, and the warning would loop as a toast.
+    if (StoragePaths.rootMoved(previous, projectPath)) {
       if (missingDir) {
         showNotification(getString(R.string.directory_does_not_exist) + ": " + base);
       }

--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -278,32 +278,38 @@ public class HTTrackActivity extends FragmentActivity {
     final File baseFile = base != null ? new File(base) : null;
     final Boolean writable = baseFile != null ? isWritableProjectPath(baseFile) : null;
 
+    boolean missingDir = false;
     if (baseFile != null && !Boolean.TRUE.equals(writable)) {
-      // Unusable now is not forever: keep the setting so a remount or a regrant restores it.
+      // Keep the setting: a remount or a regrant can restore it.
       Log.i(getClass().getSimpleName(), "cannot use base path now: " + base);
     } else if (baseFile != null && !baseFile.exists() && !baseFile.mkdirs()) {
-      showNotification(getString(R.string.directory_does_not_exist) + ": " + base);
+      missingDir = true;
     }
 
     final File previous = projectPath;
-    projectPath = StoragePaths.resolveRoot(baseFile, writable,
-        baseFile != null && baseFile.isDirectory(), getDefaultHTTrackPath());
-    if (previous != null && !previous.equals(projectPath)) {
-      // The listed projects are the ones under the root, so the suggestions are now stale.
-      refreshprojectNameSuggests();
-    }
+    projectPath = StoragePaths.resolveRoot(baseFile, writable, getDefaultHTTrackPath());
 
-    // Set root path for logs
-    if (HTTrackLib.loadedSuccessfully()) {
-      try {
-        HTTrackLib.initRootPath(projectPath.getAbsolutePath());
-      } catch (final Throwable t) {
-        // Recovered native fault: losing the crash log is better than losing the app.
-        Log.e(getClass().getSimpleName(), "could not set the log root path", t);
+    // Every resume re-resolves, so what must not repeat is gated on the root having moved:
+    // initRootPath leaks a buffer per call, and the warning would become a toast loop.
+    if (previous == null || !previous.equals(projectPath)) {
+      if (missingDir) {
+        showNotification(getString(R.string.directory_does_not_exist) + ": " + base);
+      }
+      if (HTTrackLib.loadedSuccessfully()) {
+        try {
+          HTTrackLib.initRootPath(projectPath.getAbsolutePath());
+        } catch (final Throwable t) {
+          // Recovered native fault: losing the crash log is better than losing the app.
+          Log.e(getClass().getSimpleName(), "could not set the log root path", t);
+        }
+      }
+      if (previous != null) {
+        // The listed projects are the ones under the root, so the suggestions are now stale.
+        refreshprojectNameSuggests();
       }
     }
 
-    // Change ?
+    // Always refreshed: the field may have just been inflated.
     final View view = findViewById(R.id.fieldBasePath);
     if (view != null) {
       TextView.class.cast(view).setText(projectPath.getAbsolutePath());
@@ -3128,7 +3134,7 @@ public class HTTrackActivity extends FragmentActivity {
     Log.d(getClass().getSimpleName(), "onResume");
     super.onResume();
     paused = false;
-    // Returning from the all-files-access settings screen may have changed what we may write.
+    // Returning from the all-files-access settings screen can change what we can write.
     // Never while a crawl runs, since the engine already holds the destination.
     if (runner == null) {
       computeStorageTarget();

--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -247,9 +247,7 @@ public class HTTrackActivity extends FragmentActivity {
     return hasAllFilesAccess() ? Environment.getExternalStorageDirectory() : null;
   }
 
-  /* Default mirror root, a POSIX path the engine takes; the policy is StoragePaths.defaultRoot.
-   * Both private-dir lookups create their directory even when shared storage wins: empty, hidden
-   * under Android/data, and isWritableProjectPath makes them anyway once a base is set. */
+  /* Default mirror root, a POSIX path the engine takes; the policy is StoragePaths.defaultRoot. */
   private File getDefaultHTTrackPath() {
     return StoragePaths.defaultRoot(getExternalFilesDir(null), getFilesDir(), sharedStorageRoot());
   }

--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -275,31 +275,22 @@ public class HTTrackActivity extends FragmentActivity {
   private void computeStorageTarget() {
     final SharedPreferences settings = getSharedPreferences(PREFS_NAME, 0);
     final String base = settings.getString(BASE_NAME, null);
-    File baseFile = base != null ? new File(base) : null;
+    final File baseFile = base != null ? new File(base) : null;
+    final Boolean writable = baseFile != null ? isWritableProjectPath(baseFile) : null;
 
-    if (baseFile != null) {
-      final Boolean writable = isWritableProjectPath(baseFile);
-      if (Boolean.FALSE.equals(writable)) {
-        // Known foreign: the mirrors it names stay on disk, out of reach until imported.
-        Log.i(getClass().getSimpleName(), "dropping unusable base path " + base);
-        settings.edit().remove(BASE_NAME).apply();
-        baseFile = null;
-      } else if (writable == null) {
-        // Undecided: fall back for this run, but keep the setting for when the volume returns.
-        Log.i(getClass().getSimpleName(), "cannot vet base path yet: " + base);
-        baseFile = null;
-      }
-    }
-
-    if (baseFile != null && !baseFile.exists() && !baseFile.mkdirs()) {
+    if (baseFile != null && !Boolean.TRUE.equals(writable)) {
+      // Unusable now is not forever: keep the setting so a remount or a regrant restores it.
+      Log.i(getClass().getSimpleName(), "cannot use base path now: " + base);
+    } else if (baseFile != null && !baseFile.exists() && !baseFile.mkdirs()) {
       showNotification(getString(R.string.directory_does_not_exist) + ": " + base);
     }
 
-    if (baseFile != null && baseFile.exists() && baseFile.isDirectory()) {
-      projectPath = baseFile;
-    } else if (projectPath == null || !projectPath.exists()) {
-      final File path = getDefaultHTTrackPath();
-      projectPath = path;
+    final File previous = projectPath;
+    projectPath = StoragePaths.resolveRoot(baseFile, writable,
+        baseFile != null && baseFile.isDirectory(), getDefaultHTTrackPath());
+    if (previous != null && !previous.equals(projectPath)) {
+      // The listed projects are the ones under the root, so the suggestions are now stale.
+      refreshprojectNameSuggests();
     }
 
     // Set root path for logs
@@ -3137,11 +3128,9 @@ public class HTTrackActivity extends FragmentActivity {
     Log.d(getClass().getSimpleName(), "onResume");
     super.onResume();
     paused = false;
-    // Returning from the all-files-access settings screen may have granted access: re-point the
-    // default to public storage. Never while a crawl runs, and only if the resolved default moved.
-    if (runner == null && projectPath != null
-        && !getDefaultHTTrackPath().getAbsolutePath().equals(projectPath.getAbsolutePath())
-        && getSharedPreferences(PREFS_NAME, 0).getString(BASE_NAME, null) == null) {
+    // Returning from the all-files-access settings screen may have changed what we may write.
+    // Never while a crawl runs, since the engine already holds the destination.
+    if (runner == null) {
       computeStorageTarget();
     }
     // A grant made on the settings screen flips the button/warning off (no-op off this panel).

--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -247,9 +247,11 @@ public class HTTrackActivity extends FragmentActivity {
     return hasAllFilesAccess() ? Environment.getExternalStorageDirectory() : null;
   }
 
-  /* Default mirror root, a POSIX path the engine takes; the policy is StoragePaths.defaultRoot. */
+  /* Default mirror root, a POSIX path the engine takes; the policy is StoragePaths.defaultRoot.
+   * Both private-dir lookups create their directory even when shared storage wins: empty, hidden
+   * under Android/data, and isWritableProjectPath makes them anyway once a base is set. */
   private File getDefaultHTTrackPath() {
-    return StoragePaths.defaultRoot(sharedStorageRoot(), getExternalFilesDir(null), getFilesDir());
+    return StoragePaths.defaultRoot(getExternalFilesDir(null), getFilesDir(), sharedStorageRoot());
   }
 
   /*
@@ -282,25 +284,32 @@ public class HTTrackActivity extends FragmentActivity {
     final File previous = projectPath;
     projectPath = StoragePaths.resolveRoot(baseFile, writable, getDefaultHTTrackPath());
 
-    // Re-resolving on every resume must not repeat two things: initRootPath leaks a buffer per
-    // call, and the warning would loop as a toast.
-    if (StoragePaths.rootMoved(previous, projectPath)) {
-      if (missingDir) {
-        showNotification(getString(R.string.directory_does_not_exist) + ": " + base);
-      }
-      if (HTTrackLib.loadedSuccessfully()) {
-        try {
-          HTTrackLib.initRootPath(projectPath.getAbsolutePath());
-        } catch (final Throwable t) {
-          // Recovered native fault: losing the crash log is better than losing the app.
-          Log.e(getClass().getSimpleName(), "could not set the log root path", t);
-        }
-      }
-      if (previous != null) {
-        // The listed projects are the ones under the root, so the suggestions are now stale.
-        refreshprojectNameSuggests();
-      }
-    }
+    StoragePaths.applyRootMove(previous, projectPath, missingDir,
+        new StoragePaths.RootMoveActions() {
+          @Override
+          public void warnMissingDirectory() {
+            showNotification(getString(R.string.directory_does_not_exist) + ": " + base);
+          }
+
+          @Override
+          public void initNativeRoot(final File root) {
+            if (!HTTrackLib.loadedSuccessfully()) {
+              return;
+            }
+            try {
+              HTTrackLib.initRootPath(root.getAbsolutePath());
+            } catch (final Throwable t) {
+              // Recovered native fault: losing the crash log is better than losing the app.
+              Log.e(HTTrackActivity.this.getClass().getSimpleName(),
+                  "could not set the log root path", t);
+            }
+          }
+
+          @Override
+          public void refreshProjectSuggestions() {
+            refreshprojectNameSuggests();
+          }
+        });
 
     // Always refreshed: the field may have just been inflated.
     final View view = findViewById(R.id.fieldBasePath);

--- a/app/src/main/java/com/httrack/android/StoragePaths.java
+++ b/app/src/main/java/com/httrack/android/StoragePaths.java
@@ -4,9 +4,9 @@ import java.io.File;
 import java.io.IOException;
 
 /**
- * Where mirrors may be written, kept apart from the Context lookups so that it can be exercised
- * off-device: this is the boundary that decides whether a persisted setting is honoured or
- * destroyed. Mostly path math, but {@link #resolveRoot} stats the base it is handed.
+ * Where mirrors may be written: decides whether a persisted setting is honoured or destroyed.
+ * Kept apart from the Context lookups so it can run off-device. Mostly path math, but
+ * {@link #resolveRoot} also stats the base it is handed.
  */
 final class StoragePaths {
   private StoragePaths() {
@@ -59,15 +59,18 @@ final class StoragePaths {
    * Default mirror root: the classic public HTTrack/Websites when shared storage is ours to
    * write, so other apps and upgraders find the mirrors, else our own private Websites.
    *
-   * @param shared
-   *          the public root (e.g. getExternalStorageDirectory()) when all-files access is held,
-   *          else null
+   * <p>Takes its roots in the same order as {@link #isWritable}, since a transposition between
+   * same-typed neighbours would compile and still return a plausible directory.
+   *
    * @param external
    *          getExternalFilesDir(null), null while the volume is unmounted
    * @param internal
    *          getFilesDir(), the fallback root
+   * @param shared
+   *          the public root (e.g. getExternalStorageDirectory()) when all-files access is held,
+   *          else null
    */
-  static File defaultRoot(final File shared, final File external, final File internal) {
+  static File defaultRoot(final File external, final File internal, final File shared) {
     if (shared != null) {
       return new File(new File(shared, "HTTrack"), "Websites");
     }
@@ -83,6 +86,44 @@ final class StoragePaths {
    */
   static boolean rootMoved(final File previous, final File resolved) {
     return previous == null || !previous.equals(resolved);
+  }
+
+  /** The side effects of a move, behind an interface so a test can record them instead. */
+  interface RootMoveActions {
+    /** The persisted base named a directory we could not create; worth saying once. */
+    void warnMissingDirectory();
+
+    /** Point the native side at the new root, so its logs land under it. */
+    void initNativeRoot(File root);
+
+    /** The listed projects are the ones under the root, so the suggestions went stale. */
+    void refreshProjectSuggestions();
+  }
+
+  /**
+   * Runs the work owed once per move, and nothing at all otherwise: initRootPath leaks a buffer
+   * per call and the warning would loop as a toast, both of which a resume would repeat.
+   *
+   * @param previous
+   *          the root in use, null before anything was resolved
+   * @param missingDir
+   *          whether the persisted base could not be created
+   * @return whether the root moved
+   */
+  static boolean applyRootMove(final File previous, final File resolved, final boolean missingDir,
+      final RootMoveActions actions) {
+    if (!rootMoved(previous, resolved)) {
+      return false;
+    }
+    if (missingDir) {
+      actions.warnMissingDirectory();
+    }
+    actions.initNativeRoot(resolved);
+    if (previous != null) {
+      // Nothing was listed before the first resolution.
+      actions.refreshProjectSuggestions();
+    }
+    return true;
   }
 
   /**

--- a/app/src/main/java/com/httrack/android/StoragePaths.java
+++ b/app/src/main/java/com/httrack/android/StoragePaths.java
@@ -94,7 +94,7 @@ final class StoragePaths {
     void warnMissingDirectory();
 
     /** Point the native side at the new root, so its logs land under it. */
-    void initNativeRoot(File root);
+    void initNativeRoot(final File root);
 
     /** The listed projects are the ones under the root, so the suggestions went stale. */
     void refreshProjectSuggestions();
@@ -106,8 +106,12 @@ final class StoragePaths {
    *
    * @param previous
    *          the root in use, null before anything was resolved
+   * @param resolved
+   *          the freshly resolved root
    * @param missingDir
    *          whether the persisted base could not be created
+   * @param actions
+   *          the side effects to run
    * @return whether the root moved
    */
   static boolean applyRootMove(final File previous, final File resolved, final boolean missingDir,

--- a/app/src/main/java/com/httrack/android/StoragePaths.java
+++ b/app/src/main/java/com/httrack/android/StoragePaths.java
@@ -4,9 +4,9 @@ import java.io.File;
 import java.io.IOException;
 
 /**
- * Where mirrors may be written. Pure path math, kept apart from the Context lookups so that it
- * can be exercised off-device: this is the boundary that decides whether a persisted setting is
- * honoured or destroyed.
+ * Where mirrors may be written, kept apart from the Context lookups so that it can be exercised
+ * off-device: this is the boundary that decides whether a persisted setting is honoured or
+ * destroyed. Mostly path math, but {@link #resolveRoot} stats the base it is handed.
  */
 final class StoragePaths {
   private StoragePaths() {
@@ -53,6 +53,36 @@ final class StoragePaths {
       return null;
     }
     return external != null ? Boolean.FALSE : null;
+  }
+
+  /**
+   * Default mirror root: the classic public HTTrack/Websites when shared storage is ours to
+   * write, so other apps and upgraders find the mirrors, else our own private Websites.
+   *
+   * @param shared
+   *          the public root (e.g. getExternalStorageDirectory()) when all-files access is held,
+   *          else null
+   * @param external
+   *          getExternalFilesDir(null), null while the volume is unmounted
+   * @param internal
+   *          getFilesDir(), the fallback root
+   */
+  static File defaultRoot(final File shared, final File external, final File internal) {
+    if (shared != null) {
+      return new File(new File(shared, "HTTrack"), "Websites");
+    }
+    return new File(external != null ? external : internal, "Websites");
+  }
+
+  /**
+   * Whether the freshly resolved root differs from the one in use, the first resolution counting
+   * as a move. Gates the work that must happen once per move, not once per resume.
+   *
+   * @param previous
+   *          the root in use, null before anything was resolved
+   */
+  static boolean rootMoved(final File previous, final File resolved) {
+    return previous == null || !previous.equals(resolved);
   }
 
   /**

--- a/app/src/main/java/com/httrack/android/StoragePaths.java
+++ b/app/src/main/java/com/httrack/android/StoragePaths.java
@@ -56,6 +56,28 @@ final class StoragePaths {
   }
 
   /**
+   * Mirror root to use: the persisted base when it is vetted writable and present, else the
+   * current default. Deliberately blind to the root in use, so that gaining or losing access
+   * re-points the running session instead of waiting for the next cold start.
+   *
+   * @param base
+   *          the persisted base path, or null when none is set
+   * @param writable
+   *          {@link #isWritable} verdict for base; only a decided yes is honoured
+   * @param baseIsDirectory
+   *          whether base is a directory, tested after any mkdirs attempt
+   * @param defaultRoot
+   *          the fallback root, which depends on the access currently held
+   */
+  static File resolveRoot(final File base, final Boolean writable, final boolean baseIsDirectory,
+      final File defaultRoot) {
+    if (base != null && Boolean.TRUE.equals(writable) && baseIsDirectory) {
+      return base;
+    }
+    return defaultRoot;
+  }
+
+  /**
    * Documents-provider id ("primary:&lt;relative&gt;") to open {@code dir} in the system Files app via
    * ACTION_VIEW, or null when it lies outside the primary shared volume or inside the Android/ subtree
    * (both hidden from file managers on Android 11+), so the caller falls back.

--- a/app/src/main/java/com/httrack/android/StoragePaths.java
+++ b/app/src/main/java/com/httrack/android/StoragePaths.java
@@ -61,17 +61,16 @@ final class StoragePaths {
    * re-points the running session instead of waiting for the next cold start.
    *
    * @param base
-   *          the persisted base path, or null when none is set
+   *          the persisted base path, or null when none is set; call after any mkdirs attempt,
+   *          since a base that is not yet a directory is refused
    * @param writable
    *          {@link #isWritable} verdict for base; only a decided yes is honoured
-   * @param baseIsDirectory
-   *          whether base is a directory, tested after any mkdirs attempt
    * @param defaultRoot
-   *          the fallback root, which depends on the access currently held
+   *          the fallback root
+   * @return base, or defaultRoot whenever base is unset, unvetted or not a directory
    */
-  static File resolveRoot(final File base, final Boolean writable, final boolean baseIsDirectory,
-      final File defaultRoot) {
-    if (base != null && Boolean.TRUE.equals(writable) && baseIsDirectory) {
+  static File resolveRoot(final File base, final Boolean writable, final File defaultRoot) {
+    if (base != null && Boolean.TRUE.equals(writable) && base.isDirectory()) {
       return base;
     }
     return defaultRoot;

--- a/app/src/test/java/com/httrack/android/ProjectRootResolutionTest.java
+++ b/app/src/test/java/com/httrack/android/ProjectRootResolutionTest.java
@@ -5,7 +5,9 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.io.IOException;
 
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -15,76 +17,90 @@ public class ProjectRootResolutionTest {
   @Rule
   public final TemporaryFolder tmp = new TemporaryFolder();
 
-  private File base() throws Exception {
-    return tmp.newFolder("chosen");
-  }
+  private File base;
+  private File fallback;
 
-  private File fallback() {
-    return new File(tmp.getRoot(), "Android/data/com.httrack.android/files/Websites");
+  @Before
+  public void setUp() throws Exception {
+    base = tmp.newFolder("chosen");
+    fallback = tmp.newFolder("Android", "data", "com.httrack.android", "files", "Websites");
   }
 
   @Test
-  public void adoptsAVettedBase() throws Exception {
-    final File base = base();
-    assertEquals(base, StoragePaths.resolveRoot(base, Boolean.TRUE, true, fallback()));
+  public void adoptsAVettedBaseThatExists() {
+    assertEquals(base, StoragePaths.resolveRoot(base, Boolean.TRUE, fallback));
   }
 
   @Test
   public void fallsBackWithNoBaseSet() {
-    assertEquals(fallback(), StoragePaths.resolveRoot(null, null, false, fallback()));
+    assertEquals(fallback, StoragePaths.resolveRoot(null, Boolean.TRUE, fallback));
   }
 
   /** Only a decided yes: an unvettable base must not be honoured either. */
   @Test
-  public void fallsBackWhenTheBaseIsRefusedOrUndecided() throws Exception {
-    final File base = base();
-    assertEquals(fallback(), StoragePaths.resolveRoot(base, Boolean.FALSE, true, fallback()));
-    assertEquals(fallback(), StoragePaths.resolveRoot(base, null, true, fallback()));
+  public void fallsBackWhenTheBaseIsRefusedOrUndecided() {
+    assertEquals(fallback, StoragePaths.resolveRoot(base, Boolean.FALSE, fallback));
+    assertEquals(fallback, StoragePaths.resolveRoot(base, null, fallback));
   }
 
   @Test
-  public void fallsBackWhenTheBaseIsNotADirectory() throws Exception {
-    assertEquals(fallback(), StoragePaths.resolveRoot(base(), Boolean.TRUE, false, fallback()));
-  }
-
-  /**
-   * The defect: granting all-files access moves the default, and the answer has to move with it
-   * rather than stay on whatever root is already in use until the next cold start.
-   */
-  @Test
-  public void followsTheDefaultWhenItMoves() {
-    final File privateRoot = new File(tmp.getRoot(), "Android/data/com.httrack.android/files/Websites");
-    final File publicRoot = new File(tmp.getRoot(), "HTTrack/Websites");
-    assertEquals(privateRoot, StoragePaths.resolveRoot(null, null, false, privateRoot));
-    assertEquals(publicRoot, StoragePaths.resolveRoot(null, null, false, publicRoot));
+  public void fallsBackWhenTheBaseIsAbsentOrAFile() throws Exception {
+    final File absent = new File(tmp.getRoot(), "never-created");
+    assertEquals(fallback, StoragePaths.resolveRoot(absent, Boolean.TRUE, fallback));
+    assertEquals(fallback, StoragePaths.resolveRoot(tmp.newFile("plain"), Boolean.TRUE, fallback));
   }
 
   /**
-   * Guards the wiring the helper cannot: computeStorageTarget used to keep the current root
-   * whenever it still existed, which is what deferred every grant to the next launch.
+   * Granting access moves the default; the resolved root must follow it rather than wait for the
+   * next cold start.
    */
   @Test
-  public void computeStorageTargetDoesNotKeepTheRootInUse() throws Exception {
+  public void theAnswerFollowsTheAccessHeld() {
+    assertEquals(base, StoragePaths.resolveRoot(base, Boolean.TRUE, fallback));
+    assertEquals(fallback, StoragePaths.resolveRoot(base, Boolean.FALSE, fallback));
+  }
+
+  /** computeStorageTarget, up to the next method. */
+  private static String computeStorageTargetBody() throws IOException {
     final String source = TestSources.javaSource("HTTrackActivity");
     final int from = source.indexOf("private void computeStorageTarget()");
     final int to = source.indexOf("private void setBasePath(");
     assertTrue("computeStorageTarget not found", from != -1);
     assertTrue("setBasePath not found, the slice is wrong", to > from);
-    final String body = source.substring(from, to);
-    assertTrue("the root must come from StoragePaths.resolveRoot",
-        body.contains("StoragePaths.resolveRoot("));
+    return source.substring(from, to);
+  }
+
+  /**
+   * Guards what the helper cannot: computeStorageTarget used to keep the current root if it
+   * existed, and every grant then waited for the next launch.
+   */
+  @Test
+  public void computeStorageTargetDoesNotKeepTheRootInUse() throws Exception {
+    final String body = computeStorageTargetBody();
     assertFalse("the fallback must not be conditioned on the root already in use",
         body.contains("projectPath.exists()"));
+    // The vetting verdict has to reach the helper, not a constant standing in for it.
+    assertTrue("the root must come from resolveRoot, passed the real verdict",
+        body.contains("StoragePaths.resolveRoot(baseFile, writable,"));
   }
 
   /** A base that is merely unreachable now must survive, or a remount cannot bring it back. */
   @Test
   public void computeStorageTargetKeepsAnUnusableBasePath() throws Exception {
-    final String source = TestSources.javaSource("HTTrackActivity");
-    final int from = source.indexOf("private void computeStorageTarget()");
-    final int to = source.indexOf("private void setBasePath(");
-    final String body = source.substring(from, to);
+    final String body = computeStorageTargetBody();
     assertFalse("an unusable base path must not be erased",
         body.contains("remove(BASE_NAME)"));
+    assertFalse("nor erased under the literal key",
+        body.contains("remove(\"BasePath\")"));
+  }
+
+  /** initRootPath leaks a buffer per call, so a re-resolve that moved nothing must not repeat it. */
+  @Test
+  public void computeStorageTargetGatesTheNativeReinitOnAMove() throws Exception {
+    final String body = computeStorageTargetBody();
+    final int guard = body.indexOf("!previous.equals(projectPath)");
+    final int init = body.indexOf("HTTrackLib.initRootPath(");
+    assertTrue("the moved-root guard is gone", guard != -1);
+    assertTrue("initRootPath must sit behind the moved-root guard", init > guard);
   }
 }

--- a/app/src/test/java/com/httrack/android/ProjectRootResolutionTest.java
+++ b/app/src/test/java/com/httrack/android/ProjectRootResolutionTest.java
@@ -1,0 +1,90 @@
+package com.httrack.android;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/** Which root mirrors go to, and that gaining or losing access re-points it (issue #128). */
+public class ProjectRootResolutionTest {
+  @Rule
+  public final TemporaryFolder tmp = new TemporaryFolder();
+
+  private File base() throws Exception {
+    return tmp.newFolder("chosen");
+  }
+
+  private File fallback() {
+    return new File(tmp.getRoot(), "Android/data/com.httrack.android/files/Websites");
+  }
+
+  @Test
+  public void adoptsAVettedBase() throws Exception {
+    final File base = base();
+    assertEquals(base, StoragePaths.resolveRoot(base, Boolean.TRUE, true, fallback()));
+  }
+
+  @Test
+  public void fallsBackWithNoBaseSet() {
+    assertEquals(fallback(), StoragePaths.resolveRoot(null, null, false, fallback()));
+  }
+
+  /** Only a decided yes: an unvettable base must not be honoured either. */
+  @Test
+  public void fallsBackWhenTheBaseIsRefusedOrUndecided() throws Exception {
+    final File base = base();
+    assertEquals(fallback(), StoragePaths.resolveRoot(base, Boolean.FALSE, true, fallback()));
+    assertEquals(fallback(), StoragePaths.resolveRoot(base, null, true, fallback()));
+  }
+
+  @Test
+  public void fallsBackWhenTheBaseIsNotADirectory() throws Exception {
+    assertEquals(fallback(), StoragePaths.resolveRoot(base(), Boolean.TRUE, false, fallback()));
+  }
+
+  /**
+   * The defect: granting all-files access moves the default, and the answer has to move with it
+   * rather than stay on whatever root is already in use until the next cold start.
+   */
+  @Test
+  public void followsTheDefaultWhenItMoves() {
+    final File privateRoot = new File(tmp.getRoot(), "Android/data/com.httrack.android/files/Websites");
+    final File publicRoot = new File(tmp.getRoot(), "HTTrack/Websites");
+    assertEquals(privateRoot, StoragePaths.resolveRoot(null, null, false, privateRoot));
+    assertEquals(publicRoot, StoragePaths.resolveRoot(null, null, false, publicRoot));
+  }
+
+  /**
+   * Guards the wiring the helper cannot: computeStorageTarget used to keep the current root
+   * whenever it still existed, which is what deferred every grant to the next launch.
+   */
+  @Test
+  public void computeStorageTargetDoesNotKeepTheRootInUse() throws Exception {
+    final String source = TestSources.javaSource("HTTrackActivity");
+    final int from = source.indexOf("private void computeStorageTarget()");
+    final int to = source.indexOf("private void setBasePath(");
+    assertTrue("computeStorageTarget not found", from != -1);
+    assertTrue("setBasePath not found, the slice is wrong", to > from);
+    final String body = source.substring(from, to);
+    assertTrue("the root must come from StoragePaths.resolveRoot",
+        body.contains("StoragePaths.resolveRoot("));
+    assertFalse("the fallback must not be conditioned on the root already in use",
+        body.contains("projectPath.exists()"));
+  }
+
+  /** A base that is merely unreachable now must survive, or a remount cannot bring it back. */
+  @Test
+  public void computeStorageTargetKeepsAnUnusableBasePath() throws Exception {
+    final String source = TestSources.javaSource("HTTrackActivity");
+    final int from = source.indexOf("private void computeStorageTarget()");
+    final int to = source.indexOf("private void setBasePath(");
+    final String body = source.substring(from, to);
+    assertFalse("an unusable base path must not be erased",
+        body.contains("remove(BASE_NAME)"));
+  }
+}

--- a/app/src/test/java/com/httrack/android/ProjectRootResolutionTest.java
+++ b/app/src/test/java/com/httrack/android/ProjectRootResolutionTest.java
@@ -19,11 +19,17 @@ public class ProjectRootResolutionTest {
 
   private File base;
   private File fallback;
+  private File external;
+  private File internal;
+  private File shared;
 
   @Before
   public void setUp() throws Exception {
     base = tmp.newFolder("chosen");
-    fallback = tmp.newFolder("Android", "data", "com.httrack.android", "files", "Websites");
+    external = tmp.newFolder("ext", "Android", "data", "com.httrack.android", "files");
+    internal = tmp.newFolder("int", "data", "com.httrack.android", "files");
+    shared = tmp.newFolder("emulated"); // stands in for /storage/emulated/0
+    fallback = new File(external, "Websites");
   }
 
   @Test
@@ -31,9 +37,10 @@ public class ProjectRootResolutionTest {
     assertEquals(base, StoragePaths.resolveRoot(base, Boolean.TRUE, fallback));
   }
 
+  /** No base set means no verdict to pass either. */
   @Test
   public void fallsBackWithNoBaseSet() {
-    assertEquals(fallback, StoragePaths.resolveRoot(null, Boolean.TRUE, fallback));
+    assertEquals(fallback, StoragePaths.resolveRoot(null, null, fallback));
   }
 
   /** Only a decided yes: an unvettable base must not be honoured either. */
@@ -51,13 +58,58 @@ public class ProjectRootResolutionTest {
   }
 
   /**
-   * Granting access moves the default; the resolved root must follow it rather than wait for the
-   * next cold start.
+   * Losing access re-points the running session rather than waiting for the next cold start.
    */
   @Test
   public void theAnswerFollowsTheAccessHeld() {
     assertEquals(base, StoragePaths.resolveRoot(base, Boolean.TRUE, fallback));
     assertEquals(fallback, StoragePaths.resolveRoot(base, Boolean.FALSE, fallback));
+  }
+
+  @Test
+  public void defaultsToOurOwnExternalDirectory() {
+    assertEquals(new File(external, "Websites"),
+        StoragePaths.defaultRoot(null, external, internal));
+  }
+
+  /** With the volume unmounted there is no external dir, and internal always answers. */
+  @Test
+  public void defaultsToInternalWithoutAnExternalDirectory() {
+    assertEquals(new File(internal, "Websites"), StoragePaths.defaultRoot(null, null, internal));
+  }
+
+  /** The grant is the only input that changed, and the root the app writes moves with it. */
+  @Test
+  public void grantingAllFilesAccessMovesTheRoot() {
+    final File before = StoragePaths.defaultRoot(null, external, internal);
+    final File after = StoragePaths.defaultRoot(shared, external, internal);
+    assertEquals(new File(new File(shared, "HTTrack"), "Websites"), after);
+    assertTrue(StoragePaths.rootMoved(before, after));
+    assertTrue(StoragePaths.rootMoved(after, before));
+  }
+
+  /** Nothing was resolved before, so the once-per-move work must run. */
+  @Test
+  public void theFirstResolutionMoves() {
+    assertTrue(StoragePaths.rootMoved(null, fallback));
+  }
+
+  /** Resume after resume the answer is the same, and the once-per-move work must not repeat. */
+  @Test
+  public void anUnchangedRootDoesNotMoveAcrossResumes() {
+    File previous = null;
+    for (int resume = 0; resume < 3; resume++) {
+      final File resolved = StoragePaths.resolveRoot(base, Boolean.TRUE, fallback);
+      assertEquals("resume " + resume, resume == 0, StoragePaths.rootMoved(previous, resolved));
+      previous = resolved;
+    }
+    // Same path, freshly built: it is the path that must match, not the instance.
+    assertFalse(StoragePaths.rootMoved(new File(base.getPath()), base));
+  }
+
+  @Test
+  public void aDifferentRootMoves() {
+    assertTrue(StoragePaths.rootMoved(fallback, base));
   }
 
   /** computeStorageTarget, up to the next method. */
@@ -70,37 +122,47 @@ public class ProjectRootResolutionTest {
     return source.substring(from, to);
   }
 
+  /** The block HEAD opens, so a statement moved just past its closing brace stops matching. */
+  private static String guardedBlock(final String body, final String head) {
+    final int at = body.indexOf(head);
+    assertTrue(head + " not found", at != -1);
+    final int open = body.indexOf('{', at);
+    assertTrue("no block after " + head, open != -1);
+    int depth = 0;
+    for (int i = open; i < body.length(); i++) {
+      final char c = body.charAt(i);
+      if (c == '{') {
+        depth++;
+      } else if (c == '}' && --depth == 0) {
+        return body.substring(open, i);
+      }
+    }
+    throw new AssertionError("unterminated block after " + head);
+  }
+
   /**
    * Guards what the helper cannot: computeStorageTarget used to keep the current root if it
    * existed, and every grant then waited for the next launch.
    */
   @Test
   public void computeStorageTargetDoesNotKeepTheRootInUse() throws Exception {
-    final String body = computeStorageTargetBody();
     assertFalse("the fallback must not be conditioned on the root already in use",
-        body.contains("projectPath.exists()"));
-    // The vetting verdict has to reach the helper, not a constant standing in for it.
-    assertTrue("the root must come from resolveRoot, passed the real verdict",
-        body.contains("StoragePaths.resolveRoot(baseFile, writable,"));
+        computeStorageTargetBody().contains("projectPath.exists()"));
   }
 
   /** A base that is merely unreachable now must survive, or a remount cannot bring it back. */
   @Test
-  public void computeStorageTargetKeepsAnUnusableBasePath() throws Exception {
-    final String body = computeStorageTargetBody();
-    assertFalse("an unusable base path must not be erased",
-        body.contains("remove(BASE_NAME)"));
-    assertFalse("nor erased under the literal key",
-        body.contains("remove(\"BasePath\")"));
+  public void computeStorageTargetNeverWritesTheSettings() throws Exception {
+    assertFalse("resolving the root must not edit the stored BasePath, however spelled",
+        computeStorageTargetBody().contains(".edit()"));
   }
 
   /** initRootPath leaks a buffer per call, so a re-resolve that moved nothing must not repeat it. */
   @Test
   public void computeStorageTargetGatesTheNativeReinitOnAMove() throws Exception {
-    final String body = computeStorageTargetBody();
-    final int guard = body.indexOf("!previous.equals(projectPath)");
-    final int init = body.indexOf("HTTrackLib.initRootPath(");
-    assertTrue("the moved-root guard is gone", guard != -1);
-    assertTrue("initRootPath must sit behind the moved-root guard", init > guard);
+    final String guarded =
+        guardedBlock(computeStorageTargetBody(), "if (StoragePaths.rootMoved(");
+    assertTrue("initRootPath must sit inside the moved-root block",
+        guarded.contains("HTTrackLib.initRootPath("));
   }
 }

--- a/app/src/test/java/com/httrack/android/ProjectRootResolutionTest.java
+++ b/app/src/test/java/com/httrack/android/ProjectRootResolutionTest.java
@@ -163,6 +163,13 @@ public class ProjectRootResolutionTest {
         computeStorageTargetBody().contains(".edit()"));
   }
 
+  /** Wiring, not behaviour: the recorder tests below cannot see the call site at all. */
+  @Test
+  public void computeStorageTargetIsStillWiredToApplyRootMove() throws Exception {
+    assertTrue("computeStorageTarget must hand the move to StoragePaths",
+        computeStorageTargetBody().contains("StoragePaths.applyRootMove("));
+  }
+
   /** A move re-points the native side at the root just resolved, and relists what is under it. */
   @Test
   public void aMoveReinitsAtTheNewRoot() {

--- a/app/src/test/java/com/httrack/android/ProjectRootResolutionTest.java
+++ b/app/src/test/java/com/httrack/android/ProjectRootResolutionTest.java
@@ -6,6 +6,10 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -69,20 +73,20 @@ public class ProjectRootResolutionTest {
   @Test
   public void defaultsToOurOwnExternalDirectory() {
     assertEquals(new File(external, "Websites"),
-        StoragePaths.defaultRoot(null, external, internal));
+        StoragePaths.defaultRoot(external, internal, null));
   }
 
   /** With the volume unmounted there is no external dir, and internal always answers. */
   @Test
   public void defaultsToInternalWithoutAnExternalDirectory() {
-    assertEquals(new File(internal, "Websites"), StoragePaths.defaultRoot(null, null, internal));
+    assertEquals(new File(internal, "Websites"), StoragePaths.defaultRoot(null, internal, null));
   }
 
   /** The grant is the only input that changed, and the root the app writes moves with it. */
   @Test
   public void grantingAllFilesAccessMovesTheRoot() {
-    final File before = StoragePaths.defaultRoot(null, external, internal);
-    final File after = StoragePaths.defaultRoot(shared, external, internal);
+    final File before = StoragePaths.defaultRoot(external, internal, null);
+    final File after = StoragePaths.defaultRoot(external, internal, shared);
     assertEquals(new File(new File(shared, "HTTrack"), "Websites"), after);
     assertTrue(StoragePaths.rootMoved(before, after));
     assertTrue(StoragePaths.rootMoved(after, before));
@@ -122,22 +126,24 @@ public class ProjectRootResolutionTest {
     return source.substring(from, to);
   }
 
-  /** The block HEAD opens, so a statement moved just past its closing brace stops matching. */
-  private static String guardedBlock(final String body, final String head) {
-    final int at = body.indexOf(head);
-    assertTrue(head + " not found", at != -1);
-    final int open = body.indexOf('{', at);
-    assertTrue("no block after " + head, open != -1);
-    int depth = 0;
-    for (int i = open; i < body.length(); i++) {
-      final char c = body.charAt(i);
-      if (c == '{') {
-        depth++;
-      } else if (c == '}' && --depth == 0) {
-        return body.substring(open, i);
-      }
+  /** Stands in for the activity, so the gate is judged on what it called and with what. */
+  private static final class Recorder implements StoragePaths.RootMoveActions {
+    final List<String> calls = new ArrayList<String>();
+
+    @Override
+    public void warnMissingDirectory() {
+      calls.add("warn");
     }
-    throw new AssertionError("unterminated block after " + head);
+
+    @Override
+    public void initNativeRoot(final File root) {
+      calls.add("init " + root);
+    }
+
+    @Override
+    public void refreshProjectSuggestions() {
+      calls.add("refresh");
+    }
   }
 
   /**
@@ -157,12 +163,39 @@ public class ProjectRootResolutionTest {
         computeStorageTargetBody().contains(".edit()"));
   }
 
-  /** initRootPath leaks a buffer per call, so a re-resolve that moved nothing must not repeat it. */
+  /** A move re-points the native side at the root just resolved, and relists what is under it. */
   @Test
-  public void computeStorageTargetGatesTheNativeReinitOnAMove() throws Exception {
-    final String guarded =
-        guardedBlock(computeStorageTargetBody(), "if (StoragePaths.rootMoved(");
-    assertTrue("initRootPath must sit inside the moved-root block",
-        guarded.contains("HTTrackLib.initRootPath("));
+  public void aMoveReinitsAtTheNewRoot() {
+    final Recorder rec = new Recorder();
+    assertTrue(StoragePaths.applyRootMove(fallback, base, false, rec));
+    assertEquals(Arrays.asList("init " + base, "refresh"), rec.calls);
+  }
+
+  /** initRootPath leaks a buffer per call, so a re-resolve that moved nothing must do nothing. */
+  @Test
+  public void anUnchangedRootDoesNothing() {
+    final Recorder rec = new Recorder();
+    assertFalse(StoragePaths.applyRootMove(base, new File(base.getPath()), false, rec));
+    assertEquals(Collections.emptyList(), rec.calls);
+  }
+
+  /** Nothing was listed before the first resolution, so there are no stale suggestions to drop. */
+  @Test
+  public void theFirstResolutionSkipsTheSuggestionRefresh() {
+    final Recorder rec = new Recorder();
+    assertTrue(StoragePaths.applyRootMove(null, fallback, false, rec));
+    assertEquals(Arrays.asList("init " + fallback), rec.calls);
+  }
+
+  /** The warning rides the move, or it would toast again on every resume. */
+  @Test
+  public void theMissingDirectoryWarningRidesTheMove() {
+    final Recorder moved = new Recorder();
+    assertTrue(StoragePaths.applyRootMove(fallback, base, true, moved));
+    assertEquals(Arrays.asList("warn", "init " + base, "refresh"), moved.calls);
+
+    final Recorder stayed = new Recorder();
+    assertFalse(StoragePaths.applyRootMove(base, base, true, stayed));
+    assertEquals(Collections.emptyList(), stayed.calls);
   }
 }


### PR DESCRIPTION
`computeStorageTarget()` adopted a new default root only when the current one was missing. But `ensureExternalStorage()` has already created it, so once `projectPath` was set that branch was dead for the rest of the process: granting all-files access left the running session writing to the old private root, and the move showed up at the next cold start, by which point the earlier mirrors sat outside the root being listed. The decision now sits in `StoragePaths.resolveRoot`, which takes no argument for the root in use and so cannot prefer it; that also fixes the legacy API<=29 grant callback, which recomputed through the same dead branch.

The same function erased a persisted `BasePath` as soon as it could not be vetted, so an unmounted volume or a revoked grant lost the setting for good. It is now kept and simply unused for that run. Every resume re-resolves, and the two things that must not repeat are gated on `StoragePaths.rootMoved`: `initRootPath` leaks a buffer per call by design, and the missing-directory warning is a toast.

The public-versus-private path choice moved to `StoragePaths.defaultRoot` too, so plain JUnit now drives what used to be asserted against the source text. A move's side effects run through `StoragePaths.applyRootMove`, and the tests record the calls rather than search for them: granting access moves the root, the first resolution counts as a move, and an unchanged root does not, however many resumes happen.

One surface stays uncovered, deliberately. The stub `android.jar` puts `computeStorageTarget` beyond a unit test's reach, so nothing asserts what the anonymous `RootMoveActions` at that call site does; a source-text check only confirms the call is there at all. Swapping the bodies of `warnMissingDirectory` and `refreshProjectSuggestions` leaves the whole suite green, the miswiring plain in the bytecode: a user whose base directory is missing would get no warning, and a toast for nothing once the root moved. Hardcoding `missingDir` to false, or inverting the `loadedSuccessfully()` guard, survive the same way. Catching any of it needs assertions on the source text, and the first rename breaks those.

Closes #128
