### PR TITLE
Continue an interrupted download runs as an update

### DIFF
--- a/app/src/main/java/com/httrack/android/CommandlineTokens.java
+++ b/app/src/main/java/com/httrack/android/CommandlineTokens.java
@@ -40,6 +40,47 @@ public final class CommandlineTokens {
   }
 
   /**
+   * Split a line-separated field value into one value per line, dropping the
+   * blank ones. Blanks inside a line are collapsed rather than split on, since
+   * an extra header or a rule holds them.
+   */
+  public static List<String> lineTokens(final String value) {
+    final List<String> out = new ArrayList<String>();
+    if (value == null) {
+      return out;
+    }
+    for (final String line : value.split("\n")) {
+      final String trimmed = line.replaceAll("\\s+", " ").trim();
+      if (trimmed.length() != 0) {
+        out.add(trimmed);
+      }
+    }
+    return out;
+  }
+
+  /* -%Z is the checkbox; --single-file-max-size switches single-file on by
+     itself, so both spellings count. */
+  private static final String SINGLE_FILE_TOKENS[] = { "-%Z",
+      "--single-file-max-size" };
+
+  /**
+   * True if these arguments ask for both ways of making one self-contained
+   * page. The engine refuses to start on MHTML (-%M) and single-file HTML
+   * together, naming the flags rather than the two boxes.
+   */
+  public static boolean hasSelfContainedConflict(final List<String> commandline) {
+    if (!commandline.contains("-%M")) {
+      return false;
+    }
+    for (final String token : SINGLE_FILE_TOKENS) {
+      if (commandline.contains(token)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
    * Split a rule-list field value into one rule per engine flag. Whitespace
    * separates two rules. Beside a ',' or an '=' it holds one rule together
    * instead, so it is dropped there rather than splitting the rule in three.

--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -1263,6 +1263,7 @@ public class HTTrackActivity extends FragmentActivity {
     private String string_ready;
     private String string_creating_project;
     private String string_starting_mirror;
+    private String string_self_contained_conflict;
     private String string_mirror_finished;
 
     /**
@@ -1310,6 +1311,8 @@ public class HTTrackActivity extends FragmentActivity {
       string_ready = getParentString(R.string.ready);
       string_creating_project = getParentString(R.string.creating_project);
       string_starting_mirror = getParentString(R.string.starting_mirror);
+      string_self_contained_conflict = getParentString(
+          R.string.self_contained_conflict);
       string_mirror_finished = getParentString(R.string.mirror_finished);
 
       // Execute pending actions now we are attached
@@ -1403,9 +1406,11 @@ public class HTTrackActivity extends FragmentActivity {
         args.add(target.getAbsolutePath());
 
         // Get args from mapper
-        for (final String cmd : parent.buildCommandline()) {
-          args.add(cmd);
+        final List<String> options = parent.buildCommandline();
+        if (CommandlineTokens.hasSelfContainedConflict(options)) {
+          throw new IOException(string_self_contained_conflict);
         }
+        args.addAll(options);
 
         // Final args array
         final String[] cargs = args.toArray(new String[] {});

--- a/app/src/main/java/com/httrack/android/OptionsMapper.java
+++ b/app/src/main/java/com/httrack/android/OptionsMapper.java
@@ -262,7 +262,8 @@ public class OptionsMapper {
   protected final GatedFeatureHandler sitemapHandler = new GatedFeatureHandler(
       "%m", "--sitemap-url");
   protected final GatedFeatureHandler singleFileHandler =
-      new GatedFeatureHandler("%Z", "--single-file-max-size");
+      new GatedFeatureHandler("%Z", new NumberArgumentOption(
+          "--single-file-max-size"));
   protected final PrimaryScanHandler primaryScanHandler = new PrimaryScanHandler();
   protected final MimeTypesHandler[] mimeTypesHandlers = new MimeTypesHandler[] {
       new MimeTypesHandler(), new MimeTypesHandler(), new MimeTypesHandler(),
@@ -1295,8 +1296,18 @@ public class OptionsMapper {
      *          The engine option the value follows
      */
     public GatedFeatureHandler(final String flag, final String option) {
+      this(flag, new ArgumentOption(option));
+    }
+
+    /**
+     * @param flag
+     *          The engine flag the checkbox emits
+     * @param value
+     *          The engine option the value follows
+     */
+    public GatedFeatureHandler(final String flag, final ArgumentOption value) {
       this.toggle = new SimpleOptionFlag(flag);
-      this.value = new ArgumentOption(option);
+      this.value = value;
     }
 
     /* fieldsSerializer emits the checkbox first, which is what lets the value
@@ -1463,6 +1474,25 @@ public class OptionsMapper {
       if (value != null && value.length() != 0) {
         commandline.add(option);
         commandline.add(value);
+      }
+    }
+  }
+
+  /**
+   * Argument option whose value must be a number. A field the engine scans as
+   * one panics on anything else, and no layout attribute can keep a non-digit
+   * out: inputType is a keyboard hint, and an imported profile reaches the
+   * field through setText.
+   */
+  public static class NumberArgumentOption extends ArgumentOption {
+    public NumberArgumentOption(final String option) {
+      super(option);
+    }
+
+    @Override
+    public void emit(final List<String> commandline, final String value) {
+      if (OptionValues.isDigits(value)) {
+        super.emit(commandline, value);
       }
     }
   }

--- a/app/src/main/java/com/httrack/android/OptionsMapper.java
+++ b/app/src/main/java/com/httrack/android/OptionsMapper.java
@@ -257,6 +257,12 @@ public class OptionsMapper {
   protected final BuildHandler buildHandler = new BuildHandler();
   protected final ProxyHandler proxyHandler = new ProxyHandler();
   protected final LogHandler logHandler = new LogHandler();
+  protected final GatedFeatureHandler warcHandler = new GatedFeatureHandler(
+      "%r", "--warc-file");
+  protected final GatedFeatureHandler sitemapHandler = new GatedFeatureHandler(
+      "%m", "--sitemap-url");
+  protected final GatedFeatureHandler singleFileHandler =
+      new GatedFeatureHandler("%Z", "--single-file-max-size");
   protected final PrimaryScanHandler primaryScanHandler = new PrimaryScanHandler();
   protected final MimeTypesHandler[] mimeTypesHandlers = new MimeTypesHandler[] {
       new MimeTypesHandler(), new MimeTypesHandler(), new MimeTypesHandler(),
@@ -309,16 +315,16 @@ public class OptionsMapper {
           "%q0")),
       new Pair<String, OptionMapper>("NoPurgeOldFiles", new SimpleOptionFlag(
           "X0")),
-      new Pair<String, OptionMapper>("Warc", new SimpleOptionFlag("%r")),
-      /* each companion enables its own feature; the toggle is optional */
-      new Pair<String, OptionMapper>("WarcFile", new ArgumentOption(
-          "--warc-file")),
-      new Pair<String, OptionMapper>("Sitemap", new SimpleOptionFlag("%m")),
-      new Pair<String, OptionMapper>("SitemapUrl", new ArgumentOption(
-          "--sitemap-url")),
-      new Pair<String, OptionMapper>("SingleFile", new SimpleOptionFlag("%Z")),
-      new Pair<String, OptionMapper>("SingleFileMaxSize", new ArgumentOption(
-          "--single-file-max-size")),
+      new Pair<String, OptionMapper>("Warc", warcHandler.getToggleMapper()),
+      new Pair<String, OptionMapper>("WarcFile", warcHandler.getValueMapper()),
+      new Pair<String, OptionMapper>("Sitemap",
+          sitemapHandler.getToggleMapper()),
+      new Pair<String, OptionMapper>("SitemapUrl",
+          sitemapHandler.getValueMapper()),
+      new Pair<String, OptionMapper>("SingleFile",
+          singleFileHandler.getToggleMapper()),
+      new Pair<String, OptionMapper>("SingleFileMaxSize",
+          singleFileHandler.getValueMapper()),
       new Pair<String, OptionMapper>("Changes", new SimpleOptionFlag("%d")),
       new Pair<String, OptionMapper>("Build", buildHandler.getTypeMapper()),
       new Pair<String, OptionMapper>("BuildString",
@@ -327,8 +333,7 @@ public class OptionsMapper {
       new Pair<String, OptionMapper>("Footer", new ArgumentOption("-%F")),
       new Pair<String, OptionMapper>("AcceptLanguage",
           new ArgumentOption("-%l")),
-      new Pair<String, OptionMapper>("OtherHeaders", new StringSplit(
-          Pattern.quote("\n"), "-%X")),
+      new Pair<String, OptionMapper>("OtherHeaders", new LineListOption("-%X")),
       new Pair<String, OptionMapper>("DefaultReferer",
           new ArgumentOption("-%R")),
       new Pair<String, OptionMapper>("Cookies",
@@ -366,10 +371,10 @@ public class OptionsMapper {
       new Pair<String, OptionMapper>("Index", new SimpleOptionFlag("I0", true)),
       new Pair<String, OptionMapper>("WordIndex", new SimpleOptionFlag("%I")),
       new Pair<String, OptionMapper>("MailIndex", new SimpleOptionFlag("%M")),
-      /* Checked is -C2, revalidate before reuse, not the engine's bare default
-         of preferring whatever the cache holds. */
-      new Pair<String, OptionMapper>("Cache", new MultipleChoicesOption(
-          new String[] { "C0", "C2" })),
+      /* Ticked emits nothing: the action token carries the cache mode in its
+         own digit (-iC1), and a -C here would overwrite it. */
+      new Pair<String, OptionMapper>("Cache",
+          new SimpleOptionFlag("C0", true)),
       new Pair<String, OptionMapper>("PrimaryScan",
           primaryScanHandler.getTypeMapper()),
       new Pair<String, OptionMapper>("Travel", MultipleChoicesOption.TRAVEL),
@@ -647,6 +652,25 @@ public class OptionsMapper {
     @Override
     public void emit(final List<String> commandline, final String value) {
       commandline.addAll(CommandlineTokens.urlTokens(value));
+    }
+  }
+
+  /**
+   * Line-separated list: emit the option once per line. Collapsing the blanks
+   * first, as StringSplit does, would eat the newlines and merge every line
+   * into one option.
+   */
+  public static class LineListOption extends StringSplit {
+    public LineListOption(final String option) {
+      super(option);
+    }
+
+    @Override
+    public void emit(final List<String> commandline, final String value) {
+      for (final String line : CommandlineTokens.lineTokens(value)) {
+        commandline.add(option);
+        commandline.add(line);
+      }
     }
   }
 
@@ -1251,6 +1275,65 @@ public class OptionsMapper {
           break;
         }
       }
+    }
+  }
+
+  /**
+   * A feature checkbox and the value option that configures it. The engine
+   * switches the feature on for either one, so the value only reaches it while
+   * the box is ticked, as WinHTTrack does.
+   */
+  public static class GatedFeatureHandler {
+    protected final SimpleOptionFlag toggle;
+    protected final ArgumentOption value;
+    protected boolean enabled;
+
+    /**
+     * @param flag
+     *          The engine flag the checkbox emits
+     * @param option
+     *          The engine option the value follows
+     */
+    public GatedFeatureHandler(final String flag, final String option) {
+      this.toggle = new SimpleOptionFlag(flag);
+      this.value = new ArgumentOption(option);
+    }
+
+    /* fieldsSerializer emits the checkbox first, which is what lets the value
+       read its state. */
+    private class Toggle implements OptionMapper {
+      @Override
+      public void emit(final List<String> commandline, final String value) {
+        GatedFeatureHandler.this.enabled = "1".equals(value);
+        toggle.emit(commandline, value);
+      }
+    }
+
+    private class Value implements OptionMapper {
+      @Override
+      public void emit(final List<String> commandline, final String value) {
+        if (GatedFeatureHandler.this.enabled) {
+          GatedFeatureHandler.this.value.emit(commandline, value);
+        }
+      }
+    }
+
+    /**
+     * Get the checkbox mapper
+     *
+     * @return the checkbox mapper
+     */
+    public OptionMapper getToggleMapper() {
+      return new Toggle();
+    }
+
+    /**
+     * Get the value mapper
+     *
+     * @return the value mapper
+     */
+    public OptionMapper getValueMapper() {
+      return new Value();
     }
   }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -239,6 +239,7 @@
     <string name="starting_worker_thread">Starting worker thread…</string>
     <string name="creating_project">Creating the project…</string>
     <string name="starting_mirror">Starting the mirror…</string>
+    <string name="self_contained_conflict">The mirror cannot make a self-contained page two ways at once. Untick either \"Build a single-file MHTML archive\" (Log, index, cache) or \"Inline assets as data: URIs\" (Build).</string>
     <string name="load_default">Load default options</string>
     <string name="save_default">Save default options</string>
     <string name="reset_default">Reset to default options</string>

--- a/app/src/test/java/com/httrack/android/OptionsEmissionTest.java
+++ b/app/src/test/java/com/httrack/android/OptionsEmissionTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertTrue;
 
 import com.httrack.android.OptionsMapper.ArgumentOption;
 import com.httrack.android.OptionsMapper.GatedFeatureHandler;
+import com.httrack.android.OptionsMapper.NumberArgumentOption;
 import com.httrack.android.OptionsMapper.LogHandler;
 import com.httrack.android.OptionsMapper.MultipleChoicesOption;
 import com.httrack.android.OptionsMapper.OptionMapper;
@@ -446,6 +447,26 @@ public class OptionsEmissionTest {
     assertEquals(Arrays.asList("X-One: 1", "X-Two: 2", "X-Three: 3"),
         CommandlineTokens.lineTokens("X-One: 1\n  X-Two: 2  \n\nX-Three: 3"));
     assertTrue(CommandlineTokens.lineTokens("  \n\n ").isEmpty());
+  }
+
+  /* An imported profile reaches the field through setText, past inputType, and
+     the engine panics on a size it cannot scan. */
+  @Test
+  public void aNumericCompanionDropsWhatIsNotANumber() {
+    final GatedFeatureHandler handler = new GatedFeatureHandler("%Z",
+        new NumberArgumentOption("--single-file-max-size"));
+    for (final String value : new String[] { "abc", "5000000abc", "-1", "1.5",
+        " 5000000", "" }) {
+      final List<String> cmd = new ArrayList<String>();
+      handler.getToggleMapper().emit(cmd, "1");
+      handler.getValueMapper().emit(cmd, value);
+      assertEquals("value " + value, Arrays.asList("-%Z"), cmd);
+    }
+    final List<String> cmd = new ArrayList<String>();
+    handler.getToggleMapper().emit(cmd, "1");
+    handler.getValueMapper().emit(cmd, "5000000");
+    assertEquals(
+        Arrays.asList("-%Z", "--single-file-max-size", "5000000"), cmd);
   }
 
   /* -%M and single-file HTML are two ways to fold a page into one file, and

--- a/app/src/test/java/com/httrack/android/OptionsEmissionTest.java
+++ b/app/src/test/java/com/httrack/android/OptionsEmissionTest.java
@@ -1,9 +1,11 @@
 package com.httrack.android;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import com.httrack.android.OptionsMapper.ArgumentOption;
+import com.httrack.android.OptionsMapper.GatedFeatureHandler;
 import com.httrack.android.OptionsMapper.LogHandler;
 import com.httrack.android.OptionsMapper.MultipleChoicesOption;
 import com.httrack.android.OptionsMapper.OptionMapper;
@@ -398,5 +400,64 @@ public class OptionsEmissionTest {
   @Test
   public void hostAliasIsWiredIntoTheProfile() throws IOException {
     assertTrue("HostAlias missing", serializerKeys().contains("HostAlias"));
+  }
+
+  private static List<String> emitGated(final String flag, final String option,
+      final String ticked, final String value) {
+    final GatedFeatureHandler handler = new GatedFeatureHandler(flag, option);
+    final List<String> cmd = new ArrayList<String>();
+    handler.getToggleMapper().emit(cmd, ticked);
+    handler.getValueMapper().emit(cmd, value);
+    return cmd;
+  }
+
+  /* The value switches the feature on by itself in the engine, so an unticked
+     box has to withhold it or nothing ever turns the feature off. */
+  @Test
+  public void aGatedValueNeedsItsBoxTicked() {
+    assertEquals(Arrays.asList("-%r", "--warc-file", "site.warc.gz"),
+        emitGated("%r", "--warc-file", "1", "site.warc.gz"));
+    assertTrue(emitGated("%r", "--warc-file", "0", "site.warc.gz").isEmpty());
+    assertEquals(Arrays.asList("-%Z"),
+        emitGated("%Z", "--single-file-max-size", "1", ""));
+    assertTrue(emitGated("%Z", "--single-file-max-size", "0", "5000000")
+        .isEmpty());
+  }
+
+  /* A second crawl must not inherit the first one's answer. */
+  @Test
+  public void aGatedValueRereadsItsBoxEachTime() {
+    final GatedFeatureHandler handler = new GatedFeatureHandler("%m",
+        "--sitemap-url");
+    final List<String> first = new ArrayList<String>();
+    handler.getToggleMapper().emit(first, "1");
+    handler.getValueMapper().emit(first, "http://example.com/sitemap.xml");
+    assertEquals(3, first.size());
+    final List<String> second = new ArrayList<String>();
+    handler.getToggleMapper().emit(second, "0");
+    handler.getValueMapper().emit(second, "http://example.com/sitemap.xml");
+    assertTrue(second.isEmpty());
+  }
+
+  /* Collapsing the blanks first turns every line into one, so "Other headers"
+     reached the engine as a single malformed header. */
+  @Test
+  public void aLineSeparatedFieldKeepsOneValuePerLine() {
+    assertEquals(Arrays.asList("X-One: 1", "X-Two: 2", "X-Three: 3"),
+        CommandlineTokens.lineTokens("X-One: 1\n  X-Two: 2  \n\nX-Three: 3"));
+    assertTrue(CommandlineTokens.lineTokens("  \n\n ").isEmpty());
+  }
+
+  /* -%M and single-file HTML are two ways to fold a page into one file, and
+     the engine refuses to start on both. */
+  @Test
+  public void bothWaysToOneSelfContainedPageAreRefused() {
+    assertTrue(CommandlineTokens.hasSelfContainedConflict(Arrays.asList("-%M",
+        "-%Z")));
+    assertTrue(CommandlineTokens.hasSelfContainedConflict(Arrays.asList("-%M",
+        "--single-file-max-size", "5000000")));
+    assertFalse(CommandlineTokens.hasSelfContainedConflict(Arrays.asList("-%M",
+        "-%I")));
+    assertFalse(CommandlineTokens.hasSelfContainedConflict(Arrays.asList("-%Z")));
   }
 }

--- a/app/src/test/java/com/httrack/android/WinProfileParityTest.java
+++ b/app/src/test/java/com/httrack/android/WinProfileParityTest.java
@@ -246,11 +246,10 @@ public class WinProfileParityTest {
   /* A hand-edited profile reaches the radio mappers with anything at all. */
   @Test
   public void aChoiceOutsideTheTableEmitsNothing() {
-    final OptionMapper cache = new MultipleChoicesOption(new String[] { "C0",
-        "C2" });
-    for (final String value : new String[] { "2", "99999999999", "", "abc",
+    for (final String value : new String[] { "4", "99999999999", "", "abc",
         null }) {
-      assertTrue("value " + value, emit(cache, value).isEmpty());
+      assertTrue("value " + value,
+          emit(MultipleChoicesOption.ACTION, value).isEmpty());
     }
   }
 
@@ -262,21 +261,53 @@ public class WinProfileParityTest {
         "new (SimpleOptionFlag|SimpleOption0)\\(\\s*\"([^\"]+)\""
             + "(?:\\s*,\\s*(?:/\\*[^*]*\\*/\\s*)?(true|false))?\\s*\\)")
         .matcher(mapperTable());
-    int reverted = 0;
-    int tristate = 0;
+    final List<String> reverted = new ArrayList<String>();
+    final List<String> tristate = new ArrayList<String>();
     while (m.find()) {
       final boolean isFlag = "SimpleOptionFlag".equals(m.group(1));
       if (isFlag && "true".equals(m.group(3))) {
-        reverted++;
+        reverted.add(m.group(2));
         assertTrue("-" + m.group(2) + " must carry its 0 form", m.group(2)
             .endsWith("0"));
       } else if (!isFlag) {
-        tristate++;
+        tristate.add(m.group(2));
         assertFalse("-" + m.group(2) + " emits both forms, so it may not be "
             + "spelled as its own off switch", m.group(2).endsWith("0"));
       }
     }
-    assertEquals("reverted flags parsed", 3, reverted);
-    assertEquals("tri-state options parsed", 4, tristate);
+    assertEquals("reverted flags", new TreeSet<String>(Arrays.asList("b0",
+        "j0", "I0", "C0")), new TreeSet<String>(reverted));
+    assertEquals("tri-state options", new TreeSet<String>(Arrays.asList("%P",
+        "%k", "%u", "%f")), new TreeSet<String>(tristate));
+  }
+
+  /* The engine reads -iC1 as -i followed by -C1, so a Cache token later in
+     argv decides the cache mode instead of the action radio. */
+  @Test
+  public void tickedCacheSaysNothingAboutTheCacheMode() throws IOException {
+    assertTrue("Cache must emit nothing when ticked", mapperTable().contains(
+        "new Pair<String, OptionMapper>(\"Cache\",\n"
+            + "          new SimpleOptionFlag(\"C0\", true)),"));
+    final OptionMapper cache = new SimpleOptionFlag("C0", true);
+    assertTrue(emit(cache, "1").isEmpty());
+    assertEquals(Arrays.asList("-C0"), emit(cache, "0"));
+  }
+
+  /* Each value is withheld until its box is ticked, as WinHTTrack does, and
+     the handler reads that box from the token emitted before it. */
+  @Test
+  public void everyGatedValueFollowsItsCheckbox() throws IOException {
+    final List<String> keys = serializerKeys();
+    final String pairs[][] = { { "Warc", "WarcFile" },
+        { "Sitemap", "SitemapUrl" },
+        { "SingleFile", "SingleFileMaxSize" } };
+    for (final String[] pair : pairs) {
+      assertTrue(pair[0] + " missing", keys.contains(pair[0]));
+      assertTrue(pair[1] + " missing", keys.contains(pair[1]));
+      assertTrue(pair[1] + " must follow " + pair[0],
+          keys.indexOf(pair[0]) < keys.indexOf(pair[1]));
+    }
+    assertEquals("gated pairs wired", pairs.length,
+        occurrences(mapperTable(), "Handler.getValueMapper()"));
   }
 }


### PR DESCRIPTION
Two Android options could write the same engine setting, and whichever came last in argv won. The Cache checkbox emitted `-C2`, which overwrote the cache mode carried in the action radio's own `-iC1` token, so "Continue an interrupted download" ran as an update. The engine reads `-iC1` as `-i` followed by `-C1` in one character walk, so the two are not separate tokens to it. The engine's key table gives `Cache` an empty `flag_on` and `--cache=0` for off, which is the shape the entry had before #124.

Auditing for siblings found three more. `WarcFile`, `SingleFileMaxSize` and `SitemapUrl` each switched their feature on by themselves, so unticking the box never turned it off; WinHTTrack gates all three on the checkbox, and now Android does too. "Other headers" was collapsed to one line before being split on newlines, so several headers arrived as one malformed header. And a mirror that asks for both ways of making a self-contained page now stops with a message naming the two checkboxes, instead of the engine refusing with flag names no Android user typed.

It also drops a `--single-file-max-size` value that is not a number. Xavier has ruled that the engine will panic on one rather than ignore it, and nothing here kept a non-digit out: `inputType` is a keyboard hint, not a filter, and an imported profile reaches the field through `setText`.

Two findings from the same audit are NOT fixed here, because both need a call rather than code: unticking "Accept cookies" silently voids a cookies file the user typed (the engine never opens it), and ticking both "Use DOS names" and "ISO9660" silently drops the second. The audit is in httrack-works under android-option-collisions/.
