### PR TITLE
Option fields the engine ignores now look ignored

### DIFF
--- a/app/src/main/java/com/httrack/android/OptionsActivity.java
+++ b/app/src/main/java/com/httrack/android/OptionsActivity.java
@@ -42,6 +42,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewGroup.LayoutParams;
 import android.widget.Button;
+import android.widget.CheckBox;
 import android.widget.EditText;
 import android.widget.LinearLayout;
 
@@ -102,6 +103,23 @@ public class OptionsActivity extends FragmentActivity implements
 
     /** Called when hiding the tab. **/
     public void onHide(final View view) {
+    }
+
+    /** Enable DEPENDENTS only while the box at BOXID is CHECKED; a disabled widget keeps
+     *  its value and is still saved. **/
+    protected static void enableWhile(final View view, final int boxId,
+        final boolean checked, final int... dependents) {
+      final CheckBox box = CheckBox.class.cast(view.findViewById(boxId));
+      setEnabled(view, dependents, box.isChecked() == checked);
+      box.setOnCheckedChangeListener((button, isChecked) -> setEnabled(view,
+          dependents, isChecked == checked));
+    }
+
+    private static void setEnabled(final View view, final int[] ids,
+        final boolean enabled) {
+      for (final int id : ids) {
+        view.findViewById(id).setEnabled(enabled);
+      }
     }
   }
 
@@ -195,6 +213,12 @@ public class OptionsActivity extends FragmentActivity implements
       R.id.checkHideQueryStrings, R.id.checkDoNotPurge, R.id.checkSingleFile,
       R.id.editSingleFileMaxSize, R.id.radioBuild, R.id.editCustomBuild })
   public static class BuildTab extends Tab {
+    @Override
+    public void onShow(final View view) {
+      super.onShow(view);
+      // Both boxes feed one -L token and -L0 wins, so ISO9660 cannot take effect here.
+      enableWhile(view, R.id.checkDosNames, false, R.id.checkIso9660);
+    }
   }
 
   @Title(R.string.browser_id)
@@ -214,6 +238,13 @@ public class OptionsActivity extends FragmentActivity implements
       R.id.checkUrlHacks, R.id.editHostAlias, R.id.checkTolerentRequests,
       R.id.checkForceHttp10 })
   public static class Spider extends Tab {
+    @Override
+    public void onShow(final View view) {
+      super.onShow(view);
+      // The engine reads the cookies file only when cookies are accepted.
+      enableWhile(view, R.id.checkAcceptCookies, true, R.id.textCookiesFile,
+          R.id.editCookiesFile);
+    }
   }
 
   @Title(R.string.proxy)

--- a/app/src/main/java/com/httrack/android/OptionsActivity.java
+++ b/app/src/main/java/com/httrack/android/OptionsActivity.java
@@ -43,6 +43,7 @@ import android.view.ViewGroup;
 import android.view.ViewGroup.LayoutParams;
 import android.widget.Button;
 import android.widget.CheckBox;
+import android.widget.CompoundButton;
 import android.widget.EditText;
 import android.widget.LinearLayout;
 
@@ -105,21 +106,33 @@ public class OptionsActivity extends FragmentActivity implements
     public void onHide(final View view) {
     }
 
