### PR TITLE
Play: halt a build on a track without emptying it

### DIFF
--- a/.github/workflows/play-halt.yml
+++ b/.github/workflows/play-halt.yml
@@ -1,0 +1,56 @@
+# Stop a track serving a build play-promote.yml already put there. Play refuses to halt a
+# release with nothing left to serve, so fallback_version_code names the build to put back.
+# Track names are the API's: alpha is Closed testing, beta is Open testing.
+name: Play halt
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_code:
+        description: 'versionCode to stop serving (integer)'
+        required: true
+      track:
+        description: 'track it is served on (internal, alpha = closed, beta = open)'
+        default: beta
+      fallback_version_code:
+        description: 'build to put back on the track, needed when the halted one is its last'
+        default: ''
+      dry_run:
+        description: 'print the plan and commit nothing'
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:                             # concurrent edits on the same app collide
+  group: play-promote
+
+jobs:
+  halt:
+    name: halt on Play
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: pip install -r tools/ci/play-requirements.txt
+      - name: Halt
+        # Inputs go through the environment, never interpolated into the script body.
+        env:
+          SA_JSON: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+          VERSION_CODE: ${{ inputs.version_code }}
+          TRACK: ${{ inputs.track }}
+          FALLBACK: ${{ inputs.fallback_version_code }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          umask 077
+          trap 'rm -f "$RUNNER_TEMP/play-sa.json"' EXIT
+          printf '%s' "$SA_JSON" > "$RUNNER_TEMP/play-sa.json"
+          args=()
+          if [ -n "$FALLBACK" ]; then args+=(--fallback "$FALLBACK"); fi
+          if [ "$DRY_RUN" = "true" ]; then args+=(--dry-run); fi
+          python3 tools/ci/play_track_admin.py "$RUNNER_TEMP/play-sa.json" halt \
+            "$VERSION_CODE" "$TRACK" "${args[@]}"

--- a/tools/ci/play_track_admin.py
+++ b/tools/ci/play_track_admin.py
@@ -9,6 +9,7 @@ Usage:
   play_track_admin.py <sa_json> list
   play_track_admin.py <sa_json> promote <versionCode> <fromTrack> <toTrack>
                       [--notes-dir DIR] [--halt-track TRACK] [--dry-run]
+  play_track_admin.py <sa_json> halt <versionCode> <track> [--fallback VC] [--dry-run]
 
 Track names are the API's, not the Console's: alpha is Closed testing, beta is
 Open testing.
@@ -120,11 +121,51 @@ def load_notes(notes_dir):
     return notes
 
 
+def holds(release, version_code):
+    return version_code in [int(c) for c in release.get("versionCodes") or []]
+
+
 def find_release(track, version_code):
     for rel in track.get("releases", []):
-        if version_code in [int(c) for c in rel.get("versionCodes") or []]:
+        if holds(rel, version_code):
             return rel
     return None
+
+
+def solo_release(track, version_code):
+    """The track's release holding version_code, refused when it carries sibling codes.
+
+    The PUT replaces the whole track, so a sibling would be dragged along with it.
+    """
+    rel = find_release(track, version_code)
+    if rel is None:
+        sys.exit(f"vc{version_code} is not on the {track['track']} track")
+    codes = rel.get("versionCodes") or []
+    if len(codes) > 1:
+        sys.exit(f"vc{version_code} shares a release with {', '.join(codes)}")
+    return rel
+
+
+def halt_release(track, version_code, fallback):
+    """The track's releases with version_code stopped, every other one kept as it is.
+
+    Play refuses to halt a release with nothing left to serve, and signals it with a bogus 500
+    at commit, so `fallback` names an earlier build to put back on the track in the same PUT.
+    """
+    releases = [
+        dict(r, status="halted") if holds(r, version_code) else r
+        for r in track.get("releases") or []
+    ]
+    if not any(r.get("status") not in ("halted", "draft") for r in releases):
+        if not fallback:
+            sys.exit(
+                f"halting vc{version_code} would leave {track['track']} serving nothing; "
+                "name an earlier build with --fallback"
+            )
+        releases.insert(
+            0, {"name": str(fallback), "versionCodes": [str(fallback)], "status": "completed"}
+        )
+    return releases
 
 
 def halted(track):
@@ -173,15 +214,62 @@ def unsupported_language(response, present):
     return named[0] if len(named) == 1 else None
 
 
+def halt_plan(args, by_name):
+    """The single PUT that stops `args.version_code` serving on its track."""
+    if not (args.version_code and args.from_track):
+        sys.exit("halt needs <versionCode> <track>")
+    if args.from_track not in by_name:
+        sys.exit(f"no such track: {args.from_track}")
+    # A live rollout has users on it; stopping one is a Console decision.
+    if args.from_track == "production":
+        sys.exit("refusing to halt production")
+    track = by_name[args.from_track]
+    if solo_release(track, args.version_code).get("status") == "halted":
+        sys.exit(f"vc{args.version_code} is already halted on {args.from_track}")
+    return [(args.from_track, halt_release(track, args.version_code, args.fallback))]
+
+
+def promote_plan(args, by_name, notes):
+    """The PUT(s) that put `args.version_code` on the target track, and optionally halt another."""
+    if not (args.version_code and args.from_track and args.to_track):
+        sys.exit("promote needs <versionCode> <fromTrack> <toTrack>")
+    if args.from_track not in by_name:
+        sys.exit(f"no such track: {args.from_track}")
+    src = solo_release(by_name[args.from_track], args.version_code)
+
+    release = {
+        "name": src.get("name", str(args.version_code)),
+        "versionCodes": [str(args.version_code)],
+        "status": "completed",
+    }
+    if notes:
+        release["releaseNotes"] = notes
+    elif src.get("releaseNotes"):
+        release["releaseNotes"] = src["releaseNotes"]
+
+    plan = [(args.to_track, [release])]
+    if args.halt_track:
+        if args.halt_track not in by_name:
+            sys.exit(f"no such track: {args.halt_track}")
+        # Both PUTs share one edit, so halting the target would undo the promote.
+        if args.halt_track == args.to_track:
+            sys.exit(f"--halt-track {args.halt_track} is also the promote target")
+        if args.halt_track == "production":
+            sys.exit("refusing to halt production")
+        plan.append((args.halt_track, halted(by_name[args.halt_track])))
+    return plan
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("sa_json")
-    ap.add_argument("mode", choices=["list", "promote"])
+    ap.add_argument("mode", choices=["list", "promote", "halt"])
     ap.add_argument("version_code", nargs="?", type=int)
     ap.add_argument("from_track", nargs="?")
     ap.add_argument("to_track", nargs="?")
     ap.add_argument("--notes-dir", help="directory of <locale>.txt release notes")
     ap.add_argument("--halt-track", help="track to stop serving, in the same edit")
+    ap.add_argument("--fallback", type=int, help="halt: build to put back on the track")
     ap.add_argument("--dry-run", action="store_true", help="print the plan, commit nothing")
     args = ap.parse_args()
 
@@ -212,38 +300,10 @@ def main():
         if args.mode == "list":
             return
 
-        if not (args.version_code and args.from_track and args.to_track):
-            sys.exit("promote needs <versionCode> <fromTrack> <toTrack>")
-        if args.from_track not in by_name:
-            sys.exit(f"no such track: {args.from_track}")
-        src = find_release(by_name[args.from_track], args.version_code)
-        if src is None:
-            sys.exit(f"vc{args.version_code} is not on the {args.from_track} track")
-        # A multi-code release would lose its siblings, since the PUT replaces the track.
-        codes = src.get("versionCodes") or []
-        if len(codes) > 1:
-            sys.exit(f"vc{args.version_code} shares a release with {', '.join(codes)}")
-
-        release = {
-            "name": src.get("name", str(args.version_code)),
-            "versionCodes": [str(args.version_code)],
-            "status": "completed",
-        }
-        if notes:
-            release["releaseNotes"] = notes
-        elif src.get("releaseNotes"):
-            release["releaseNotes"] = src["releaseNotes"]
-
-        plan = [(args.to_track, [release])]
-        if args.halt_track:
-            if args.halt_track not in by_name:
-                sys.exit(f"no such track: {args.halt_track}")
-            # Both PUTs share one edit, so halting the target would undo the promote.
-            if args.halt_track == args.to_track:
-                sys.exit(f"--halt-track {args.halt_track} is also the promote target")
-            if args.halt_track == "production":
-                sys.exit("refusing to halt production")
-            plan.append((args.halt_track, halted(by_name[args.halt_track])))
+        if args.mode == "halt":
+            plan = halt_plan(args, by_name)
+        else:
+            plan = promote_plan(args, by_name, notes)
 
         if args.dry_run:
             print("=== plan (dry run, nothing committed) ===")

--- a/tools/ci/play_track_admin_test.py
+++ b/tools/ci/play_track_admin_test.py
@@ -30,6 +30,13 @@ TRACKS = {
             "releases": [{"name": "3.49.14.86", "versionCodes": ["86"], "status": "completed"}],
         },
         {"track": "beta", "releases": []},
+        {
+            "track": "history",
+            "releases": [
+                {"name": "3.49.14.86", "versionCodes": ["86"], "status": "completed"},
+                {"name": "3.50-beta-1", "versionCodes": ["89"], "status": "completed"},
+            ],
+        },
         {"track": "empty", "releases": []},
         {"track": "production", "releases": []},
     ]
