### PR TITLE
Saving a project writes every option, so keys the profile never had come back set

### DIFF
--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -1418,7 +1418,7 @@ public class HTTrackActivity extends FragmentActivity {
             "starting engine: " + HTTrackActivity.printArray(cargs));
 
         // Serialize settings
-        parent.serialize(outLock);
+        parent.serialize(outLock, profile);
 
         // Progress info for slow phones
         setProgressLines(new String[] { string_starting_mirror });
@@ -1925,12 +1925,14 @@ public class HTTrackActivity extends FragmentActivity {
   /**
    * Serialize current profile to an existing OutputStream.
    * 
+   * @param profile
+   *          The profile file the stream writes for.
    * @throws IOException
    *           Upon I/O error.
    */
-  protected synchronized void serialize(final OutputStream os)
-      throws IOException {
-    mapper.serialize(os);
+  protected synchronized void serialize(final OutputStream os,
+      final File profile) throws IOException {
+    mapper.serialize(os, profile);
     os.flush();
   }
 

--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -1926,7 +1926,8 @@ public class HTTrackActivity extends FragmentActivity {
    * Serialize current profile to an existing OutputStream.
    * 
    * @param profile
-   *          The profile file the stream writes for.
+   *          The existing profile whose stated keys must be preserved; not
+   *          necessarily where the stream writes.
    * @throws IOException
    *           Upon I/O error.
    */

--- a/app/src/main/java/com/httrack/android/OptionsMapper.java
+++ b/app/src/main/java/com/httrack/android/OptionsMapper.java
@@ -520,22 +520,23 @@ public class OptionsMapper {
     }
 
     /* The four tables below are winprofile-keys.tsv columns for the keys we
-       write; WinProfileOmissionTest holds them against that table. */
+       write. */
 
     // default_state=derived: every front end computes its own value.
-    private static final String DERIVED[] = { "AcceptLanguage", "UserID" };
+    static final String DERIVED[] = { "AcceptLanguage", "UserID" };
 
     // default_state=none: no reader substitutes anything for an absent key.
-    private static final String NO_DEFAULT[] = { "Debugging", "Iso9660",
-        "MaxRate", "ProjectName", "Sockets", "WarcFile" };
+    static final String NO_DEFAULT[] = { "Debugging", "Iso9660", "MaxRate",
+        "ProjectName", "Sockets", "WarcFile" };
 
     // empty_means=literal: a reader takes an empty value at face value instead
     // of falling back, so a cleared field still has to be stated.
-    private static final String EMPTY_IS_LITERAL[] = { "AcceptLanguage",
-        "BuildString", "Footer", "UserID", "WildCardFilters" };
+    static final String EMPTY_IS_LITERAL[] = { "AcceptLanguage", "BuildString",
+        "Footer", "UserID", "WildCardFilters" };
 
     // Shared defaults that are not ours: our action radio seeds no value.
-    private static final String SHARED_DEFAULTS[][] = { { "CurrentAction", "0" } };
+    // A String[][] and not a Pair[]: the stub android.jar nulls Pair's fields.
+    static final String SHARED_DEFAULTS[][] = { { "CurrentAction", "0" } };
 
     private static boolean holds(final String set[], final String key) {
       for (final String entry : set) {
@@ -645,6 +646,24 @@ public class OptionsMapper {
         keys.add(DOS_KEY);
       }
       return keys;
+    }
+
+    /**
+     * Put PENDING in TARGET's place, dropping PENDING whichever way it goes.
+     *
+     * @throws IOException
+     *           When the rename fails, TARGET being left as it was.
+     */
+    static void commit(final File pending, final File target)
+        throws IOException {
+      try {
+        if (!pending.renameTo(target)) {
+          throw new IOException("could not rename " + pending + " over "
+              + target);
+        }
+      } finally {
+        pending.delete();
+      }
     }
   }
 
@@ -2021,7 +2040,6 @@ public class OptionsMapper {
     return dirty;
   }
 
-  /* The settings, by winprofile.ini key name. */
   private static Map<String, String> valuesOf(final SparseArray<String> map) {
     final Map<String, String> values = new LinkedHashMap<String, String>();
     for (final Pair<Integer, String> field : OptionsMapper.fieldsSerializer) {
@@ -2053,8 +2071,8 @@ public class OptionsMapper {
    * @param fos
    *          The Output Stream.
    * @param profile
-   *          The profile file the stream writes for, read back to tell which
-   *          keys it already states.
+   *          The existing profile whose stated keys must be preserved; not
+   *          necessarily where the stream writes.
    * @throws UnsupportedEncodingException
    *           Upon encoding error
    * @throws IOException
@@ -2112,7 +2130,8 @@ public class OptionsMapper {
   public void serialize(final File profile)
       throws UnsupportedEncodingException, IOException {
     // Through a sibling: a write that dies half way must not leave a truncated
-    // profile behind.
+    // profile behind, and statedKeys reads the original, which writing in place
+    // would have emptied.
     final File pending = new File(profile.getPath() + ".tmp");
     try {
       final FileOutputStream fos = new FileOutputStream(pending);
@@ -2121,10 +2140,15 @@ public class OptionsMapper {
       } finally {
         fos.close();
       }
-      if (!pending.renameTo(profile)) {
-        throw new IOException("could not rename " + pending + " over "
-            + profile);
+      // Reopened only to reach the disk before the rename does: serialize()
+      // closes the stream it is handed, taking the descriptor with it.
+      final FileOutputStream sync = new FileOutputStream(pending, true);
+      try {
+        sync.getFD().sync();
+      } finally {
+        sync.close();
       }
+      ProfileFormat.commit(pending, profile);
     } finally {
       pending.delete();
     }

--- a/app/src/main/java/com/httrack/android/OptionsMapper.java
+++ b/app/src/main/java/com/httrack/android/OptionsMapper.java
@@ -32,10 +32,12 @@ import java.io.OutputStreamWriter;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 import android.content.Context;
@@ -246,7 +248,7 @@ public class OptionsMapper {
       new Pair<String, String>("MaxRate", "25000"),
       new Pair<String, String>(
           "WildCardFilters",
-          "+*.png +*.gif +*.jpg +*.css +*.js -ad.doubleclick.net/* -mime:application/foobar"),
+          "+*.png +*.gif +*.jpg +*.jpeg +*.css +*.js -ad.doubleclick.net/* -mime:application/foobar"),
   // new Pair<String, String>("CurrentAction", "0")
   };
 
@@ -515,6 +517,134 @@ public class OptionsMapper {
       file.put(DOS_KEY, pack(values.get(DOS_KEY), values.get(ISO9660_KEY)));
       file.remove(ISO9660_KEY);
       return file;
+    }
+
+    /* The four tables below are winprofile-keys.tsv columns for the keys we
+       write; WinProfileOmissionTest holds them against that table. */
+
+    // default_state=derived: every front end computes its own value.
+    private static final String DERIVED[] = { "AcceptLanguage", "UserID" };
+
+    // default_state=none: no reader substitutes anything for an absent key.
+    private static final String NO_DEFAULT[] = { "Debugging", "Iso9660",
+        "MaxRate", "ProjectName", "Sockets", "WarcFile" };
+
+    // empty_means=literal: a reader takes an empty value at face value instead
+    // of falling back, so a cleared field still has to be stated.
+    private static final String EMPTY_IS_LITERAL[] = { "AcceptLanguage",
+        "BuildString", "Footer", "UserID", "WildCardFilters" };
+
+    // Shared defaults that are not ours: our action radio seeds no value.
+    private static final String SHARED_DEFAULTS[][] = { { "CurrentAction", "0" } };
+
+    private static boolean holds(final String set[], final String key) {
+      for (final String entry : set) {
+        if (entry.equals(key)) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    private static String text(final String value) {
+      return value != null ? value : "";
+    }
+
+    /**
+     * Whether leaving KEY out says the same thing as writing BASELINE for it.
+     *
+     * @param baseline
+     *          the value a freshly reset profile holds
+     * @param ourDefault
+     *          the value we substitute for an absent key
+     * @return true when every reader rebuilds BASELINE from nothing
+     */
+    static boolean absentMeansSame(final String key, final String baseline,
+        final String ourDefault) {
+      final String value = text(baseline);
+      if (value.length() == 0 && holds(EMPTY_IS_LITERAL, key)) {
+        return false;
+      }
+      if (holds(DERIVED, key)) {
+        return true;
+      }
+      if (holds(NO_DEFAULT, key)) {
+        return value.length() == 0;
+      }
+      for (final String[] shared : SHARED_DEFAULTS) {
+        if (shared[0].equals(key)) {
+          return shared[1].equals(value);
+        }
+      }
+      return text(ourDefault).equals(value);
+    }
+
+    /**
+     * The subset of {@link #toFile(Map)} a save has to state: what the file
+     * already carries, what differs from a freshly reset profile, and what
+     * another front end would not put back on its own.
+     *
+     * @param values
+     *          the settings to save
+     * @param baseline
+     *          the settings a freshly reset profile holds
+     * @param defaults
+     *          what we substitute for an absent key, by key
+     * @param present
+     *          the keys the file already states
+     * @return the pairs to write
+     */
+    static Map<String, String> toFile(final Map<String, String> values,
+        final Map<String, String> baseline, final Map<String, String> defaults,
+        final Set<String> present) {
+      final Map<String, String> file = toFile(values);
+      final Map<String, String> was = toFile(baseline);
+      final Map<String, String> stated = new LinkedHashMap<String, String>();
+      for (final Map.Entry<String, String> entry : file.entrySet()) {
+        final String key = entry.getKey();
+        final String seeded = was.get(key);
+        if (present.contains(key)
+            || !text(entry.getValue()).equals(text(seeded))
+            || !absentMeansSame(key, seeded, defaults.get(key))) {
+          stated.put(key, entry.getValue());
+        }
+      }
+      return stated;
+    }
+
+    /**
+     * The keys a profile file already states, under their current spelling.
+     *
+     * @param profile
+     *          The profile file (winprofile.ini)
+     * @return the keys, empty when there is no such file
+     * @throws IOException
+     *           Upon I/O error.
+     */
+    static Set<String> statedKeys(final File profile) throws IOException {
+      final Set<String> keys = new HashSet<String>();
+      if (!profile.exists()) {
+        return keys;
+      }
+      final BufferedReader reader = new BufferedReader(new FileReader(profile));
+      try {
+        String rawline;
+        while ((rawline = reader.readLine()) != null) {
+          final String line = rawline.trim();
+          final int sep = line.indexOf('=');
+          if (line.length() == 0 || line.charAt(0) == ';' || sep == -1) {
+            continue;
+          }
+          keys.add(canonicalName(line.substring(0, sep)));
+        }
+      } finally {
+        reader.close();
+      }
+      // Both name-mangling boxes live on the Dos line, so either states it.
+      if (keys.contains(ISO9660_KEY)) {
+        keys.add(DOS_KEY);
+      }
+      return keys;
     }
   }
 
@@ -1891,26 +2021,60 @@ public class OptionsMapper {
     return dirty;
   }
 
+  /* The settings, by winprofile.ini key name. */
+  private static Map<String, String> valuesOf(final SparseArray<String> map) {
+    final Map<String, String> values = new LinkedHashMap<String, String>();
+    for (final Pair<Integer, String> field : OptionsMapper.fieldsSerializer) {
+      values.put(field.second, map.get(field.first));
+    }
+    return values;
+  }
+
+  /* What a freshly reset profile holds, on a throwaway mapper: the saved
+     defaults resetMap() layers on top are part of the baseline. */
+  private Map<String, String> seededValues() {
+    final OptionsMapper seed = new OptionsMapper(context);
+    seed.resetMap();
+    return valuesOf(seed.map);
+  }
+
+  /* What we substitute for an absent key, by key. */
+  private static Map<String, String> ourDefaults() {
+    final Map<String, String> defaults = new LinkedHashMap<String, String>();
+    for (final Pair<String, String> field : OptionsMapper.fieldsDefaults) {
+      defaults.put(field.first, field.second);
+    }
+    return defaults;
+  }
+
   /**
    * Serialize settings on disk.
    * 
    * @param fos
    *          The Output Stream.
+   * @param profile
+   *          The profile file the stream writes for, read back to tell which
+   *          keys it already states.
    * @throws UnsupportedEncodingException
    *           Upon encoding error
    * @throws IOException
    *           Upon I/O error.
    */
-  public void serialize(final OutputStream fos)
+  public void serialize(final OutputStream fos, final File profile)
       throws UnsupportedEncodingException, IOException {
     final OutputStreamWriter writer = new OutputStreamWriter(fos);
     final BufferedWriter lwriter = new BufferedWriter(writer);
     try {
-      final Map<String, String> values = new LinkedHashMap<String, String>();
-      for (final Pair<Integer, String> field : OptionsMapper.fieldsSerializer) {
-        values.put(field.second, getMap(field.first));
+      final Map<String, String> values = valuesOf(map);
+      Set<String> present;
+      try {
+        present = ProfileFormat.statedKeys(profile);
+      } catch (final IOException e) {
+        // Nothing may be dropped from a profile we could not read back.
+        present = values.keySet();
       }
-      final Map<String, String> file = ProfileFormat.toFile(values);
+      final Map<String, String> file = ProfileFormat.toFile(values,
+          seededValues(), ourDefaults(), present);
       for (final Pair<Integer, String> field : OptionsMapper.fieldsSerializer) {
         final String key = field.second;
         if (!file.containsKey(key)) {
@@ -1947,11 +2111,22 @@ public class OptionsMapper {
    */
   public void serialize(final File profile)
       throws UnsupportedEncodingException, IOException {
-    final FileOutputStream fos = new FileOutputStream(profile);
+    // Through a sibling: a write that dies half way must not leave a truncated
+    // profile behind.
+    final File pending = new File(profile.getPath() + ".tmp");
     try {
-      serialize(fos);
+      final FileOutputStream fos = new FileOutputStream(pending);
+      try {
+        serialize(fos, profile);
+      } finally {
+        fos.close();
+      }
+      if (!pending.renameTo(profile)) {
+        throw new IOException("could not rename " + pending + " over "
+            + profile);
+      }
     } finally {
-      fos.close();
+      pending.delete();
     }
   }
 

--- a/app/src/test/java/com/httrack/android/OptionsEmissionTest.java
+++ b/app/src/test/java/com/httrack/android/OptionsEmissionTest.java
@@ -14,14 +14,10 @@ import com.httrack.android.OptionsMapper.PrimaryScanHandler;
 import com.httrack.android.OptionsMapper.ProxyHandler;
 import com.httrack.android.OptionsMapper.SimpleOptionFlag;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import org.junit.Test;
 
 /** Guards the argv emitted for the engine options exposed by issue #6. */
@@ -368,22 +364,8 @@ public class OptionsEmissionTest {
     }
   }
 
-  /* fieldsSerializer fixes the emission order but pulls in R.id, which the stub
-     android.jar cannot load, so read the declared order out of the source. */
   private static List<String> serializerKeys() throws IOException {
-    final String src = new String(Files.readAllBytes(Paths
-        .get("src/main/java/com/httrack/android/OptionsMapper.java")), "UTF-8");
-    final int from = src.indexOf("fieldsSerializer[] = new Pair[] {");
-    final int to = src.indexOf("\n  };", from);
-    assertTrue("fieldsSerializer not found", from != -1 && to > from);
-    final Matcher m = Pattern.compile(", \"(\\w+)\"\\)").matcher(
-        src.substring(from, to));
-    final List<String> keys = new ArrayList<String>();
-    while (m.find()) {
-      keys.add(m.group(1));
-    }
-    assertTrue("no keys parsed", keys.size() > 80);
-    return keys;
+    return TestSources.serializerKeys();
   }
 
   /* The engine counts URLs positionally and -iC* carries its 'i': behind the

--- a/app/src/test/java/com/httrack/android/TestSources.java
+++ b/app/src/test/java/com/httrack/android/TestSources.java
@@ -5,6 +5,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /** Checked-in sources the tests read; they run with the app project as
  *  working directory. */
@@ -59,5 +61,40 @@ final class TestSources {
   static String javaSource(final String name) throws IOException {
     return read(new File(dir("src/main/java"), "com/httrack/android/" + name
         + ".java"));
+  }
+
+  /** A file of the pinned engine submodule, such as "winprofile-keys.tsv". */
+  static File engineFile(final String name) {
+    return new File(dir("src/main/jni/httrack"), name);
+  }
+
+  static int occurrences(final String source, final String text) {
+    int count = 0;
+    for (int at = source.indexOf(text); at != -1; at = source.indexOf(text,
+        at + 1)) {
+      count++;
+    }
+    return count;
+  }
+
+  /** The winprofile.ini keys fieldsSerializer declares, in order. The table
+   *  pulls in R.id, which the stub android.jar cannot load, and three of its
+   *  entries wrap across two lines. */
+  static List<String> serializerKeys() throws IOException {
+    final String source = javaSource("OptionsMapper");
+    final String declaration = "new Pair<Integer, String>(R.id.";
+    final Matcher m = Pattern.compile(
+        "new Pair<Integer, String>\\(R\\.id\\.\\w+,\\s*\"([^\"]+)\"\\)")
+        .matcher(source);
+    final List<String> keys = new ArrayList<String>();
+    while (m.find()) {
+      keys.add(m.group(1));
+    }
+    // A regex that quietly stopped matching would shorten every list built here.
+    if (keys.size() != occurrences(source, declaration)) {
+      throw new IllegalStateException("parsed " + keys.size() + " of "
+          + occurrences(source, declaration) + " fieldsSerializer entries");
+    }
+    return keys;
   }
 }

--- a/app/src/test/java/com/httrack/android/WinProfileOmissionTest.java
+++ b/app/src/test/java/com/httrack/android/WinProfileOmissionTest.java
@@ -3,6 +3,7 @@ package com.httrack.android;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import com.httrack.android.OptionsMapper.ProfileFormat;
 import java.io.File;
@@ -20,9 +21,8 @@ import java.util.regex.Pattern;
 import org.junit.Test;
 
 /**
- * A save must not state a setting nobody chose: the other front ends read the
- * same file and substitute their own default for a key that is not there. The
- * policy is pinned to the engine's shared winprofile-keys.tsv.
+ * A save must not state a setting nobody chose, under the policy the engine's
+ * shared winprofile-keys.tsv pins.
  */
 public class WinProfileOmissionTest {
   /* Our default is the shared one for every agreed key but this: our action
@@ -30,13 +30,19 @@ public class WinProfileOmissionTest {
   private static final Set<String> KNOWN_DIVERGENCES = new TreeSet<String>(
       Arrays.asList("CurrentAction"));
 
+  /* Rows the defaults sweep cannot compare: a derived row counts as a skip the
+     same way an unresolved one does. */
+  private static final Set<String> NO_SHARED_DEFAULT = new TreeSet<String>(
+      Arrays.asList("AcceptLanguage", "Debugging", "Iso9660", "MaxRate",
+          "ProjectName", "Sockets", "UserID", "WarcFile"));
+
   private static final int KEY = 0;
+  private static final int OWNERS = 1;
   private static final int DEFAULT_STATE = 7;
   private static final int DEFAULT_VALUE = 8;
   private static final int EMPTY_MEANS = 9;
 
-  /* The shared key table, by key. A table we cannot read is a failure and
-     never a skip: a policy checked against nothing passes for no reason. */
+  /* A table we cannot read is a failure and never a skip. */
   private static Map<String, String[]> sharedTable() throws IOException {
     final File table = TestSources.engineFile("winprofile-keys.tsv");
     final Map<String, String[]> rows = new LinkedHashMap<String, String[]>();
@@ -76,8 +82,6 @@ public class WinProfileOmissionTest {
     return defaults;
   }
 
-  /* What the shared table says an absent key means, for a profile seeded with
-     BASELINE. */
   private static boolean tableSaysAbsentMeansSame(final String row[],
       final String baseline) {
     if (baseline.length() == 0 && "literal".equals(row[EMPTY_MEANS])) {
@@ -101,8 +105,36 @@ public class WinProfileOmissionTest {
         new TreeSet<String>(), unknown);
   }
 
-  /* The rule read back off the shared table, key by key and for each baseline
-     that changes the answer. */
+  /* The other direction: a key dropped from fieldsSerializer shortens every
+     list built off it, so nothing else here would notice. */
+  @Test
+  public void everyKeyTheTableGivesUsIsWritten() throws IOException {
+    final Set<String> ours = new TreeSet<String>(TestSources.serializerKeys());
+    final Set<String> missing = new TreeSet<String>();
+    for (final String row[] : sharedTable().values()) {
+      if (Arrays.asList(row[OWNERS].split(",")).contains("droid")
+          && !ours.contains(row[KEY])) {
+        missing.add(row[KEY]);
+      }
+    }
+    assertEquals("keys the table says we write but we do not",
+        new TreeSet<String>(), missing);
+  }
+
+  @Test
+  public void everyKeyTheFilterTablesNameIsWritten() throws IOException {
+    final Set<String> named = new TreeSet<String>();
+    named.addAll(Arrays.asList(ProfileFormat.DERIVED));
+    named.addAll(Arrays.asList(ProfileFormat.NO_DEFAULT));
+    named.addAll(Arrays.asList(ProfileFormat.EMPTY_IS_LITERAL));
+    for (final String shared[] : ProfileFormat.SHARED_DEFAULTS) {
+      named.add(shared[0]);
+    }
+    named.removeAll(TestSources.serializerKeys());
+    assertEquals("table entries naming a key we no longer write",
+        new TreeSet<String>(), named);
+  }
+
   @Test
   public void omissionAgreesWithTheSharedTable() throws IOException {
     final Map<String, String[]> shared = sharedTable();
@@ -123,16 +155,16 @@ public class WinProfileOmissionTest {
         TestSources.serializerKeys()), checked);
   }
 
-  /* Our default is what a reader of the shared table substitutes, or the two
-     disagree on what an absent key restores. */
   @Test
   public void ourDefaultsAreTheSharedOnes() throws IOException {
     final Map<String, String[]> shared = sharedTable();
     final Map<String, String> defaults = ourDefaults();
     final Set<String> diverging = new TreeSet<String>();
+    final Set<String> skipped = new TreeSet<String>();
     for (final String key : TestSources.serializerKeys()) {
       final String row[] = shared.get(key);
       if (!"agreed".equals(row[DEFAULT_STATE])) {
+        skipped.add(key);
         continue;
       }
       final String ours = defaults.containsKey(key) ? defaults.get(key) : "";
@@ -141,6 +173,7 @@ public class WinProfileOmissionTest {
       }
     }
     assertEquals(KNOWN_DIVERGENCES, diverging);
+    assertEquals("keys the sweep never compared", NO_SHARED_DEFAULT, skipped);
   }
 
   private static Map<String, String> values(final String... pairs) {
@@ -155,14 +188,18 @@ public class WinProfileOmissionTest {
     return new HashSet<String>(Arrays.asList(keys));
   }
 
-  /* A profile whose seeded values are exactly our defaults. */
+  /* What a reader substitutes for an absent key. Never the map a case passes
+     as the seed, so swapping the two arguments reds. */
+  private static final Map<String, String> OUR_DEFAULTS = values("Dos", "0",
+      "Footer", "<!-- ours -->", "WildCardFilters", "+*.png", "MaxRate",
+      "25000", "AcceptLanguage", "en,*");
+
   private static Map<String, String> written(final Map<String, String> values,
       final Map<String, String> seeded, final Set<String> present) {
-    return ProfileFormat.toFile(values, seeded, seeded, present);
+    return ProfileFormat.toFile(values, seeded, OUR_DEFAULTS, present);
   }
 
-  /* The bug: a WinHTTrack profile opened, changed in one field and saved came
-     back carrying our footer, our filter list and an empty Sockets line. */
+  /* The bug: a saved WinHTTrack profile came back with our footer. */
   @Test
   public void aSettingNobodyChoseStaysOutOfTheFile() {
     final Map<String, String> seeded = values("Depth", null, "Footer",
@@ -174,6 +211,17 @@ public class WinProfileOmissionTest {
     assertFalse("Footer restated", file.containsKey("Footer"));
     assertFalse("filters restated", file.containsKey("WildCardFilters"));
     assertFalse("Sockets restated", file.containsKey("Sockets"));
+  }
+
+  /* resetMap layers the user's saved defaults over the table, so what the seed
+     holds and what a reader substitutes are two different maps. */
+  @Test
+  public void aSavedDefaultMovesTheSeedOffOurTable() {
+    final Map<String, String> seeded = values("AcceptLanguage", "fr,*",
+        "MaxRate", "");
+    final Map<String, String> file = written(seeded, seeded, present());
+    assertFalse("AcceptLanguage stamped", file.containsKey("AcceptLanguage"));
+    assertFalse("MaxRate restated", file.containsKey("MaxRate"));
   }
 
   /* #127 in mirror image: an empty UserID is the user asking the engine to
@@ -263,8 +311,32 @@ public class WinProfileOmissionTest {
     assertTrue(ProfileFormat.statedKeys(missing).isEmpty());
   }
 
-  /* What a project that never had a profile writes: only the keys no reader
-     would put back on its own. */
+  @Test
+  public void commitReplacesTheProfile() throws IOException {
+    final File target = profile("old\n");
+    final File pending = profile("new\n");
+    ProfileFormat.commit(pending, target);
+    assertEquals("new\n", TestSources.read(target));
+    assertFalse("pending left behind", pending.exists());
+  }
+
+  @Test
+  public void commitThatCannotRenameLeavesTheProfileAlone() throws IOException {
+    final File target = profile("old\n");
+    assertTrue(target.delete() && target.mkdir());
+    final File pending = profile("new\n");
+    try {
+      ProfileFormat.commit(pending, target);
+      fail("renamed a file over a directory");
+    } catch (final IOException e) {
+      assertTrue(e.getMessage(), e.getMessage().contains(pending.getPath()));
+      assertTrue(e.getMessage(), e.getMessage().contains(target.getPath()));
+    }
+    assertFalse("pending left behind", pending.exists());
+    assertTrue("profile clobbered", target.isDirectory());
+    assertTrue(target.delete());
+  }
+
   @Test
   public void aBrandNewProjectStatesOnlyWhatCannotBeInferred()
       throws IOException {

--- a/app/src/test/java/com/httrack/android/WinProfileOmissionTest.java
+++ b/app/src/test/java/com/httrack/android/WinProfileOmissionTest.java
@@ -1,0 +1,283 @@
+package com.httrack.android;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.httrack.android.OptionsMapper.ProfileFormat;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.Writer;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.junit.Test;
+
+/**
+ * A save must not state a setting nobody chose: the other front ends read the
+ * same file and substitute their own default for a key that is not there. The
+ * policy is pinned to the engine's shared winprofile-keys.tsv.
+ */
+public class WinProfileOmissionTest {
+  /* Our default is the shared one for every agreed key but this: our action
+     radio seeds nothing, so the key is written whatever it holds. */
+  private static final Set<String> KNOWN_DIVERGENCES = new TreeSet<String>(
+      Arrays.asList("CurrentAction"));
+
+  private static final int KEY = 0;
+  private static final int DEFAULT_STATE = 7;
+  private static final int DEFAULT_VALUE = 8;
+  private static final int EMPTY_MEANS = 9;
+
+  /* The shared key table, by key. A table we cannot read is a failure and
+     never a skip: a policy checked against nothing passes for no reason. */
+  private static Map<String, String[]> sharedTable() throws IOException {
+    final File table = TestSources.engineFile("winprofile-keys.tsv");
+    final Map<String, String[]> rows = new LinkedHashMap<String, String[]>();
+    for (final String raw : TestSources.read(table).split("\n")) {
+      final String line = raw.endsWith("\r") ? raw.substring(0,
+          raw.length() - 1) : raw;
+      if (line.length() == 0 || line.charAt(0) == '#') {
+        continue;
+      }
+      final String columns[] = line.split("\t", -1);
+      assertEquals(line, 11, columns.length);
+      rows.put(columns[KEY], columns);
+    }
+    assertTrue("table holds " + rows.size() + " rows", rows.size() > 90);
+    return rows;
+  }
+
+  /* fieldsDefaults pulls in Pair, whose stub constructor drops both fields. */
+  private static Map<String, String> ourDefaults() throws IOException {
+    final String source = TestSources.javaSource("OptionsMapper");
+    final int from = source.indexOf("fieldsDefaults[] = new Pair[] {");
+    final int to = source.indexOf("\n  };", from);
+    assertTrue("fieldsDefaults not found", from != -1 && to > from);
+    // One entry is commented out, and would otherwise be read as declared.
+    final String declarations = source.substring(from, to).replaceAll(
+        "(?m)^\\s*//.*$", "");
+    final Matcher m = Pattern.compile(
+        "new Pair<String, String>\\(\\s*\"([^\"]+)\",\\s*\"([^\"]*)\"\\)")
+        .matcher(declarations);
+    final Map<String, String> defaults = new LinkedHashMap<String, String>();
+    while (m.find()) {
+      defaults.put(m.group(1), m.group(2));
+    }
+    assertEquals("fieldsDefaults entries parsed",
+        TestSources.occurrences(declarations, "new Pair<String, String>("),
+        defaults.size());
+    return defaults;
+  }
+
+  /* What the shared table says an absent key means, for a profile seeded with
+     BASELINE. */
+  private static boolean tableSaysAbsentMeansSame(final String row[],
+      final String baseline) {
+    if (baseline.length() == 0 && "literal".equals(row[EMPTY_MEANS])) {
+      return false;
+    }
+    if ("derived".equals(row[DEFAULT_STATE])) {
+      return true;
+    }
+    if ("none".equals(row[DEFAULT_STATE])) {
+      return baseline.length() == 0;
+    }
+    return row[DEFAULT_VALUE].equals(baseline);
+  }
+
+  @Test
+  public void everyWrittenKeyIsInTheSharedTable() throws IOException {
+    final Set<String> unknown = new TreeSet<String>(
+        TestSources.serializerKeys());
+    unknown.removeAll(sharedTable().keySet());
+    assertEquals("keys we write that the shared table does not state",
+        new TreeSet<String>(), unknown);
+  }
+
+  /* The rule read back off the shared table, key by key and for each baseline
+     that changes the answer. */
+  @Test
+  public void omissionAgreesWithTheSharedTable() throws IOException {
+    final Map<String, String[]> shared = sharedTable();
+    final Map<String, String> defaults = ourDefaults();
+    final Set<String> checked = new TreeSet<String>();
+    for (final String key : TestSources.serializerKeys()) {
+      final String row[] = shared.get(key);
+      assertTrue(key + " has no row", row != null);
+      for (final String baseline : new String[] { "", row[DEFAULT_VALUE],
+          "not-a-default" }) {
+        assertEquals(key + " seeded \"" + baseline + "\"",
+            tableSaysAbsentMeansSame(row, baseline),
+            ProfileFormat.absentMeansSame(key, baseline, defaults.get(key)));
+      }
+      checked.add(key);
+    }
+    assertEquals("keys checked", new TreeSet<String>(
+        TestSources.serializerKeys()), checked);
+  }
+
+  /* Our default is what a reader of the shared table substitutes, or the two
+     disagree on what an absent key restores. */
+  @Test
+  public void ourDefaultsAreTheSharedOnes() throws IOException {
+    final Map<String, String[]> shared = sharedTable();
+    final Map<String, String> defaults = ourDefaults();
+    final Set<String> diverging = new TreeSet<String>();
+    for (final String key : TestSources.serializerKeys()) {
+      final String row[] = shared.get(key);
+      if (!"agreed".equals(row[DEFAULT_STATE])) {
+        continue;
+      }
+      final String ours = defaults.containsKey(key) ? defaults.get(key) : "";
+      if (!row[DEFAULT_VALUE].equals(ours)) {
+        diverging.add(key);
+      }
+    }
+    assertEquals(KNOWN_DIVERGENCES, diverging);
+  }
+
+  private static Map<String, String> values(final String... pairs) {
+    final Map<String, String> values = new LinkedHashMap<String, String>();
+    for (int i = 0; i < pairs.length; i += 2) {
+      values.put(pairs[i], pairs[i + 1]);
+    }
+    return values;
+  }
+
+  private static Set<String> present(final String... keys) {
+    return new HashSet<String>(Arrays.asList(keys));
+  }
+
+  /* A profile whose seeded values are exactly our defaults. */
+  private static Map<String, String> written(final Map<String, String> values,
+      final Map<String, String> seeded, final Set<String> present) {
+    return ProfileFormat.toFile(values, seeded, seeded, present);
+  }
+
+  /* The bug: a WinHTTrack profile opened, changed in one field and saved came
+     back carrying our footer, our filter list and an empty Sockets line. */
+  @Test
+  public void aSettingNobodyChoseStaysOutOfTheFile() {
+    final Map<String, String> seeded = values("Depth", null, "Footer",
+        "<!-- ours -->", "WildCardFilters", "+*.png", "Sockets", null);
+    final Map<String, String> saved = new LinkedHashMap<String, String>(seeded);
+    saved.put("Depth", "3");
+    final Map<String, String> file = written(saved, seeded, present("Depth"));
+    assertEquals("3", file.get("Depth"));
+    assertFalse("Footer restated", file.containsKey("Footer"));
+    assertFalse("filters restated", file.containsKey("WildCardFilters"));
+    assertFalse("Sockets restated", file.containsKey("Sockets"));
+  }
+
+  /* #127 in mirror image: an empty UserID is the user asking the engine to
+     pick, and WinHTTrack reads an absent one as its own fixed literal. */
+  @Test
+  public void aFieldTheUserClearedIsStillStated() {
+    final Map<String, String> seeded = values("UserID", "", "AcceptLanguage",
+        "en,*", "OtherHeaders", "");
+    final Map<String, String> file = written(seeded, seeded, present());
+    assertEquals("", file.get("UserID"));
+    assertTrue("UserID dropped", file.containsKey("UserID"));
+    assertFalse("AcceptLanguage stamped", file.containsKey("AcceptLanguage"));
+    assertFalse("OtherHeaders restated", file.containsKey("OtherHeaders"));
+  }
+
+  /* Dropping a key the file states leaves the old line as the answer, since
+     nothing truncates on the crawl path. */
+  @Test
+  public void whatTheFileAlreadyStatesIsRestated() {
+    final Map<String, String> seeded = values("Depth", null, "Footer",
+        "<!-- ours -->");
+    final Map<String, String> file = written(seeded, seeded, present("Depth",
+        "Footer"));
+    assertTrue("Depth dropped", file.containsKey("Depth"));
+    assertTrue("Footer dropped", file.containsKey("Footer"));
+  }
+
+  /* A key no reader substitutes for has to be seeded empty to be omissible;
+     ours seeds 25000, so it is written until that seed goes. */
+  @Test
+  public void aSeededValueNoReaderRestoresIsAlwaysWritten() {
+    final Map<String, String> seeded = values("MaxRate", "25000", "Sockets",
+        null, "Debugging", null);
+    final Map<String, String> file = written(seeded, seeded, present());
+    assertEquals("25000", file.get("MaxRate"));
+    assertFalse("Sockets restated", file.containsKey("Sockets"));
+    assertFalse("Debugging restated", file.containsKey("Debugging"));
+  }
+
+  @Test
+  public void aChangedSettingIsAlwaysWritten() {
+    final Map<String, String> seeded = values("Footer", "<!-- ours -->",
+        "ParseAll", "1");
+    final Map<String, String> saved = values("Footer", "<!-- mine -->",
+        "ParseAll", "0");
+    final Map<String, String> file = written(saved, seeded, present());
+    assertEquals("<!-- mine -->", file.get("Footer"));
+    assertEquals("0", file.get("ParseAll"));
+  }
+
+  /* Both name-mangling boxes reach the file as one Dos line, so the filter has
+     to compare the packed value rather than either box. */
+  @Test
+  public void bothNameManglingBoxesAreComparedPacked() {
+    final Map<String, String> seeded = values("Dos", "0", "Iso9660", "0");
+    assertFalse("Dos restated",
+        written(seeded, seeded, present()).containsKey("Dos"));
+    final Map<String, String> saved = values("Dos", "0", "Iso9660", "1");
+    final Map<String, String> file = written(saved, seeded, present());
+    assertEquals("2", file.get("Dos"));
+    assertFalse("Iso9660 written", file.containsKey("Iso9660"));
+  }
+
+  private static File profile(final String content) throws IOException {
+    final File file = File.createTempFile("winprofile", ".ini");
+    file.deleteOnExit();
+    final Writer writer = new FileWriter(file);
+    try {
+      writer.write(content);
+    } finally {
+      writer.close();
+    }
+    return file;
+  }
+
+  @Test
+  public void statedKeysReadsTheCurrentSpellings() throws IOException {
+    final Set<String> keys = ProfileFormat.statedKeys(profile("Pause=2:5\r\n"
+        + "; a comment\r\n\r\nIso9660=1\r\nFooter=\r\nno separator here\r\n"));
+    assertEquals(new TreeSet<String>(Arrays.asList("Dos", "Footer", "Iso9660",
+        "PauseFiles")), new TreeSet<String>(keys));
+  }
+
+  @Test
+  public void aProfileThatDoesNotExistStatesNothing() throws IOException {
+    final File missing = new File(profile("").getPath() + ".gone");
+    assertTrue(ProfileFormat.statedKeys(missing).isEmpty());
+  }
+
+  /* What a project that never had a profile writes: only the keys no reader
+     would put back on its own. */
+  @Test
+  public void aBrandNewProjectStatesOnlyWhatCannotBeInferred()
+      throws IOException {
+    final Map<String, String> defaults = ourDefaults();
+    final Map<String, String> seeded = new LinkedHashMap<String, String>();
+    for (final String key : TestSources.serializerKeys()) {
+      seeded.put(key, defaults.get(key));
+    }
+    seeded.put("ProjectName", "myproject");
+    seeded.put("CurrentUrl", "http://example.com/");
+    final Set<String> file = new TreeSet<String>(ProfileFormat.toFile(seeded,
+        seeded, defaults, present()).keySet());
+    assertEquals(new TreeSet<String>(Arrays.asList("CurrentAction",
+        "CurrentUrl", "MaxRate", "ProjectName", "UserID")), file);
+  }
+}

--- a/app/src/test/java/com/httrack/android/WinProfileParityTest.java
+++ b/app/src/test/java/com/httrack/android/WinProfileParityTest.java
@@ -172,15 +172,6 @@ public class WinProfileParityTest {
     return TestSources.javaSource("OptionsMapper");
   }
 
-  private static int occurrences(final String source, final String text) {
-    int count = 0;
-    for (int at = source.indexOf(text); at != -1; at = source.indexOf(text,
-        at + 1)) {
-      count++;
-    }
-    return count;
-  }
-
   /* Counting the declarations separately keeps a regex that quietly stops
      matching from passing every key test on a short list. */
   private static List<String> keysOf(final String declaration,
@@ -192,13 +183,12 @@ public class WinProfileParityTest {
       keys.add(m.group(1));
     }
     assertEquals(declaration + " entries parsed",
-        occurrences(source, declaration), keys.size());
+        TestSources.occurrences(source, declaration), keys.size());
     return keys;
   }
 
   private static List<String> serializerKeys() throws IOException {
-    return keysOf("new Pair<Integer, String>(R.id.",
-        "new Pair<Integer, String>\\(R\\.id\\.\\w+,\\s*\"([^\"]+)\"\\)");
+    return TestSources.serializerKeys();
   }
 
   private static List<String> mapperKeys() throws IOException {
@@ -308,6 +298,6 @@ public class WinProfileParityTest {
           keys.indexOf(pair[0]) < keys.indexOf(pair[1]));
     }
     assertEquals("gated pairs wired", pairs.length,
-        occurrences(mapperTable(), "Handler.getValueMapper()"));
+        TestSources.occurrences(mapperTable(), "Handler.getValueMapper()"));
   }
 }


### PR DESCRIPTION
A save now writes a key only if the profile file already carries it, if the value differs from what a freshly reset profile holds, or if leaving it out would say something else to WinHTTrack and WebHTTrack. That last test comes from the engine's shared winprofile-keys.tsv: a value each front end derives for itself, like AcceptLanguage, never gets stamped into the file; a key nobody substitutes a default for is dropped only while it is unset; and a key whose empty value is read literally, UserID above all, is still written empty. That is the one PR #127 had backwards. A key we write that the shared table says nothing about keeps today's behaviour.

The baseline is whatever resetMap() seeds, saved default preferences included, computed on a throwaway mapper instead of being carried as state across the Parcelable hop through OptionsActivity, where process death would lose it. serialize(File) writes a sibling and renames it over the profile, so a write that dies half way can no longer truncate the file, and the crawl path still appends under its lock. Two things ride along: the default filter list gains +*.jpeg to match the shared table, and MaxRate keeps its 25000 seed, so that key is written every time until you decide to drop the seed. WinProfileOmissionTest reads the table out of the submodule and checks the app's policy against it key by key; a table it cannot read fails the test rather than skipping it.

Closes #126