-    /** Enable DEPENDENTS only while the box at BOXID is CHECKED; a disabled widget keeps
-     *  its value and is still saved. **/
-    protected static void enableWhile(final View view, final int boxId,
-        final boolean checked, final int... dependents) {
-      final CheckBox box = CheckBox.class.cast(view.findViewById(boxId));
-      setEnabled(view, dependents, box.isChecked() == checked);
-      box.setOnCheckedChangeListener((button, isChecked) -> setEnabled(view,
-          dependents, isChecked == checked));
+    /** Enable DEPENDENTS only while the box at BOXID is ticked; a disabled widget keeps its
+     *  value and is still saved. **/
+    protected static void enableWhileChecked(final View view, final int boxId,
+        final int... dependents) {
+      gate(view, boxId, true, dependents);
     }
 
-    private static void setEnabled(final View view, final int[] ids,
-        final boolean enabled) {
-      for (final int id : ids) {
-        view.findViewById(id).setEnabled(enabled);
-      }
+    /** Enable DEPENDENTS only while the box at BOXID is clear. **/
+    protected static void enableWhileClear(final View view, final int boxId,
+        final int... dependents) {
+      gate(view, boxId, false, dependents);
+    }
+
+    /*
+     * One gate per box, since the second call on a box would replace the first. The starting
+     * state goes through the listener too, so it cannot drift from what a toggle does.
+     */
+    private static void gate(final View view, final int boxId,
+        final boolean enabledWhenChecked, final int[] dependents) {
+      final CheckBox box = CheckBox.class.cast(view.findViewById(boxId));
+      final CompoundButton.OnCheckedChangeListener gate = (button, isChecked) -> {
+        for (final int id : dependents) {
+          view.findViewById(id).setEnabled(isChecked == enabledWhenChecked);
+        }
+      };
+      gate.onCheckedChanged(box, box.isChecked());
+      box.setOnCheckedChangeListener(gate);
     }
   }
 
@@ -217,7 +230,7 @@ public class OptionsActivity extends FragmentActivity implements
     public void onShow(final View view) {
       super.onShow(view);
       // Both boxes feed one -L token and -L0 wins, so ISO9660 cannot take effect here.
-      enableWhile(view, R.id.checkDosNames, false, R.id.checkIso9660);
+      enableWhileClear(view, R.id.checkDosNames, R.id.checkIso9660);
     }
   }
 
@@ -242,7 +255,7 @@ public class OptionsActivity extends FragmentActivity implements
     public void onShow(final View view) {
       super.onShow(view);
       // The engine reads the cookies file only when cookies are accepted.
-      enableWhile(view, R.id.checkAcceptCookies, true, R.id.textCookiesFile,
+      enableWhileChecked(view, R.id.checkAcceptCookies, R.id.textCookiesFile,
           R.id.editCookiesFile);
     }
   }