@@ -190,6 +197,61 @@ class Test(unittest.TestCase):
             with self.assertRaises(SystemExit):
                 run(promote("--halt-track", "alpha"), s)
         self.assertEqual(s.puts, [])
+
+    def test_halt_stops_one_release_and_leaves_the_others_alone(self):
+        s = FakeSession()
+        run(["halt", "89", "history"], s)
+        self.assertEqual(
+            dict(s.puts)["history"]["releases"],
+            [
+                {"name": "3.49.14.86", "versionCodes": ["86"], "status": "completed"},
+                {"name": "3.50-beta-1", "versionCodes": ["89"], "status": "halted"},
+            ],
+        )
+        self.assertEqual(len(s.commits), 1)
+
+    def test_halting_the_last_release_needs_a_fallback(self):
+        s = FakeSession()
+        with self.assertRaises(SystemExit):
+            run(["halt", "86", "alpha"], s)  # Play answers a fallback-less halt with a 500
+        self.assertEqual(s.puts, [])
+
+    def test_the_fallback_is_released_in_the_same_put(self):
+        s = FakeSession()
+        run(["halt", "86", "alpha", "--fallback", "83"], s)
+        self.assertEqual(
+            dict(s.puts)["alpha"]["releases"],
+            [
+                {"name": "83", "versionCodes": ["83"], "status": "completed"},
+                {"name": "3.49.14.86", "versionCodes": ["86"], "status": "halted"},
+            ],
+        )
+
+    def test_halting_an_already_halted_release_aborts(self):
+        s = FakeSession()
+        halted = [{"name": "x", "versionCodes": ["86"], "status": "halted"}]
+        with mock.patch.dict(TRACKS["tracks"][1], {"releases": halted}):
+            with self.assertRaises(SystemExit):
+                run(["halt", "86", "alpha"], s)
+        self.assertEqual(s.puts, [])
+
+    def test_halting_a_version_the_track_does_not_serve_aborts(self):
+        s = FakeSession()
+        with self.assertRaises(SystemExit):
+            run(["halt", "999", "alpha"], s)
+        self.assertEqual(s.puts, [])
+
+    def test_halt_refuses_production(self):
+        s = FakeSession()
+        with self.assertRaises(SystemExit):
+            run(["halt", "63", "production"], s)
+        self.assertEqual(s.puts, [])
+
+    def test_halt_dry_run_commits_nothing(self):
+        s = FakeSession()
+        out = run(["halt", "89", "history", "--dry-run"], s)
+        self.assertEqual((s.puts, s.commits), ([], []))
+        self.assertIn("dry run", out)
 
     def test_dry_run_commits_nothing(self):
         s = FakeSession()


### PR DESCRIPTION
vc96 went to open testing this morning and has to come back off it, and nothing in the tooling can do that. An empty `releases` list is a committed no-op, and `promote` only moves a build that some track still holds.

`halt <versionCode> <track>` PUTs the track back with that release flipped to `halted`, every other release untouched. Play will not halt a release with nothing left to serve, and reports that as a 500 at commit time, so `--fallback <versionCode>` puts an earlier build back on the track in the same PUT. `play-halt.yml` is the dispatch for it, dry run included.

Whether Play takes a lower versionCode as that fallback, I do not know. If it refuses, the PUT fails and the edit is never committed.