### PR TITLE
Open the project folder from the finished panel

### DIFF
--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -155,7 +155,7 @@ public class HTTrackActivity extends FragmentActivity {
 
   // Marks the mirror path in the finish message; the panel swaps it for a span, so it never
   // resolves as a URL.
-  protected static final String MIRROR_FOLDER_HREF = "httrack:mirror-folder";
+  private static final String MIRROR_FOLDER_HREF = "httrack:mirror-folder";
 
   // Channel carrying every notification we post. Never rename: the user's sound/importance
   // choices are keyed on it, and a new id silently resets them.
@@ -2329,11 +2329,12 @@ public class HTTrackActivity extends FragmentActivity {
         if (displayMessage != null) {
           final View view = findViewById(R.id.fieldDisplay);
           if (view != null) {
-            final TextView text = TextView.class.cast(view);
-            text.setText(renderFinishedMessage(displayMessage, mirrorFolder));
+            final Spanned text = renderFinishedMessage(displayMessage, mirrorFolder);
+            TextView.class.cast(view).setText(text);
             // Without a movement method the span is styled but never receives the tap.
-            text.setMovementMethod(
-                mirrorFolder != null ? LinkMovementMethod.getInstance() : null);
+            TextView.class.cast(view).setMovementMethod(
+                text.getSpans(0, text.length(), ClickableSpan.class).length != 0
+                    ? LinkMovementMethod.getInstance() : null);
           }
         }
         if (errorsCount != 0) {
@@ -2357,16 +2358,15 @@ public class HTTrackActivity extends FragmentActivity {
     });
   }
 
-  /* Render the finish message: a folder makes the mirror path open it, null drops the link,
-   * which a notification could not act on. */
+  /* Rewrite our own mirror-path link to open folder, or drop it when folder is null, since a
+   * notification cannot follow a tap. */
   private Spanned renderFinishedMessage(final String message, final File folder) {
     final Spanned rendered = Html.fromHtml(message);
-    final URLSpan[] links = rendered.getSpans(0, rendered.length(), URLSpan.class);
-    if (links.length == 0) {
-      return rendered;
-    }
     final SpannableStringBuilder text = new SpannableStringBuilder(rendered);
-    for (final URLSpan link : links) {
+    for (final URLSpan link : rendered.getSpans(0, rendered.length(), URLSpan.class)) {
+      if (!MIRROR_FOLDER_HREF.equals(link.getURL())) {
+        continue;
+      }
       final int start = text.getSpanStart(link);
       final int end = text.getSpanEnd(link);
       final int flags = text.getSpanFlags(link);

--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -76,8 +76,13 @@ import android.provider.DocumentsContract;
 import android.provider.Settings;
 import android.text.Editable;
 import android.text.Html;
+import android.text.SpannableStringBuilder;
+import android.text.Spanned;
 import android.text.TextUtils;
 import android.text.TextWatcher;
+import android.text.method.LinkMovementMethod;
+import android.text.style.ClickableSpan;
+import android.text.style.URLSpan;
 import android.util.Log;
 import android.util.SparseArray;
 import android.view.Menu;
@@ -147,6 +152,10 @@ public class HTTrackActivity extends FragmentActivity {
   
   // ".nomedia" ; prevents media scanner from reading media files
   public static final String NOMEDIA_FILE = ".nomedia";
+
+  // Marks the mirror path in the finish message; the panel swaps it for a span, so it never
+  // resolves as a URL.
+  protected static final String MIRROR_FOLDER_HREF = "httrack:mirror-folder";
 
   // Channel carrying every notification we post. Never rename: the user's sound/importance
   // choices are keyed on it, and a new id silently resets them.
@@ -509,19 +518,24 @@ public class HTTrackActivity extends FragmentActivity {
     requestAllFilesAccess();
   }
 
-  // Base-path panel button. Tries a viewer then the SAF picker; if neither resolves (e.g. private
-  // storage), copies the path to the clipboard so the user can paste it into a file manager.
+  // Base-path panel button.
   public void onClickBrowseFolder(final View view) {
-    final File dir = getProjectRootFile();
-    if (!openFolderInFilesApp(dir)) {
-      final String path = dir.getAbsolutePath();
-      final ClipboardManager clipboard =
-          ClipboardManager.class.cast(getSystemService(CLIPBOARD_SERVICE));
-      if (clipboard != null) {
-        clipboard.setPrimaryClip(ClipData.newPlainText("path", path));
-      }
-      Toast.makeText(this, getString(R.string.base_path_toast, path), Toast.LENGTH_LONG).show();
+    openFolderOrCopyPath(getProjectRootFile());
+  }
+
+  /* Show dir in a file manager, or copy its path when none can reach it, so the user can paste
+   * it into one. */
+  private void openFolderOrCopyPath(final File dir) {
+    if (openFolderInFilesApp(dir)) {
+      return;
     }
+    final String path = dir.getAbsolutePath();
+    final ClipboardManager clipboard =
+        ClipboardManager.class.cast(getSystemService(CLIPBOARD_SERVICE));
+    if (clipboard != null) {
+      clipboard.setPrimaryClip(ClipData.newPlainText("path", path));
+    }
+    Toast.makeText(this, getString(R.string.base_path_toast, path), Toast.LENGTH_LONG).show();
   }
 
   /* Open dir in a file viewer, else the SAF picker pre-navigated to it. False if neither resolves
@@ -1357,6 +1371,8 @@ public class HTTrackActivity extends FragmentActivity {
     protected void runInternal() {
       // Rock'in!
       String message = null;
+      // Null unless the mirror completed, leaving the finish message unlinked.
+      File mirrorFolder = null;
       RandomAccessFile outLock = null;
       FileLock lock = null;
       File profile = null;
@@ -1440,8 +1456,10 @@ public class HTTrackActivity extends FragmentActivity {
             message = "<b>Failed</b>! (" + lastStats.errorsCount
                 + " errors, no files written)";
           }
-          message += "<br /><br />Mirror copied in <i>"
-              + target.getAbsolutePath() + "</i>";
+          mirrorFolder = target;
+          message += "<br /><br />Mirror copied in <i><a href=\""
+              + MIRROR_FOLDER_HREF + "\">"
+              + TextUtils.htmlEncode(target.getAbsolutePath()) + "</a></i>";
         } else {
           message = "<b>Error</b> (<i>code " + code + "</i>)";
         }
@@ -1477,7 +1495,7 @@ public class HTTrackActivity extends FragmentActivity {
       // Ensure we switch to the final pane
       final String displayMessage = string_mirror_finished + ": " + message;
       final long errorsCount = lastStats != null ? lastStats.errorsCount : 0;
-      displayFinishedPanel(displayMessage, errorsCount);
+      displayFinishedPanel(displayMessage, errorsCount, mirrorFolder);
     }
 
     /*
@@ -1500,14 +1518,14 @@ public class HTTrackActivity extends FragmentActivity {
      * Trunk to parent.displayFinishedPanel().
      */
     private synchronized void displayFinishedPanel(final String displayMessage,
-        final long errorsCount) {
+        final long errorsCount, final File mirrorFolder) {
       if (parent != null) {
-        parent.displayFinishedPanel(displayMessage, errorsCount);
+        parent.displayFinishedPanel(displayMessage, errorsCount, mirrorFolder);
       } else {
         pendingParentActions.add(new Runnable() {
           @Override
           public void run() {
-            parent.displayFinishedPanel(displayMessage, errorsCount);
+            parent.displayFinishedPanel(displayMessage, errorsCount, mirrorFolder);
           }
         });
       }
@@ -2300,7 +2318,7 @@ public class HTTrackActivity extends FragmentActivity {
    * Display the final "finished" panel.
    */
   protected void displayFinishedPanel(final String displayMessage,
-      final long errorsCount) {
+      final long errorsCount, final File mirrorFolder) {
     handlerUI.post(new Runnable() {
       @Override
       public void run() {
@@ -2311,7 +2329,11 @@ public class HTTrackActivity extends FragmentActivity {
         if (displayMessage != null) {
           final View view = findViewById(R.id.fieldDisplay);
           if (view != null) {
-            TextView.class.cast(view).setText(Html.fromHtml(displayMessage));
+            final TextView text = TextView.class.cast(view);
+            text.setText(renderFinishedMessage(displayMessage, mirrorFolder));
+            // Without a movement method the span is styled but never receives the tap.
+            text.setMovementMethod(
+                mirrorFolder != null ? LinkMovementMethod.getInstance() : null);
           }
         }
         if (errorsCount != 0) {
@@ -2329,10 +2351,36 @@ public class HTTrackActivity extends FragmentActivity {
           /* FIXME TODO check intent */
           final Intent current = getCurrentIntentReference();
           sendSystemNotification(current, finished + ": " + name,
-              Html.fromHtml(displayMessage));
+              renderFinishedMessage(displayMessage, null));
         }
       }
     });
+  }
+
+  /* Render the finish message: a folder makes the mirror path open it, null drops the link,
+   * which a notification could not act on. */
+  private Spanned renderFinishedMessage(final String message, final File folder) {
+    final Spanned rendered = Html.fromHtml(message);
+    final URLSpan[] links = rendered.getSpans(0, rendered.length(), URLSpan.class);
+    if (links.length == 0) {
+      return rendered;
+    }
+    final SpannableStringBuilder text = new SpannableStringBuilder(rendered);
+    for (final URLSpan link : links) {
+      final int start = text.getSpanStart(link);
+      final int end = text.getSpanEnd(link);
+      final int flags = text.getSpanFlags(link);
+      text.removeSpan(link);
+      if (folder != null) {
+        text.setSpan(new ClickableSpan() {
+          @Override
+          public void onClick(final View widget) {
+            openFolderOrCopyPath(folder);
+          }
+        }, start, end, flags);
+      }
+    }
+    return text;
   }
 
   /** Whether the setup pane should (re)load the selected project's saved profile; see loadedProjectName. */

--- a/app/src/test/java/com/httrack/android/FinishedMessageTest.java
+++ b/app/src/test/java/com/httrack/android/FinishedMessageTest.java
@@ -4,13 +4,44 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.junit.Test;
 
 /** The finish message is concatenated HTML rendered in two places, one of which cannot follow a
- *  link. */
+ *  link. Html.fromHtml and the spans it yields need an Android runtime, so these read the source:
+ *  they pin what a regression would have to look like, not what the panel draws. */
 public class FinishedMessageTest {
+  /** A path accessor, whatever the variable it hangs off. */
+  private static final Pattern PATH_ACCESSOR =
+      Pattern.compile("\\w+\\.get(?:Absolute)?Path\\(\\)");
+
   private static String source() throws IOException {
     return TestSources.javaSource("HTTrackActivity");
+  }
+
+  /** Source with every whitespace run flattened, so a match ignores wrapping. */
+  private static String flattened(final String source) {
+    return source.replaceAll("\\s+", " ");
+  }
+
+  /** Each statement writing the finish message, up to its semicolon. Scoped to the crawl runner:
+   *  another local named message elsewhere goes to a Toast, which renders no HTML. */
+  private static List<String> messageStatements(final String source) {
+    final int from = source.indexOf("protected void runInternal()");
+    final int to = source.indexOf("displayFinishedPanel(displayMessage, errorsCount, mirrorFolder)");
+    assertTrue("runInternal no longer bounded by its displayFinishedPanel call",
+        from != -1 && to > from);
+    final List<String> statements = new ArrayList<String>();
+    final Matcher m = Pattern.compile("(?m)^\\s*message\\s*\\+?=")
+        .matcher(source.substring(from, to));
+    while (m.find()) {
+      statements.add(source.substring(from + m.start(), source.indexOf(';', from + m.start())));
+    }
+    assertFalse("no finish message assignments found", statements.isEmpty());
+    return statements;
   }
 
   /** The statement building the "Mirror copied in" line. */
@@ -22,23 +53,57 @@ public class FinishedMessageTest {
 
   /** A base path is user-chosen, so an unescaped '&' or '<' would corrupt the render. */
   @Test
-  public void theMirrorPathIsEscapedBeforeItReachesTheHtml() throws Exception {
-    final String line = mirrorPathStatement(source());
-    assertTrue(line, line.contains("TextUtils.htmlEncode(target.getAbsolutePath())"));
-    assertFalse(line, line.contains("+ target.getAbsolutePath()"));
+  public void everyPathReachingTheMessageIsEscaped() throws Exception {
+    boolean anyPath = false;
+    for (final String statement : messageStatements(source())) {
+      final Matcher m = PATH_ACCESSOR.matcher(statement);
+      while (m.find()) {
+        anyPath = true;
+        assertTrue(statement,
+            statement.substring(0, m.start()).endsWith("TextUtils.htmlEncode("));
+      }
+    }
+    assertTrue("no path reaches the finish message, so nothing was checked", anyPath);
   }
 
+  /** An unclosed anchor makes Html.fromHtml run the link to the end of the message. */
   @Test
-  public void theMirrorPathIsWrappedInTheFolderHref() throws Exception {
-    final String line = mirrorPathStatement(source());
-    assertTrue(line, line.contains("<a href="));
-    assertTrue(line, line.contains("MIRROR_FOLDER_HREF"));
+  public void theMirrorPathIsWrappedInAClosedHref() throws Exception {
+    final String statement = mirrorPathStatement(source());
+    assertTrue(statement, statement.contains("<a href="));
+    assertTrue(statement, statement.contains("MIRROR_FOLDER_HREF"));
+    assertTrue(statement, statement.contains("</a>"));
+  }
+
+  /** A styled span nothing can tap is the likeliest regression, so the movement method must
+   *  follow the spans actually rendered rather than the folder the panel was handed. */
+  @Test
+  public void theMovementMethodFollowsTheRenderedSpans() throws Exception {
+    final String flat = flattened(source());
+    assertTrue(flat, flat.contains("setMovementMethod( text.getSpans(0, text.length(), "
+        + "ClickableSpan.class).length != 0 ? LinkMovementMethod.getInstance() : null)"));
+  }
+
+  /** The notification cannot follow a tap, so it is the caller that must pass no folder. */
+  @Test
+  public void onlyThePanelTakesTheFolder() throws Exception {
+    final String flat = flattened(source());
+    assertTrue(flat, flat.contains("renderFinishedMessage(displayMessage, mirrorFolder)"));
+    assertTrue(flat, flat.contains("sendSystemNotification(current, finished + \": \" + name, "
+        + "renderFinishedMessage(displayMessage, null))"));
+  }
+
+  /** Stripping every link would turn a URL in an engine error message into a second folder tap
+   *  target, so only our own href may be rewritten. */
+  @Test
+  public void onlyOurOwnHrefIsRewritten() throws Exception {
+    assertTrue(flattened(source()).contains("if (!MIRROR_FOLDER_HREF.equals(link.getURL()))"));
   }
 
   /** Rendering the message raw would leave a link in the notification that nothing can tap. */
   @Test
   public void nothingRendersTheMessageOutsideTheHelper() throws Exception {
-    assertFalse(source().contains("Html.fromHtml(displayMessage)"));
+    assertFalse(flattened(source()).contains("Html.fromHtml(displayMessage"));
   }
 
   /** Private storage resolves no folder intent, so both entry points need the clipboard fallback. */

--- a/app/src/test/java/com/httrack/android/FinishedMessageTest.java
+++ b/app/src/test/java/com/httrack/android/FinishedMessageTest.java
@@ -1,0 +1,51 @@
+package com.httrack.android;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import org.junit.Test;
+
+/** The finish message is concatenated HTML rendered in two places, one of which cannot follow a
+ *  link. */
+public class FinishedMessageTest {
+  private static String source() throws IOException {
+    return TestSources.javaSource("HTTrackActivity");
+  }
+
+  /** The statement building the "Mirror copied in" line. */
+  private static String mirrorPathStatement(final String source) {
+    final int at = source.indexOf("Mirror copied in");
+    assertTrue("no mirror path line left in HTTrackActivity", at != -1);
+    return source.substring(at, source.indexOf(';', at));
+  }
+
+  /** A base path is user-chosen, so an unescaped '&' or '<' would corrupt the render. */
+  @Test
+  public void theMirrorPathIsEscapedBeforeItReachesTheHtml() throws Exception {
+    final String line = mirrorPathStatement(source());
+    assertTrue(line, line.contains("TextUtils.htmlEncode(target.getAbsolutePath())"));
+    assertFalse(line, line.contains("+ target.getAbsolutePath()"));
+  }
+
+  @Test
+  public void theMirrorPathIsWrappedInTheFolderHref() throws Exception {
+    final String line = mirrorPathStatement(source());
+    assertTrue(line, line.contains("<a href="));
+    assertTrue(line, line.contains("MIRROR_FOLDER_HREF"));
+  }
+
+  /** Rendering the message raw would leave a link in the notification that nothing can tap. */
+  @Test
+  public void nothingRendersTheMessageOutsideTheHelper() throws Exception {
+    assertFalse(source().contains("Html.fromHtml(displayMessage)"));
+  }
+
+  /** Private storage resolves no folder intent, so both entry points need the clipboard fallback. */
+  @Test
+  public void bothFolderEntryPointsShareTheFallback() throws Exception {
+    final String source = source();
+    assertTrue(source.contains("openFolderOrCopyPath(getProjectRootFile())"));
+    assertTrue(source.contains("openFolderOrCopyPath(folder)"));
+  }
+}

--- a/app/src/test/java/com/httrack/android/StoragePathsTest.java
+++ b/app/src/test/java/com/httrack/android/StoragePathsTest.java
@@ -114,6 +114,15 @@ public class StoragePathsTest {
         StoragePaths.externalStorageDocId(mirror, shared));
   }
 
+  /** The finish panel opens the project folder, one level below the mirror root. */
+  @Test
+  public void mapsAProjectFolderBelowTheMirrorRoot() throws Exception {
+    final File shared = tmp.newFolder("shared4");
+    final File root = new File(new File(shared, "HTTrack"), "Websites");
+    assertEquals("primary:HTTrack" + File.separator + "Websites" + File.separator + "my site",
+        StoragePaths.externalStorageDocId(new File(root, "my site"), shared));
+  }
+
   /** The Android/ subtree is hidden from file managers, so it must not map. */
   @Test
   public void refusesThePrivateAndroidSubtree() throws Exception {

--- a/app/src/test/java/com/httrack/android/StoragePathsTest.java
+++ b/app/src/test/java/com/httrack/android/StoragePathsTest.java
@@ -114,15 +114,6 @@ public class StoragePathsTest {
         StoragePaths.externalStorageDocId(mirror, shared));
   }
 
-  /** The finish panel opens the project folder, one level below the mirror root. */
-  @Test
-  public void mapsAProjectFolderBelowTheMirrorRoot() throws Exception {
-    final File shared = tmp.newFolder("shared4");
-    final File root = new File(new File(shared, "HTTrack"), "Websites");
-    assertEquals("primary:HTTrack" + File.separator + "Websites" + File.separator + "my site",
-        StoragePaths.externalStorageDocId(new File(root, "my site"), shared));
-  }
-
   /** The Android/ subtree is hidden from file managers, so it must not map. */
   @Test
   public void refusesThePrivateAndroidSubtree() throws Exception {


### PR DESCRIPTION
The finished panel printed the mirror path as inert text. The one "Open folder" button opened the Websites root, not the project just copied. Tapping the path now opens the project folder. It reuses the intent chain from #66: a document viewer, then the SAF picker aimed at the folder, then the clipboard when no intent reaches private storage.

Also fixed here: the path went into the HTML message unescaped, so a base path holding `&` or `<` corrupted the render. The notification cannot follow a link, so it now renders the same message with the link dropped.

Only the mirror path's own href is rewritten, so a link arriving from elsewhere in the message cannot become a second tap target. The tests are source scans over the finish-message builder: `Html.fromHtml` and the spans it yields need an Android runtime these unit tests do not have.

Closes #148