### PR TITLE
One 16 KB alignment check, and a test for it

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -118,6 +118,8 @@ jobs:
           python-version: '3.12'
       - run: pip install -r tools/ci/play-requirements.txt
       - run: python3 tools/ci/play_track_admin_test.py
+      # No job builds an .aab, so the alignment script's bundle branch has no other cover.
+      - run: tools/ci/check-so-alignment-test.sh
 
   # --- Phases below land with the app modernization (see the plan) ---
   #

--- a/.github/workflows/play-publish.yml
+++ b/.github/workflows/play-publish.yml
@@ -56,22 +56,13 @@ jobs:
             echo "keyPassword=$KEY_PW"
           } > keystore.properties
       - name: Bundle release (signed)
-        run: ./gradlew --no-daemon bundleRelease assembleRelease
-      - name: Assert 16 KB .so alignment
-        run: |
-          tools/ci/check-so-alignment.sh app/build/outputs/bundle/release/app-release.aab
-          tools/ci/check-so-alignment.sh app/build/outputs/apk/release/app-release.apk
+        run: ./gradlew --no-daemon bundleRelease
+      - name: Check 16 KB .so alignment
+        run: tools/ci/check-so-alignment.sh app/build/outputs/bundle/release/app-release.aab
       - uses: actions/upload-artifact@v4
         with:
           name: release-aab
           path: app/build/outputs/bundle/release/app-release.aab
-          if-no-files-found: error
-      # Upload-key signed, so it will not update a Play install: Play re-signs with the
-      # app signing key. For one that does, take the universal APK from the Console.
-      - uses: actions/upload-artifact@v4
-        with:
-          name: release-apk-upload-key
-          path: app/build/outputs/apk/release/app-release.apk
           if-no-files-found: error
 
   publish:

--- a/.github/workflows/play-publish.yml
+++ b/.github/workflows/play-publish.yml
@@ -56,27 +56,22 @@ jobs:
             echo "keyPassword=$KEY_PW"
           } > keystore.properties
       - name: Bundle release (signed)
-        run: ./gradlew --no-daemon bundleRelease
-      - name: Assert 16 KB .so alignment in the AAB
+        run: ./gradlew --no-daemon bundleRelease assembleRelease
+      - name: Assert 16 KB .so alignment
         run: |
-          set -eu    # steps run under dash here; no pipefail (a readelf failure yields a="" -> $((a))=0, still trips the guard)
-          aab=app/build/outputs/bundle/release/app-release.aab
-          readelf="$(command -v llvm-readelf || command -v readelf || true)"
-          [ -n "$readelf" ] || readelf="$(ls "${ANDROID_NDK_ROOT:-/nonexistent}"/toolchains/llvm/prebuilt/*/bin/llvm-readelf 2>/dev/null | head -1)"
-          [ -n "$readelf" ] || { echo "no readelf/llvm-readelf found"; exit 1; }
-          tmp="$(mktemp -d)"; unzip -q -o "$aab" 'base/lib/*' -d "$tmp"
-          n=0
-          for so in $(find "$tmp" -name '*.so'); do
-            n=$((n + 1))
-            a="$("$readelf" -lW "$so" | awk '$1 == "LOAD" { print $NF; exit }')"
-            [ "$((a))" -ge 16384 ] || { echo "FAIL $so p_align $a < 16384"; exit 1; }
-          done
-          [ "$n" -gt 0 ] || { echo "no .so in AAB"; exit 1; }
-          echo "16 KB aligned: $n .so in the AAB"
+          tools/ci/check-so-alignment.sh app/build/outputs/bundle/release/app-release.aab
+          tools/ci/check-so-alignment.sh app/build/outputs/apk/release/app-release.apk
       - uses: actions/upload-artifact@v4
         with:
           name: release-aab
           path: app/build/outputs/bundle/release/app-release.aab
+          if-no-files-found: error
+      # Upload-key signed, so it will not update a Play install: Play re-signs with the
+      # app signing key. For one that does, take the universal APK from the Console.
+      - uses: actions/upload-artifact@v4
+        with:
+          name: release-apk-upload-key
+          path: app/build/outputs/apk/release/app-release.apk
           if-no-files-found: error
 
   publish:

--- a/tools/ci/check-so-alignment-test.sh
+++ b/tools/ci/check-so-alignment-test.sh
@@ -9,70 +9,119 @@ SUT="$HERE/check-so-alignment.sh"
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 
+OK=4000   # 16 KB, the minimum Play accepts
+LOW=1000  # 4 KB
+NEAR=2000 # 8 KB: still short, and pins the threshold against a halved WANT
+
 # Stand in for llvm-readelf so the fixtures need no toolchain and no real ELF.
