### PR TITLE
Play: release the halt fallback in its own edit

### DIFF
--- a/.github/workflows/play-halt.yml
+++ b/.github/workflows/play-halt.yml
@@ -1,5 +1,6 @@
 # Stop a track serving a build play-promote.yml already put there. Play refuses to halt a
-# release with nothing left to serve, so fallback_version_code names the build to put back.
+# release with nothing left to serve, so fallback_version_code names the build to put back,
+# released as its own commit first because Play rejects both moves inside one edit.
 # Track names are the API's: alpha is Closed testing, beta is Open testing.
 name: Play halt
 

--- a/tools/ci/play_track_admin.py
+++ b/tools/ci/play_track_admin.py
@@ -11,6 +11,9 @@ Usage:
                       [--notes-dir DIR] [--halt-track TRACK] [--dry-run]
   play_track_admin.py <sa_json> halt <versionCode> <track> [--fallback VC] [--dry-run]
 
+A plan is a list of stages, one committed edit each: promote is a single stage, and a
+halt that needs its fallback released first is two.
+
 Track names are the API's, not the Console's: alpha is Closed testing, beta is
 Open testing.
 """
@@ -146,26 +149,9 @@ def solo_release(track, version_code):
     return rel
 
 
-def halt_release(track, version_code, fallback):
-    """The track's releases with version_code stopped, every other one kept as it is.
-
-    Play refuses to halt a release with nothing left to serve, and signals it with a bogus 500
-    at commit, so `fallback` names an earlier build to put back on the track in the same PUT.
-    """
-    releases = [
-        dict(r, status="halted") if holds(r, version_code) else r
-        for r in track.get("releases") or []
-    ]
-    if not any(r.get("status") not in ("halted", "draft") for r in releases):
-        if not fallback:
-            sys.exit(
-                f"halting vc{version_code} would leave {track['track']} serving nothing; "
-                "name an earlier build with --fallback"
-            )
-        releases.insert(
-            0, {"name": str(fallback), "versionCodes": [str(fallback)], "status": "completed"}
-        )
-    return releases
+def serving(releases):
+    """Whether the track would still hand something out. A draft or halted release does not."""
+    return any(r.get("status") not in ("halted", "draft") for r in releases)
 
 
 def halted(track):
@@ -209,13 +195,19 @@ def unsupported_language(response, present):
         message = response.json().get("error", {}).get("message", "")
     except ValueError:
         return None
-    words = set(re.findall(r"[A-Za-z]{2}(?:-[A-Za-z]{2,4})?", message))
+    words = set(re.findall(r"\b[A-Za-z]{2}(?:-[A-Za-z]{2,4})?\b", message))
     named = [loc for loc in present if loc in words]
     return named[0] if len(named) == 1 else None
 
 
-def halt_plan(args, by_name):
-    """The single PUT that stops `args.version_code` serving on its track."""
+def halt_stages(args, by_name):
+    """The stages that stop `args.version_code` serving on its track.
+
+    Play refuses to halt a release with nothing left to serve (a bogus 500 at commit), and it
+    also refuses to halt one and fully roll another out inside a single edit. So when the track
+    has nothing else to fall back on, `--fallback` goes out as its own commit first and the halt
+    follows in a second one.
+    """
     if not (args.version_code and args.from_track):
         sys.exit("halt needs <versionCode> <track>")
     if args.from_track not in by_name:
@@ -226,11 +218,28 @@ def halt_plan(args, by_name):
     track = by_name[args.from_track]
     if solo_release(track, args.version_code).get("status") == "halted":
         sys.exit(f"vc{args.version_code} is already halted on {args.from_track}")
-    return [(args.from_track, halt_release(track, args.version_code, args.fallback))]
+
+    stopped = [
+        dict(r, status="halted") if holds(r, args.version_code) else r
+        for r in track.get("releases") or []
+    ]
+    if serving(stopped):
+        return [[(args.from_track, stopped)]]
+    if not args.fallback:
+        sys.exit(
+            f"halting vc{args.version_code} would leave {args.from_track} serving nothing; "
+            "name an earlier build with --fallback"
+        )
+    back = {
+        "name": str(args.fallback),
+        "versionCodes": [str(args.fallback)],
+        "status": "completed",
+    }
+    return [[(args.from_track, [back])], [(args.from_track, [back] + stopped)]]
 
 
 def promote_plan(args, by_name, notes):
-    """The PUT(s) that put `args.version_code` on the target track, and optionally halt another."""
+    """The one stage that puts `args.version_code` on the target track, and optionally halts another."""
     if not (args.version_code and args.from_track and args.to_track):
         sys.exit("promote needs <versionCode> <fromTrack> <toTrack>")
     if args.from_track not in by_name:
@@ -257,7 +266,7 @@ def promote_plan(args, by_name, notes):
         if args.halt_track == "production":
             sys.exit("refusing to halt production")
         plan.append((args.halt_track, halted(by_name[args.halt_track])))
-    return plan
+    return [plan]
 
 
 def main():
@@ -301,26 +310,34 @@ def main():
             return
 
         if args.mode == "halt":
-            plan = halt_plan(args, by_name)
+            stages = halt_stages(args, by_name)
         else:
-            plan = promote_plan(args, by_name, notes)
+            stages = promote_plan(args, by_name, notes)
 
         if args.dry_run:
             print("=== plan (dry run, nothing committed) ===")
-            print(json.dumps({t: rels for t, rels in plan}, indent=2, ensure_ascii=False))
+            for n, plan in enumerate(stages, 1):
+                print(f"--- edit {n} of {len(stages)} ---")
+                print(json.dumps({t: rels for t, rels in plan}, indent=2, ensure_ascii=False))
             return
 
-        for track, releases in plan:
-            print(f"=== PUT {track} ({len(releases)} release(s)) ===")
-            print(
-                json.dumps(put_track(session, eid, track, releases), indent=2, ensure_ascii=False)
-            )
-
-        c = session.post(f"{BASE}/edits/{eid}:commit", timeout=TIMEOUT)
-        if not c.ok:
-            sys.exit(f"commit failed: {c.status_code} {c.text}")
-        eid = None
-        print("committed")
+        for n, plan in enumerate(stages, 1):
+            if eid is None:  # each stage after the first needs an edit of its own
+                r = session.post(f"{BASE}/edits", timeout=TIMEOUT)
+                r.raise_for_status()
+                eid = r.json()["id"]
+            for track, releases in plan:
+                print(f"=== edit {n}: PUT {track} ({len(releases)} release(s)) ===")
+                print(
+                    json.dumps(
+                        put_track(session, eid, track, releases), indent=2, ensure_ascii=False
+                    )
+                )
+            c = session.post(f"{BASE}/edits/{eid}:commit", timeout=TIMEOUT)
+            if not c.ok:
+                sys.exit(f"commit failed: {c.status_code} {c.text}")
+            eid = None
+            print("committed")
 
         r = session.post(f"{BASE}/edits", timeout=TIMEOUT)  # fresh edit, just to read back
         r.raise_for_status()

--- a/tools/ci/play_track_admin_test.py
+++ b/tools/ci/play_track_admin_test.py
@@ -77,6 +77,7 @@ class FakeSession:
         self.fail_after_commit = fail_after_commit
         self.headers = {}
         self.puts = []
+        self.put_edits = []
         self.commits = []
         self.deleted = []
         self.reject_message = reject_message
@@ -108,11 +109,12 @@ class FakeSession:
 
     def put(self, url, json=None, **kw):
         track = url.rsplit("/", 1)[-1]
-        self._edit_id(url, f"/tracks/{track}")
+        eid = self._edit_id(url, f"/tracks/{track}")
         if self.reject_message is not None and self.reject_times > 0:
             self.reject_times -= 1
             return FakeResponse(400, {"error": {"message": self.reject_message}})
         self.puts.append((track, copy.deepcopy(json)))
+        self.put_edits.append(eid)
         return FakeResponse(200) if self.body_less_put else FakeResponse(200, json)
 
     def delete(self, url, **kw):
@@ -216,16 +218,31 @@ class Test(unittest.TestCase):
             run(["halt", "86", "alpha"], s)  # Play answers a fallback-less halt with a 500
         self.assertEqual(s.puts, [])
 
-    def test_the_fallback_is_released_in_the_same_put(self):
+    def test_the_fallback_is_released_in_its_own_edit_before_the_halt(self):
+        # Play rejects a halt and a new full rollout in one edit, so the two must not share one.
         s = FakeSession()
         run(["halt", "86", "alpha", "--fallback", "83"], s)
-        self.assertEqual(
-            dict(s.puts)["alpha"]["releases"],
-            [
-                {"name": "83", "versionCodes": ["83"], "status": "completed"},
-                {"name": "3.49.14.86", "versionCodes": ["86"], "status": "halted"},
-            ],
-        )
+        back = {"name": "83", "versionCodes": ["83"], "status": "completed"}
+        stopped = {"name": "3.49.14.86", "versionCodes": ["86"], "status": "halted"}
+        self.assertEqual([t for t, _ in s.puts], ["alpha", "alpha"])
+        self.assertEqual([body["releases"] for _, body in s.puts], [[back], [back, stopped]])
+        self.assertEqual(s.put_edits, ["edit-1", "edit-2"])
+        self.assertEqual(s.commits, ["edit-1", "edit-2"])
+        self.assertEqual(s.deleted, ["edit-3"])  # only the read-back edit is abandoned
+
+    def test_a_halt_needing_no_fallback_stays_in_one_edit(self):
+        s = FakeSession()
+        run(["halt", "89", "history"], s)
+        self.assertEqual(s.put_edits, ["edit-1"])
+        self.assertEqual(s.commits, ["edit-1"])
+
+    def test_an_error_naming_a_locale_inside_a_word_is_not_a_locale_rejection(self):
+        # "rolled" holds "ro", which is Romanian; matching it dropped a locale Play never named.
+        message = "You can't halt a fully rolled out release and create a new one in one edit."
+        r = FakeResponse(400, {"error": {"message": message}})
+        self.assertIsNone(pta.unsupported_language(r, {"ro", "en-US"}))
+        named = FakeResponse(400, {"error": {"message": "Invalid language: ro"}})
+        self.assertEqual(pta.unsupported_language(named, {"ro", "en-US"}), "ro")
 
     def test_halting_an_already_halted_release_aborts(self):
         s = FakeSession()


### PR DESCRIPTION
The halt run failed. Play answers a PUT that halts one release and fully rolls another one out with a 400: "You can't halt a fully rolled out release and create a new fully rolled out release in a single edit."

The fallback now goes out as its own commit, and the halt follows in a second edit, so `halt --fallback` costs two commits. A halt that needs no fallback still takes one edit, and promote is unchanged.

That same run printed "dropping unsupported locale ro", which turned out to be a second bug. The matcher that picks the locale out of Play's 400 was matching two-letter runs inside words, and "rolled" holds "ro". It read a rejection Play never made, dropped Romanian from the notes, and burned a retry. Whole words only now.