### PR TITLE
Android writes a pause key the other front ends do not read

### DIFF
--- a/app/src/main/java/com/httrack/android/OptionsMapper.java
+++ b/app/src/main/java/com/httrack/android/OptionsMapper.java
@@ -88,7 +88,7 @@ public class OptionsMapper {
       new Pair<Integer, String>(R.id.editRetries, "Retry"),
       new Pair<Integer, String>(R.id.editMinTransferRate, "RateOut"),
       new Pair<Integer, String>(R.id.checkRemoveHostIfSlow, "RemoveRateout"),
-      new Pair<Integer, String>(R.id.editPause, "Pause"),
+      new Pair<Integer, String>(R.id.editPause, "PauseFiles"),
 
       /* Links */
       new Pair<Integer, String>(R.id.checkDetectAllLinks, "ParseAll"),
@@ -348,7 +348,7 @@ public class OptionsMapper {
       new Pair<String, OptionMapper>("Proxy", proxyHandler.getAddressMapper()),
       new Pair<String, OptionMapper>("Port", proxyHandler.getPortMapper()),
       new Pair<String, OptionMapper>("CookiesFile", new ArgumentOption("-%K")),
-      new Pair<String, OptionMapper>("Pause", new ArgumentOption("-%G")),
+      new Pair<String, OptionMapper>("PauseFiles", new ArgumentOption("-%G")),
       new Pair<String, OptionMapper>("StripQuery", new ArgumentOption("-%g")),
       new Pair<String, OptionMapper>("HostAlias", new RuleListOption(
           "--host-alias")),
@@ -420,7 +420,7 @@ public class OptionsMapper {
     // Spellings earlier builds wrote; accepted on read, never written back.
     private static final String LEGACY_NAMES[][] = {
         { "ProxyProtocol", "ProxyType" }, { "KeepWwwPrefix", "KeepWww" },
-        { "KeepDoubleSlashes", "KeepSlashes" } };
+        { "KeepDoubleSlashes", "KeepSlashes" }, { "Pause", "PauseFiles" } };
 
     // WinHTTrack packs both name-mangling boxes in Dos; Iso9660 is ours alone.
     static final String DOS_KEY = "Dos";

--- a/app/src/test/java/com/httrack/android/WinProfileParityTest.java
+++ b/app/src/test/java/com/httrack/android/WinProfileParityTest.java
@@ -16,6 +16,7 @@ import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.junit.Test;
@@ -171,37 +172,46 @@ public class WinProfileParityTest {
     return TestSources.javaSource("OptionsMapper");
   }
 
-  private static List<String> serializerKeys() throws IOException {
-    final Matcher m = Pattern.compile(
-        "new Pair<Integer, String>\\(R\\.id\\.\\w+,\\s*\"([^\"]+)\"\\)")
-        .matcher(mapperTable());
+  private static int occurrences(final String source, final String text) {
+    int count = 0;
+    for (int at = source.indexOf(text); at != -1; at = source.indexOf(text,
+        at + 1)) {
+      count++;
+    }
+    return count;
+  }
+
+  /* Counting the declarations separately keeps a regex that quietly stops
+     matching from passing every key test on a short list. */
+  private static List<String> keysOf(final String declaration,
+      final String pattern) throws IOException {
+    final String source = mapperTable();
+    final Matcher m = Pattern.compile(pattern).matcher(source);
     final List<String> keys = new ArrayList<String>();
     while (m.find()) {
       keys.add(m.group(1));
     }
-    assertEquals("serializer keys parsed", 94, keys.size());
+    assertEquals(declaration + " entries parsed",
+        occurrences(source, declaration), keys.size());
     return keys;
+  }
+
+  private static List<String> serializerKeys() throws IOException {
+    return keysOf("new Pair<Integer, String>(R.id.",
+        "new Pair<Integer, String>\\(R\\.id\\.\\w+,\\s*\"([^\"]+)\"\\)");
   }
 
   private static List<String> mapperKeys() throws IOException {
-    final Matcher m = Pattern.compile(
-        "new Pair<String, OptionMapper>\\(\"([^\"]+)\"").matcher(mapperTable());
-    final List<String> keys = new ArrayList<String>();
-    while (m.find()) {
-      keys.add(m.group(1));
-    }
-    assertEquals("mapper keys parsed", 94, keys.size());
-    return keys;
+    return keysOf("new Pair<String, OptionMapper>(",
+        "new Pair<String, OptionMapper>\\(\"([^\"]+)\"");
   }
 
-  /* Renaming a key in one table only strands the other half: an option whose
-     mapper no longer matches a stored key emits nothing, in silence. */
+  /* The two tables are halves of one wiring: a key stored with no mapper never
+     reaches the engine, and a mapper under no stored key never runs. */
   @Test
-  public void everyMapperKeyIsStored() throws IOException {
-    final List<String> stored = serializerKeys();
-    for (final String key : mapperKeys()) {
-      assertTrue(key + " maps an option no field stores", stored.contains(key));
-    }
+  public void everyStoredKeyHasAMapper() throws IOException {
+    assertEquals(new TreeSet<String>(serializerKeys()),
+        new TreeSet<String>(mapperKeys()));
   }
 
   @Test

--- a/app/src/test/java/com/httrack/android/WinProfileParityTest.java
+++ b/app/src/test/java/com/httrack/android/WinProfileParityTest.java
@@ -183,6 +183,27 @@ public class WinProfileParityTest {
     return keys;
   }
 
+  private static List<String> mapperKeys() throws IOException {
+    final Matcher m = Pattern.compile(
+        "new Pair<String, OptionMapper>\\(\"([^\"]+)\"").matcher(mapperTable());
+    final List<String> keys = new ArrayList<String>();
+    while (m.find()) {
+      keys.add(m.group(1));
+    }
+    assertEquals("mapper keys parsed", 94, keys.size());
+    return keys;
+  }
+
+  /* Renaming a key in one table only strands the other half: an option whose
+     mapper no longer matches a stored key emits nothing, in silence. */
+  @Test
+  public void everyMapperKeyIsStored() throws IOException {
+    final List<String> stored = serializerKeys();
+    for (final String key : mapperKeys()) {
+      assertTrue(key + " maps an option no field stores", stored.contains(key));
+    }
+  }
+
   @Test
   public void keysUseTheWinHttrackSpelling() throws IOException {
     final List<String> keys = serializerKeys();

--- a/app/src/test/java/com/httrack/android/WinProfileParityTest.java
+++ b/app/src/test/java/com/httrack/android/WinProfileParityTest.java
@@ -89,11 +89,12 @@ public class WinProfileParityTest {
   public void olderProfileKeepsEveryRenamedSetting() {
     final Map<String, String> values = ProfileFormat.resolve(file("Dos", "1",
         "Iso9660", "1", "ProxyProtocol", "1", "KeepWwwPrefix", "1",
-        "KeepDoubleSlashes", "1"));
+        "KeepDoubleSlashes", "1", "Pause", "2:5"));
     assertArrayEquals(new String[] { "1", "1" }, boxes(values));
     assertEquals("1", values.get("ProxyType"));
     assertEquals("1", values.get("KeepWww"));
     assertEquals("1", values.get("KeepSlashes"));
+    assertEquals("2:5", values.get("PauseFiles"));
     assertFalse(values.containsKey("ProxyProtocol"));
   }
 
@@ -159,6 +160,8 @@ public class WinProfileParityTest {
     assertEquals("KeepWww", ProfileFormat.canonicalName("KeepWwwPrefix"));
     assertEquals("KeepSlashes",
         ProfileFormat.canonicalName("KeepDoubleSlashes"));
+    assertEquals("PauseFiles", ProfileFormat.canonicalName("Pause"));
+    assertEquals("Pause", ProfileFormat.legacyName("PauseFiles"));
     assertEquals("Near", ProfileFormat.canonicalName("Near"));
     assertNull(ProfileFormat.legacyName("Near"));
   }
@@ -184,9 +187,9 @@ public class WinProfileParityTest {
   public void keysUseTheWinHttrackSpelling() throws IOException {
     final List<String> keys = serializerKeys();
     assertTrue(keys.containsAll(Arrays.asList("ProxyType", "KeepWww",
-        "KeepSlashes")));
+        "KeepSlashes", "PauseFiles")));
     for (final String legacy : new String[] { "ProxyProtocol",
-        "KeepWwwPrefix", "KeepDoubleSlashes" }) {
+        "KeepWwwPrefix", "KeepDoubleSlashes", "Pause" }) {
       assertFalse(legacy + " still written", keys.contains(legacy));
     }
   }
@@ -203,7 +206,7 @@ public class WinProfileParityTest {
       }
     }
     for (final String legacy : new String[] { "ProxyProtocol",
-        "KeepWwwPrefix", "KeepDoubleSlashes" }) {
+        "KeepWwwPrefix", "KeepDoubleSlashes", "Pause" }) {
       assertTrue(legacy + " resolves to no stored key",
           keys.contains(ProfileFormat.canonicalName(legacy)));
     }


### PR DESCRIPTION
Android wrote `Pause` for the random inter-file pause (`-%G`), where WinHTTrack and WebHTTrack both write `PauseFiles`. A profile written by one side reached the other two with that setting missing. This takes the majority spelling and reads the old one back through the rename shim that already carries `ProxyType`, `KeepWww` and `KeepSlashes`, so existing profiles and saved defaults keep their value.

This was the fourth and last divergence the three-way key census turned up; the other three landed in #124.