-# Alignment comes from the file name, one LOAD line per requested value.
+# Alignment comes from the file name; the non-LOAD segments are what real output
+# carries and what makes the LOAD filter load-bearing.
 mkdir -p "$tmp/bin"
 cat >"$tmp/bin/llvm-readelf" <<'STUB'
 #!/usr/bin/env bash
+echo "  DYNAMIC        0x000000 0x0 0x0 0x10 0x10 RW  0x8"
+echo "  NOTE           0x000000 0x0 0x0 0x10 0x10 R   0x4"
 for a in $(basename "${!#}" .so | tr '-' ' '); do
     case "$a" in
-    [0-9]*) echo "  LOAD           0x000000 0x0 0x0 0x10 0x10 R   0x$a" ;;
+    [0-9a-f]*) echo "  LOAD           0x000000 0x0 0x0 0x10 0x10 R E 0x$a" ;;
     esac
 done
+echo "  GNU_EH_FRAME   0x000000 0x0 0x0 0x10 0x10 R   0x4"
 STUB
 chmod +x "$tmp/bin/llvm-readelf"
 export PATH="$tmp/bin:$PATH"
 
-# Name each .so after the p_align values its LOAD segments report, in hex.
+# Each .so is named for the p_align values its LOAD segments report, in hex,
+# separated by '-'. A name with no hex digits reports no LOAD segments at all.
 mkzip() {
     local out="$1" dir="$2"
     shift 2
     rm -rf "$tmp/stage"
-    if [ "$#" -gt 0 ]; then
-        mkdir -p "$tmp/stage/$dir/arm64-v8a"
-        local n
-        for n in "$@"; do touch "$tmp/stage/$dir/arm64-v8a/$n.so"; done
-    else
-        mkdir -p "$tmp/stage"
+    mkdir -p "$tmp/stage/${dir:-.}"
+    if [ "$#" -eq 0 ]; then
         touch "$tmp/stage/readme.txt"
+    else
+        local n i=0
+        for n in "$@"; do
+            # One ABI directory each, so two libs of equal alignment stay two files.
+            mkdir -p "$tmp/stage/$dir/abi$i"
+            touch "$tmp/stage/$dir/abi$i/$n.so"
+            i=$((i + 1))
+        done
     fi
     (cd "$tmp/stage" && zip -qr "$out" .)
 }
 
 fail=0
+# want: expected exit code. pattern: text the run must print, so a case cannot
+# pass merely by failing for some unrelated reason.
 check() {
-    local label="$1" want="$2" archive="$3"
-    local got=0
-    "$SUT" "$archive" >/dev/null 2>&1 || got=$?
+    local label="$1" want="$2" pattern="$3" archive="$4"
+    local got=0 out
+    out="$("$SUT" "$archive" 2>&1)" || got=$?
     if [ "$got" -ne "$want" ]; then
         echo "FAIL $label: want exit $want, got $got"
+        fail=1
+    elif ! printf '%s' "$out" | grep -q -- "$pattern"; then
+        echo "FAIL $label: output did not match '$pattern'"
+        printf '   got: %s\n' "$out"
         fail=1
     else
         echo "ok   $label"
     fi
 }
 
-mkzip "$tmp/aligned.apk" lib 4000
-check "apk layout, 16 KB" 0 "$tmp/aligned.apk"
+mkzip "$tmp/apk-ok.apk" lib $OK
+check "apk layout, aligned" 0 "1 .so" "$tmp/apk-ok.apk"
 
-mkzip "$tmp/aligned.aab" base/lib 4000
-check "aab layout, 16 KB" 0 "$tmp/aligned.aab"
+mkzip "$tmp/aab-ok.aab" base/lib $OK
+check "aab layout, aligned" 0 "1 .so" "$tmp/aab-ok.aab"
 
-mkzip "$tmp/low.apk" lib 1000
-check "apk below 16 KB" 1 "$tmp/low.apk"
+mkzip "$tmp/apk-low.apk" lib $LOW
+check "apk below 16 KB" 1 "p_align" "$tmp/apk-low.apk"
 
-# The regression the inline AAB check could not see: only a later LOAD is short.
-mkzip "$tmp/mixed.aab" base/lib 4000-1000
-check "aab, later LOAD below 16 KB" 1 "$tmp/mixed.aab"
+mkzip "$tmp/near.aab" base/lib $NEAR
+check "8 KB is still short" 1 "p_align" "$tmp/near.aab"
+
+# The regression the deleted inline check could not see, in both orderings.
+mkzip "$tmp/hi-lo.aab" base/lib "$OK-$LOW"
+check "aab, later LOAD short" 1 "p_align" "$tmp/hi-lo.aab"
+mkzip "$tmp/lo-hi.aab" base/lib "$LOW-$OK"
+check "aab, earlier LOAD short" 1 "p_align" "$tmp/lo-hi.aab"
+
+# One bad lib among several must fail: the check is per-.so, not per-archive.
+mkzip "$tmp/two.aab" base/lib $OK $LOW
+check "second of two libs short" 1 "p_align" "$tmp/two.aab"
+mkzip "$tmp/two-ok.aab" base/lib $OK $OK
+check "both libs aligned" 0 "2 .so" "$tmp/two-ok.aab"
+
+mkzip "$tmp/noload.aab" base/lib "none"
+check "no LOAD segments" 1 "no LOAD segments" "$tmp/noload.aab"
 
 mkzip "$tmp/empty.apk" lib