--- a/app/src/main/java/com/httrack/android/OptionsMapper.java
+++ b/app/src/main/java/com/httrack/android/OptionsMapper.java
@@ -197,6 +197,7 @@ public class OptionsMapper {
       new Pair<String, String>("Cache", "1"),
       new Pair<String, String>("NoRecatch", "0"),
       new Pair<String, String>("Dos", "0"),
+      new Pair<String, String>("Iso9660", "0"),
       new Pair<String, String>("Index", "1"),
       new Pair<String, String>("WordIndex", "0"),
       new Pair<String, String>("MailIndex", "0"),

--- a/app/src/main/java/com/httrack/android/OptionsMapper.java
+++ b/app/src/main/java/com/httrack/android/OptionsMapper.java
@@ -101,7 +101,7 @@ public class OptionsMapper {
 
       /* Build */
       new Pair<Integer, String>(R.id.checkDosNames, "Dos"),
-      new Pair<Integer, String>(R.id.checkIso9660, "Iso9660"), /* FIXME with Dos */
+      new Pair<Integer, String>(R.id.checkIso9660, "Iso9660"),
       new Pair<Integer, String>(R.id.checkNoErrorPages, "NoErrorPages"),
       new Pair<Integer, String>(R.id.checkNoExternalPages, "NoExternalPages"),
       new Pair<Integer, String>(R.id.checkHidePasswords, "NoPwdInPages"),

--- a/app/src/test/java/com/httrack/android/OptionsGatedFieldTest.java
+++ b/app/src/test/java/com/httrack/android/OptionsGatedFieldTest.java
@@ -1,0 +1,95 @@
+package com.httrack.android;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.junit.Test;
+
+/**
+ * A widget greyed out because the engine would ignore it must still be saved: the profile
+ * keeps the value either way.
+ */
+public class OptionsGatedFieldTest {
+  /** Layout, controlling box, box state that enables, gated views. */
+  private static final String[] EXPECTED = {
+      "activity_options_build checkDosNames=false checkIso9660",
+      "activity_options_spider checkAcceptCookies=true "
+          + "textCookiesFile,editCookiesFile" };
+
+  private static final Pattern GATE = Pattern
+      .compile("enableWhile\\(view, R\\.id\\.(\\w+), (true|false),([^;]*)\\);");
+
+  private static final Pattern TAB_LAYOUT = Pattern
+      .compile("@ActivityId\\(R\\.layout\\.(\\w+)\\)");
+
+  /** Layout of the tab class the call at OFFSET is in. */
+  private static String enclosingTab(final String source, final int offset) {
+    final Matcher m = TAB_LAYOUT.matcher(source.substring(0, offset));
+    String layout = null;
+    while (m.find()) {
+      layout = m.group(1);
+    }
+    assertFalse("gate outside any tab", layout == null);
+    return layout;
+  }
+
+  /** Every gate the options screen wires, in the EXPECTED notation. */
+  private static Set<String> gates() throws IOException {
+    final String source = TestSources.javaSource("OptionsActivity");
+    final Set<String> gates = new LinkedHashSet<String>();
+    final Matcher m = GATE.matcher(source);
+    while (m.find()) {
+      final List<String> gated = OptionsTabFieldsTest.ids(
+          OptionsTabFieldsTest.FIELD_ID, m.group(3));
+      assertFalse("gate on nothing: " + m.group(), gated.isEmpty());
+      gates.add(enclosingTab(source, m.start()) + " " + m.group(1) + "="
+          + m.group(2) + " " + String.join(",", gated));
+    }
+    return gates;
+  }
+
+  @Test
+  public void theOptionsScreenWiresTheGatesItIsMeantTo() throws IOException {
+    assertEquals(new LinkedHashSet<String>(Arrays.asList(EXPECTED)), gates());
+  }
+
+  @Test
+  public void aGatedViewIsInItsTabsLayoutAndStillSaved() throws IOException {
+    final Set<String> mapped = new HashSet<String>(OptionsTabFieldsTest.ids(
+        OptionsTabFieldsTest.FIELD_ID, TestSources.javaSource("OptionsMapper")));
+    final Map<String, List<String>> tabs = OptionsTabFieldsTest.tabs();
+    for (final String gate : gates()) {
+      final String[] parts = gate.split("[ =]");
+      final String layout = parts[0];
+      final List<String> views = new ArrayList<String>();
+      views.add(parts[1]);
+      views.addAll(Arrays.asList(parts[3].split(",")));
+      final List<String> fields = tabs.get(layout);
+      assertFalse("no tab for " + layout, fields == null);
+      for (final File file : TestSources.layouts(layout)) {
+        final Set<String> declared = new HashSet<String>(
+            OptionsTabFieldsTest.ids(OptionsTabFieldsTest.LAYOUT_ID,
+                TestSources.read(file)));
+        for (final String view : views) {
+          assertTrue(file.getName() + " has no " + view, declared.contains(view));
+        }
+      }
+      for (final String view : views) {
+        assertTrue(view + " is an option the tab does not save",
+            !mapped.contains(view) || fields.contains(view));
+      }
+    }
+  }
+}

--- a/app/src/test/java/com/httrack/android/OptionsGatedFieldTest.java
+++ b/app/src/test/java/com/httrack/android/OptionsGatedFieldTest.java
@@ -18,18 +18,18 @@ import java.util.regex.Pattern;
 import org.junit.Test;
 
 /**
- * A widget greyed out because the engine would ignore it must still be saved: the profile
- * keeps the value either way.
+ * The gates the options screen wires. A greyed widget is still saved, so each one has to stay
+ * declared in its tab's fields and present in its layout.
  */
 public class OptionsGatedFieldTest {
   /** Layout, controlling box, box state that enables, gated views. */
   private static final String[] EXPECTED = {
-      "activity_options_build checkDosNames=false checkIso9660",
-      "activity_options_spider checkAcceptCookies=true "
+      "activity_options_build checkDosNames=Clear checkIso9660",
+      "activity_options_spider checkAcceptCookies=Checked "
           + "textCookiesFile,editCookiesFile" };
 
   private static final Pattern GATE = Pattern
-      .compile("enableWhile\\(view, R\\.id\\.(\\w+), (true|false),([^;]*)\\);");
+      .compile("enableWhile(Checked|Clear)\\(view, R\\.id\\.(\\w+),([^;]*)\\);");
 
   private static final Pattern TAB_LAYOUT = Pattern
       .compile("@ActivityId\\(R\\.layout\\.(\\w+)\\)");
@@ -54,8 +54,8 @@ public class OptionsGatedFieldTest {
       final List<String> gated = OptionsTabFieldsTest.ids(
           OptionsTabFieldsTest.FIELD_ID, m.group(3));
       assertFalse("gate on nothing: " + m.group(), gated.isEmpty());
-      gates.add(enclosingTab(source, m.start()) + " " + m.group(1) + "="
-          + m.group(2) + " " + String.join(",", gated));
+      gates.add(enclosingTab(source, m.start()) + " " + m.group(2) + "="
+          + m.group(1) + " " + String.join(",", gated));
     }
     return gates;
   }
@@ -66,7 +66,7 @@ public class OptionsGatedFieldTest {
   }
 
   @Test
-  public void aGatedViewIsInItsTabsLayoutAndStillSaved() throws IOException {
+  public void aGatedViewIsInItsTabsLayoutAndFields() throws IOException {
     final Set<String> mapped = new HashSet<String>(OptionsTabFieldsTest.ids(
         OptionsTabFieldsTest.FIELD_ID, TestSources.javaSource("OptionsMapper")));
     final Map<String, List<String>> tabs = OptionsTabFieldsTest.tabs();

--- a/app/src/test/java/com/httrack/android/OptionsTabFieldsTest.java
+++ b/app/src/test/java/com/httrack/android/OptionsTabFieldsTest.java
@@ -26,12 +26,12 @@ public class OptionsTabFieldsTest {
       "@ActivityId\\(R\\.layout\\.(\\w+)\\)(.*?)public static class",
       Pattern.DOTALL);
 
-  private static final Pattern FIELD_ID = Pattern.compile("R\\.id\\.(\\w+)");
+  static final Pattern FIELD_ID = Pattern.compile("R\\.id\\.(\\w+)");
 
-  private static final Pattern LAYOUT_ID = Pattern
+  static final Pattern LAYOUT_ID = Pattern
       .compile("android:id=\"@\\+?id/(\\w+)\"");
 
-  private static List<String> ids(final Pattern pattern, final String text) {
+  static List<String> ids(final Pattern pattern, final String text) {
     final List<String> ids = new ArrayList<String>();
     final Matcher m = pattern.matcher(text);
     while (m.find()) {
@@ -41,7 +41,7 @@ public class OptionsTabFieldsTest {
   }
 
   /** Layout of each option tab, with the field ids that tab declares. */
-  private static Map<String, List<String>> tabs() throws IOException {
+  static Map<String, List<String>> tabs() throws IOException {
     final Map<String, List<String>> tabs = new LinkedHashMap<String, List<String>>();
     final Matcher tab = TAB.matcher(TestSources.javaSource("OptionsActivity"));
     while (tab.find()) {


### PR DESCRIPTION
Two fields on the options screen stay live while the engine ignores what they hold: the cookies file is read only when "Accept cookies" is ticked, and the ISO9660 box loses to DOS names, since both feed a single -L token and -L0 wins. They are now greyed out in the state where they do nothing. The value still saves, so the emitted command line and the profile bitmask are untouched and a `Dos=3` profile still round-trips.

`Iso9660` was also the one checkbox with no default, so "reset to defaults" used to leave it ticked.

Closes #141
Closes #142