### PR TITLE
The crawl releases winprofile.ini's lock before the mirror starts

### DIFF
--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -31,10 +31,12 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintWriter;
+import java.io.RandomAccessFile;
 import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
 import java.net.SocketException;
+import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
 import java.util.ArrayList;
 import java.util.Enumeration;
@@ -1355,7 +1357,7 @@ public class HTTrackActivity extends FragmentActivity {
     protected void runInternal() {
       // Rock'in!
       String message = null;
-      FileOutputStream outLock = null;
+      RandomAccessFile outLock = null;
       FileLock lock = null;
       File profile = null;
       try {
@@ -1381,9 +1383,9 @@ public class HTTrackActivity extends FragmentActivity {
         profile = parent.createProfileDirectory();
         markRunningInstance(profile);
 
-        // Lock winprofile.ini by opening it in append mode, and requesting an
-        // exclusive lock
-        outLock = new FileOutputStream(profile, true);
+        // "rw" creates winprofile.ini without emptying it, so a refused lock
+        // still leaves the settings behind.
+        outLock = new RandomAccessFile(profile, "rw");
         lock = outLock.getChannel().tryLock();
         if (lock == null) {
           throw new IOException("This project is already in progress");
@@ -1417,7 +1419,7 @@ public class HTTrackActivity extends FragmentActivity {
             "starting engine: " + HTTrackActivity.printArray(cargs));
 
         // Serialize settings
-        parent.serialize(outLock, profile);
+        parent.serialize(outLock.getChannel(), profile);
 
         // Progress info for slow phones
         setProgressLines(new String[] { string_starting_mirror });
@@ -1922,17 +1924,17 @@ public class HTTrackActivity extends FragmentActivity {
   }
 
   /**
-   * Serialize current profile to an existing stream, left open.
+   * Serialize current profile to an existing channel, left open.
    * 
    * @param profile
    *          The existing profile whose stated keys must be preserved; not
-   *          necessarily where the stream writes.
+   *          necessarily where the channel writes.
    * @throws IOException
    *           Upon I/O error.
    */
-  protected synchronized void serialize(final FileOutputStream os,
+  protected synchronized void serialize(final FileChannel channel,
       final File profile) throws IOException {
-    mapper.serialize(os, profile);
+    mapper.serialize(channel, profile);
   }
 
   /**

--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -30,7 +30,6 @@ import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.net.Inet6Address;
 import java.net.InetAddress;
@@ -1923,7 +1922,7 @@ public class HTTrackActivity extends FragmentActivity {
   }
 
   /**
-   * Serialize current profile to an existing OutputStream.
+   * Serialize current profile to an existing stream, left open.
    * 
    * @param profile
    *          The existing profile whose stated keys must be preserved; not
@@ -1931,10 +1930,9 @@ public class HTTrackActivity extends FragmentActivity {
    * @throws IOException
    *           Upon I/O error.
    */
-  protected synchronized void serialize(final OutputStream os,
+  protected synchronized void serialize(final FileOutputStream os,
       final File profile) throws IOException {
     mapper.serialize(os, profile);
-    os.flush();
   }
 
   /**

--- a/app/src/main/java/com/httrack/android/OptionsMapper.java
+++ b/app/src/main/java/com/httrack/android/OptionsMapper.java
@@ -22,14 +22,13 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 package com.httrack.android;
 
 import java.io.BufferedReader;
-import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.FileReader;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.UnsupportedEncodingException;
+import java.io.Writer;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -665,6 +664,31 @@ public class OptionsMapper {
       } finally {
         pending.delete();
       }
+    }
+
+    /**
+     * Write LINES over whatever STREAM holds, leaving STREAM open.
+     *
+     * @param stream
+     *          Where to write; never closed, the crawl holding its "already in
+     *          progress" lock on this very descriptor
+     * @param lines
+     *          The already-encoded values to write, in the order to write them
+     * @throws IOException
+     *           Upon I/O error.
+     */
+    static void write(final FileOutputStream stream,
+        final Map<String, String> lines) throws IOException {
+      final StringBuilder text = new StringBuilder();
+      for (final Map.Entry<String, String> line : lines.entrySet()) {
+        text.append(line.getKey()).append('=').append(line.getValue())
+            .append('\n');
+      }
+      // An append-mode stream would otherwise leave the old copy in front.
+      stream.getChannel().truncate(0);
+      final Writer writer = new OutputStreamWriter(stream);
+      writer.write(text.toString());
+      writer.flush();
     }
   }
 
@@ -2067,10 +2091,10 @@ public class OptionsMapper {
   }
 
   /**
-   * Serialize settings on disk.
+   * Serialize settings to a stream the caller owns, and leaves open.
    * 
    * @param fos
-   *          The Output Stream.
+   *          Where to write, emptied of what it held.
    * @param profile
    *          The existing profile whose stated keys must be preserved; not
    *          necessarily where the stream writes.
@@ -2079,42 +2103,32 @@ public class OptionsMapper {
    * @throws IOException
    *           Upon I/O error.
    */
-  public void serialize(final OutputStream fos, final File profile)
+  public void serialize(final FileOutputStream fos, final File profile)
       throws UnsupportedEncodingException, IOException {
-    final OutputStreamWriter writer = new OutputStreamWriter(fos);
-    final BufferedWriter lwriter = new BufferedWriter(writer);
+    final Map<String, String> values = valuesOf(map);
+    Set<String> present;
     try {
-      final Map<String, String> values = valuesOf(map);
-      Set<String> present;
-      try {
-        present = ProfileFormat.statedKeys(profile);
-      } catch (final IOException e) {
-        // Nothing may be dropped from a profile we could not read back.
-        present = values.keySet();
+      present = ProfileFormat.statedKeys(profile);
+    } catch (final IOException e) {
+      // Nothing may be dropped from a profile we could not read back.
+      present = values.keySet();
+    }
+    final Map<String, String> file = ProfileFormat.toFile(values,
+        seededValues(), ourDefaults(), present);
+    final Map<String, String> lines = new LinkedHashMap<String, String>();
+    for (final Pair<Integer, String> field : OptionsMapper.fieldsSerializer) {
+      final String key = field.second;
+      if (!file.containsKey(key)) {
+        continue;
       }
-      final Map<String, String> file = ProfileFormat.toFile(values,
-          seededValues(), ourDefaults(), present);
-      for (final Pair<Integer, String> field : OptionsMapper.fieldsSerializer) {
-        final String key = field.second;
-        if (!file.containsKey(key)) {
-          continue;
-        }
-        final String value = file.get(key);
-        lwriter.write(key);
-        lwriter.write("=");
-        if (value != null) {
-          lwriter.write(OptionsMapper.profileEncode(value));
-        }
-        lwriter.write("\n");
-      }
-      lwriter.close();
-      if (dirty) {
-        dirty = false;
-        Log.d(getClass().getSimpleName(),
-            "map set clean: serialize to file (sync'ed)");
-      }
-    } finally {
-      writer.close();
+      final String value = file.get(key);
+      lines.put(key, value != null ? OptionsMapper.profileEncode(value) : "");
+    }
+    ProfileFormat.write(fos, lines);
+    if (dirty) {
+      dirty = false;
+      Log.d(getClass().getSimpleName(),
+          "map set clean: serialize to file (sync'ed)");
     }
   }
 
@@ -2138,16 +2152,10 @@ public class OptionsMapper {
       final FileOutputStream fos = new FileOutputStream(pending);
       try {
         serialize(fos, profile);
+        // Reach the disk before the rename does.
+        fos.getFD().sync();
       } finally {
         fos.close();
-      }
-      // Reopened only to reach the disk before the rename does: serialize()
-      // closes the stream it is handed, taking the descriptor with it.
-      final FileOutputStream sync = new FileOutputStream(pending, true);
-      try {
-        sync.getFD().sync();
-      } finally {
-        sync.close();
       }
       ProfileFormat.commit(pending, profile);
     } finally {

--- a/app/src/main/java/com/httrack/android/OptionsMapper.java
+++ b/app/src/main/java/com/httrack/android/OptionsMapper.java
@@ -26,9 +26,9 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.FileReader;
 import java.io.IOException;
-import java.io.OutputStreamWriter;
 import java.io.UnsupportedEncodingException;
-import java.io.Writer;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -667,28 +667,31 @@ public class OptionsMapper {
     }
 
     /**
-     * Write LINES over whatever STREAM holds, leaving STREAM open.
+     * Write LINES over whatever CHANNEL holds, leaving CHANNEL open.
      *
-     * @param stream
-     *          Where to write; never closed, the crawl holding its "already in
-     *          progress" lock on this very descriptor
+     * @param channel
+     *          Where to write; the crawl holds its lock here, so this must not
+     *          close it
      * @param lines
-     *          The already-encoded values to write, in the order to write them
+     *          The already-encoded values; iteration order is write order
      * @throws IOException
      *           Upon I/O error.
      */
-    static void write(final FileOutputStream stream,
+    static void write(final FileChannel channel,
         final Map<String, String> lines) throws IOException {
       final StringBuilder text = new StringBuilder();
       for (final Map.Entry<String, String> line : lines.entrySet()) {
         text.append(line.getKey()).append('=').append(line.getValue())
             .append('\n');
       }
-      // An append-mode stream would otherwise leave the old copy in front.
-      stream.getChannel().truncate(0);
-      final Writer writer = new OutputStreamWriter(stream);
-      writer.write(text.toString());
-      writer.flush();
+      // Overwritten, then trimmed. The profile is the only copy of the
+      // settings, so emptying it first would lose them to a failed write.
+      final ByteBuffer bytes = ByteBuffer.wrap(text.toString().getBytes());
+      channel.position(0);
+      while (bytes.hasRemaining()) {
+        channel.write(bytes);
+      }
+      channel.truncate(channel.position());
     }
   }
 
@@ -2091,19 +2094,19 @@ public class OptionsMapper {
   }
 
   /**
-   * Serialize settings to a stream the caller owns, and leaves open.
+   * Serialize settings to a caller-owned channel, left open.
    * 
-   * @param fos
-   *          Where to write, emptied of what it held.
+   * @param channel
+   *          Where to write, over whatever it held.
    * @param profile
    *          The existing profile whose stated keys must be preserved; not
-   *          necessarily where the stream writes.
+   *          necessarily where the channel writes.
    * @throws UnsupportedEncodingException
    *           Upon encoding error
    * @throws IOException
    *           Upon I/O error.
    */
-  public void serialize(final FileOutputStream fos, final File profile)
+  public void serialize(final FileChannel channel, final File profile)
       throws UnsupportedEncodingException, IOException {
     final Map<String, String> values = valuesOf(map);
     Set<String> present;
@@ -2124,7 +2127,7 @@ public class OptionsMapper {
       final String value = file.get(key);
       lines.put(key, value != null ? OptionsMapper.profileEncode(value) : "");
     }
-    ProfileFormat.write(fos, lines);
+    ProfileFormat.write(channel, lines);
     if (dirty) {
       dirty = false;
       Log.d(getClass().getSimpleName(),
@@ -2151,7 +2154,7 @@ public class OptionsMapper {
     try {
       final FileOutputStream fos = new FileOutputStream(pending);
       try {
-        serialize(fos, profile);
+        serialize(fos.getChannel(), profile);
         // Reach the disk before the rename does.
         fos.getFD().sync();
       } finally {

--- a/app/src/main/java/com/httrack/android/OptionsMapper.java
+++ b/app/src/main/java/com/httrack/android/OptionsMapper.java
@@ -670,8 +670,8 @@ public class OptionsMapper {
      * Write LINES over whatever CHANNEL holds, leaving CHANNEL open.
      *
      * @param channel
-     *          Where to write; the crawl holds its lock here, so this must not
-     *          close it
+     *          Where to write, never opened for append; the crawl holds its
+     *          lock here, so this must not close it
      * @param lines
      *          The already-encoded values; iteration order is write order
      * @throws IOException

--- a/app/src/test/java/com/httrack/android/ProfileWriteTest.java
+++ b/app/src/test/java/com/httrack/android/ProfileWriteTest.java
@@ -2,12 +2,13 @@ package com.httrack.android;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import com.httrack.android.OptionsMapper.ProfileFormat;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.RandomAccessFile;
 import java.nio.channels.FileLock;
 import java.nio.file.Files;
 import java.util.LinkedHashMap;
@@ -18,16 +19,16 @@ import org.junit.rules.TemporaryFolder;
 
 /**
  * A crawl writes the profile through the very descriptor it holds the "already
- * in progress" lock on, so the write must neither close it nor append to it.
+ * in progress" lock on, so the write must neither close it nor grow the file.
  */
 public class ProfileWriteTest {
   @Rule
   public final TemporaryFolder tmp = new TemporaryFolder();
 
-  private static Map<String, String> lines(final String... pairs) {
+  private static Map<String, String> lines(final String... keysAndValues) {
     final Map<String, String> lines = new LinkedHashMap<String, String>();
-    for (int i = 0; i < pairs.length; i += 2) {
-      lines.put(pairs[i], pairs[i + 1]);
+    for (int i = 0; i < keysAndValues.length; i += 2) {
+      lines.put(keysAndValues[i], keysAndValues[i + 1]);
     }
     return lines;
   }
@@ -42,55 +43,87 @@ public class ProfileWriteTest {
     return new String(Files.readAllBytes(file.toPath()), "UTF-8");
   }
 
-  @Test
-  public void keepsTheLockTheCrawlWritesThrough() throws IOException {
-    final File file = profile("Category=old\n");
-    final FileOutputStream stream = new FileOutputStream(file, true);
-    try {
-      final FileLock lock = stream.getChannel().tryLock();
-      ProfileFormat.write(stream, lines("Category", "new"));
-      assertTrue("lock released before the mirror starts", lock.isValid());
-      assertTrue(stream.getChannel().isOpen());
-    } finally {
-      stream.close();
-    }
+  /** As the crawl opens it: creates the file, and never empties it. */
+  private static RandomAccessFile open(final File file) throws IOException {
+    return new RandomAccessFile(file, "rw");
   }
 
   @Test
-  public void replacesWhatTheProfileHeld() throws IOException {
-    final File file = profile("Category=old\nProjectName=old\n");
-    final FileOutputStream stream = new FileOutputStream(file, true);
+  public void keepsTheLockTheCrawlWritesThrough() throws IOException {
+    final File file = profile("Category=old\n");
+    final RandomAccessFile handle = open(file);
     try {
-      ProfileFormat.write(stream, lines("Category", "new"));
+      final FileLock lock = handle.getChannel().tryLock();
+      assertNotNull("nobody else holds this profile", lock);
+      ProfileFormat.write(handle.getChannel(), lines("Category", "new"));
+      assertTrue("lock released before the mirror starts", lock.isValid());
     } finally {
-      stream.close();
+      handle.close();
     }
     assertEquals("Category=new\n", read(file));
   }
 
   @Test
-  public void writesEveryPairInOrder() throws IOException {
-    final File file = profile("");
-    final FileOutputStream stream = new FileOutputStream(file, true);
+  public void replacesWhatTheProfileHeld() throws IOException {
+    final File file = profile("Category=old\nProjectName=old\n");
+    final RandomAccessFile handle = open(file);
     try {
-      ProfileFormat.write(stream, lines("Category", "b", "ProjectName", "a"));
+      ProfileFormat.write(handle.getChannel(), lines("Category", "new"));
     } finally {
-      stream.close();
+      handle.close();
     }
-    assertEquals("Category=b\nProjectName=a\n", read(file));
+    assertEquals("Category=new\n", read(file));
+  }
+
+  /** ProjectName before Category: sorting the keys would swap the two lines. */
+  @Test
+  public void writesEveryPairInTheOrderGiven() throws IOException {
+    final File file = profile("");
+    final RandomAccessFile handle = open(file);
+    try {
+      ProfileFormat.write(handle.getChannel(),
+          lines("ProjectName", "a", "Category", "b"));
+    } finally {
+      handle.close();
+    }
+    assertEquals("ProjectName=a\nCategory=b\n", read(file));
+  }
+
+  /* Source of the OptionsMapper method declared as SIGNATURE, up to the first
+     line closing at INDENT. */
+  private static String methodBody(final String signature, final String indent)
+      throws IOException {
+    final String source = TestSources.javaSource("OptionsMapper");
+    final int start = source.indexOf(signature);
+    assertTrue(signature, start != -1);
+    final int end = source.indexOf("\n" + indent + "}", start);
+    assertTrue(signature, end != -1);
+    return source.substring(start, end);
   }
 
   /** What the tests above cannot see: a close() around the write. */
   @Test
-  public void serializeLeavesTheStreamItIsHandedOpen() throws IOException {
-    final String source = TestSources.javaSource("OptionsMapper");
-    final String signature =
-        "public void serialize(final FileOutputStream fos,";
-    final int start = source.indexOf(signature);
-    assertTrue(signature, start != -1);
-    final int end = source.indexOf("\n  }", start);
-    assertTrue(signature, end != -1);
-    assertFalse("serialize() closes the stream carrying the crawl's lock",
-        source.substring(start, end).contains("close("));
+  public void serializeLeavesTheChannelItIsHandedOpen() throws IOException {
+    final String body = methodBody(
+        "public void serialize(final FileChannel channel,", "  ");
+    // A region that stopped covering the write would pass the check below.
+    assertTrue("body does not reach the write",
+        body.contains("ProfileFormat.write(channel"));
+    assertFalse("serialize() closes the channel carrying the crawl's lock",
+        body.contains("close(") || body.contains("try ("));
+  }
+
+  /**
+   * Trimming after the write has no runtime tell, and getting it backwards
+   * empties the only copy of the settings until the write lands.
+   */
+  @Test
+  public void trimsTheProfileOnlyAfterWritingIt() throws IOException {
+    final String body = methodBody(
+        "static void write(final FileChannel channel,", "    ");
+    assertTrue("body does not reach the write",
+        body.contains("channel.write("));
+    assertTrue("the profile is emptied before it is written",
+        body.indexOf("channel.truncate(") > body.indexOf("channel.write("));
   }
 }

--- a/app/src/test/java/com/httrack/android/ProfileWriteTest.java
+++ b/app/src/test/java/com/httrack/android/ProfileWriteTest.java
@@ -1,0 +1,96 @@
+package com.httrack.android;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.httrack.android.OptionsMapper.ProfileFormat;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.channels.FileLock;
+import java.nio.file.Files;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * A crawl writes the profile through the very descriptor it holds the "already
+ * in progress" lock on, so the write must neither close it nor append to it.
+ */
+public class ProfileWriteTest {
+  @Rule
+  public final TemporaryFolder tmp = new TemporaryFolder();
+
+  private static Map<String, String> lines(final String... pairs) {
+    final Map<String, String> lines = new LinkedHashMap<String, String>();
+    for (int i = 0; i < pairs.length; i += 2) {
+      lines.put(pairs[i], pairs[i + 1]);
+    }
+    return lines;
+  }
+
+  private File profile(final String contents) throws IOException {
+    final File file = tmp.newFile("winprofile.ini");
+    Files.write(file.toPath(), contents.getBytes("UTF-8"));
+    return file;
+  }
+
+  private static String read(final File file) throws IOException {
+    return new String(Files.readAllBytes(file.toPath()), "UTF-8");
+  }
+
+  @Test
+  public void keepsTheLockTheCrawlWritesThrough() throws IOException {
+    final File file = profile("Category=old\n");
+    final FileOutputStream stream = new FileOutputStream(file, true);
+    try {
+      final FileLock lock = stream.getChannel().tryLock();
+      ProfileFormat.write(stream, lines("Category", "new"));
+      assertTrue("lock released before the mirror starts", lock.isValid());
+      assertTrue(stream.getChannel().isOpen());
+    } finally {
+      stream.close();
+    }
+  }
+
+  @Test
+  public void replacesWhatTheProfileHeld() throws IOException {
+    final File file = profile("Category=old\nProjectName=old\n");
+    final FileOutputStream stream = new FileOutputStream(file, true);
+    try {
+      ProfileFormat.write(stream, lines("Category", "new"));
+    } finally {
+      stream.close();
+    }
+    assertEquals("Category=new\n", read(file));
+  }
+
+  @Test
+  public void writesEveryPairInOrder() throws IOException {
+    final File file = profile("");
+    final FileOutputStream stream = new FileOutputStream(file, true);
+    try {
+      ProfileFormat.write(stream, lines("Category", "b", "ProjectName", "a"));
+    } finally {
+      stream.close();
+    }
+    assertEquals("Category=b\nProjectName=a\n", read(file));
+  }
+
+  /** What the tests above cannot see: a close() around the write. */
+  @Test
+  public void serializeLeavesTheStreamItIsHandedOpen() throws IOException {
+    final String source = TestSources.javaSource("OptionsMapper");
+    final String signature =
+        "public void serialize(final FileOutputStream fos,";
+    final int start = source.indexOf(signature);
+    assertTrue(signature, start != -1);
+    final int end = source.indexOf("\n  }", start);
+    assertTrue(signature, end != -1);
+    assertFalse("serialize() closes the stream carrying the crawl's lock",
+        source.substring(start, end).contains("close("));
+  }
+}


### PR DESCRIPTION
The crawl locks `hts-cache/winprofile.ini` to refuse a second run of the same project, then writes the settings through that same descriptor. The writer closed the stream, so the lock was gone before `engine.main` ran, and only the in-process `runningInstances` map still refused a second run.

The write now goes through the caller's `FileChannel` and never closes it. The lock handle becomes a `RandomAccessFile` opened `"rw"`, which creates the profile without emptying it, so the rewrite overwrites in place and trims afterwards rather than truncating first: the file is the only copy of a project's settings. That also drops the duplicate the old append-mode write left behind, which `hts_getcategory` picked up first when it built the top index, showing the category from before the last edit.

Closes #146