-check "no .so at all" 1 "$tmp/empty.apk"
+check "apk with no .so" 1 "no lib/" "$tmp/empty.apk"
+mkzip "$tmp/empty.aab" base/lib
+check "aab with no .so" 1 "no base/lib/" "$tmp/empty.aab"
 
 # An .aab read as an apk finds nothing, so layout detection must not pass it.
-cp "$tmp/aligned.aab" "$tmp/mislabelled.apk"
-check "aab named .apk" 1 "$tmp/mislabelled.apk"
+cp "$tmp/aab-ok.aab" "$tmp/mislabelled.apk"
+check "aab named .apk" 1 "no lib/" "$tmp/mislabelled.apk"
 
-check "missing file" 1 "$tmp/nope.apk"
+check "missing file" 1 "cannot extract" "$tmp/nope.apk"
+
+# The listing-versus-walk cross-check: two entries, one file on disk.
+if command -v python3 >/dev/null; then
+    python3 - "$tmp/dup.aab" <<'PY'
+import sys, zipfile
+with zipfile.ZipFile(sys.argv[1], "w") as z:
+    for _ in range(2):
+        z.writestr("base/lib/arm64-v8a/4000.so", "x")
+PY
+    check "listed more .so than walked" 1 "walked" "$tmp/dup.aab"
+else
+    echo "FAIL duplicate-entry case needs python3"
+    fail=1
+fi
 
 [ "$fail" -eq 0 ] && echo "check-so-alignment: all cases pass"
 exit "$fail"

--- a/tools/ci/check-so-alignment-test.sh
+++ b/tools/ci/check-so-alignment-test.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+#
+# Exercise check-so-alignment.sh on both archive layouts. CI builds no .aab, so
+# without this the AAB branch is first exercised by a real release.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SUT="$HERE/check-so-alignment.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+# Stand in for llvm-readelf so the fixtures need no toolchain and no real ELF.
+# Alignment comes from the file name, one LOAD line per requested value.
+mkdir -p "$tmp/bin"
+cat >"$tmp/bin/llvm-readelf" <<'STUB'
+#!/usr/bin/env bash
+for a in $(basename "${!#}" .so | tr '-' ' '); do
+    case "$a" in
+    [0-9]*) echo "  LOAD           0x000000 0x0 0x0 0x10 0x10 R   0x$a" ;;
+    esac
+done
+STUB
+chmod +x "$tmp/bin/llvm-readelf"
+export PATH="$tmp/bin:$PATH"
+
+# Name each .so after the p_align values its LOAD segments report, in hex.
+mkzip() {
+    local out="$1" dir="$2"
+    shift 2
+    rm -rf "$tmp/stage"
+    if [ "$#" -gt 0 ]; then
+        mkdir -p "$tmp/stage/$dir/arm64-v8a"
+        local n
+        for n in "$@"; do touch "$tmp/stage/$dir/arm64-v8a/$n.so"; done
+    else
+        mkdir -p "$tmp/stage"
+        touch "$tmp/stage/readme.txt"
+    fi
+    (cd "$tmp/stage" && zip -qr "$out" .)
+}
+
+fail=0
+check() {
+    local label="$1" want="$2" archive="$3"
+    local got=0
+    "$SUT" "$archive" >/dev/null 2>&1 || got=$?
+    if [ "$got" -ne "$want" ]; then
+        echo "FAIL $label: want exit $want, got $got"
+        fail=1
+    else
+        echo "ok   $label"
+    fi
+}
+
+mkzip "$tmp/aligned.apk" lib 4000
+check "apk layout, 16 KB" 0 "$tmp/aligned.apk"
+
+mkzip "$tmp/aligned.aab" base/lib 4000
+check "aab layout, 16 KB" 0 "$tmp/aligned.aab"
+
+mkzip "$tmp/low.apk" lib 1000
+check "apk below 16 KB" 1 "$tmp/low.apk"
+
+# The regression the inline AAB check could not see: only a later LOAD is short.
+mkzip "$tmp/mixed.aab" base/lib 4000-1000
+check "aab, later LOAD below 16 KB" 1 "$tmp/mixed.aab"
+
+mkzip "$tmp/empty.apk" lib
+check "no .so at all" 1 "$tmp/empty.apk"
+
+# An .aab read as an apk finds nothing, so layout detection must not pass it.
+cp "$tmp/aligned.aab" "$tmp/mislabelled.apk"
+check "aab named .apk" 1 "$tmp/mislabelled.apk"
+
+check "missing file" 1 "$tmp/nope.apk"
+
+[ "$fail" -eq 0 ] && echo "check-so-alignment: all cases pass"
+exit "$fail"

--- a/tools/ci/check-so-alignment.sh
+++ b/tools/ci/check-so-alignment.sh
@@ -4,8 +4,14 @@
 # at targetSdk 35+, and nothing in a normal build says so — the regression is silent.
 set -euo pipefail
 
-APK="${1:?usage: $0 <apk>}"
+ARCHIVE="${1:?usage: $0 <apk|aab>}"
 WANT=16384
+
+# An AAB keeps its libs under the module directory; an .apk has them at the root.
+case "$ARCHIVE" in
+*.aab) libdir="base/lib" ;;
+*) libdir="lib" ;;
+esac
 
 # The toolchain image carries the NDK but no binutils, so fall back to its llvm-readelf.
 READELF="$(command -v llvm-readelf || command -v readelf || true)"
@@ -21,12 +27,12 @@ fi
 
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
-mkdir -p "$tmp/lib"
+mkdir -p "$tmp/$libdir"
 # 11 is "nothing matched", which the count check below reports in its own words.
 rc=0
-unzip -q -o "$APK" 'lib/*' -d "$tmp" || rc=$?
+unzip -q -o "$ARCHIVE" "$libdir/*" -d "$tmp" || rc=$?
 if [ "$rc" -ne 0 ] && [ "$rc" -ne 11 ]; then
-    echo "check-so-alignment: cannot extract $APK (unzip rc=$rc)" >&2
+    echo "check-so-alignment: cannot extract $ARCHIVE (unzip rc=$rc)" >&2
     exit 1
 fi
 
@@ -35,13 +41,13 @@ fi
 # still report success; comparing counts asserts completeness, not merely non-emptiness.
 # unzip -Z1 exits 11 when the pattern matches nothing, which is the likely regression here
 # (a build shipping no native libs at all), so name that case rather than blame the archive.
-listed="$(unzip -Z1 "$APK" 'lib/*.so' | wc -l)" || {
-    echo "check-so-alignment: no lib/*.so in $APK, or it is unreadable" >&2
+listed="$(unzip -Z1 "$ARCHIVE" "$libdir/*.so" | wc -l)" || {
+    echo "check-so-alignment: no $libdir/*.so in $ARCHIVE, or it is unreadable" >&2
     exit 1
 }
-mapfile -t sos < <(find "$tmp/lib" -type f -name '*.so' | sort)
+mapfile -t sos < <(find "$tmp/$libdir" -type f -name '*.so' | sort)
 if [ "${#sos[@]}" -ne "$listed" ]; then
-    echo "check-so-alignment: $APK lists $listed .so, walked ${#sos[@]}" >&2
+    echo "check-so-alignment: $ARCHIVE lists $listed .so, walked ${#sos[@]}" >&2
     exit 1
 fi
 
@@ -61,5 +67,5 @@ for so in "${sos[@]}"; do
     done
 done
 
-[ "$rc" -eq 0 ] && echo "16 KB aligned: ${#sos[@]} .so in $(basename "$APK")"
+[ "$rc" -eq 0 ] && echo "16 KB aligned: ${#sos[@]} .so in $(basename "$ARCHIVE")"
 exit "$rc"


### PR DESCRIPTION
The workflow checked the AAB's `.so` alignment with an inline copy of what `tools/ci/check-so-alignment.sh` already did for APKs. The copy was the weaker of the two. It read only the first LOAD segment per `.so`, so a library whose later segment dropped to 4 KB passed green, and it could not tell a truncated walk from a clean one. The script now knows the bundle layout and the workflow calls it, so the AAB gets the stricter check.

No job builds an `.aab`, so that branch would otherwise first run during a real release. The new test drives both layouts against a stub readelf, which keeps it free of any toolchain, and covers the later-LOAD case the old inline check could not see. Reverting the script to first-LOAD-only fails that case and nothing else; pointing the bundle branch at `lib/` fails the AAB case and nothing else.

This branch previously also built and published a signed APK. That is dropped. Xavier had already chosen to link Play rather than host a build, and an upload-key APK cannot update a Play install, because Play re-signs with the app signing key. The uninstall that resolves the signature clash also erases the default mirror root, which lives in app-private storage unless the user granted all-files access. Issue 152 is closed separately as decided against, with the constraint written down there.