### PR TITLE
Collect Play reviews from both places Play keeps them

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -118,6 +118,7 @@ jobs:
           python-version: '3.12'
       - run: pip install -r tools/ci/play-requirements.txt
       - run: python3 tools/ci/play_track_admin_test.py
+      - run: python3 tools/ci/play_reviews_test.py
 
   # --- Phases below land with the app modernization (see the plan) ---
   #

--- a/.github/workflows/play-reviews.yml
+++ b/.github/workflows/play-reviews.yml
@@ -1,7 +1,4 @@
-# Collect Play reviews. reviews.list carries only the last week and only reviews with
-# text, so the history and the bare star ratings come from the monthly CSVs in the
-# report bucket, which the service account can read only once it holds
-# "View app information and download bulk reports".
+# Collect Play reviews; play_reviews.py explains why two sources are needed.
 name: Play reviews
 
 on:
@@ -53,3 +50,5 @@ jobs:
           name: play-reviews
           path: reviews.csv
           if-no-files-found: error
+          # This repo is public, so anyone can download the artifact.
+          retention-days: 1

--- a/.github/workflows/play-reviews.yml
+++ b/.github/workflows/play-reviews.yml
@@ -1,0 +1,55 @@
+# Collect Play reviews. reviews.list carries only the last week and only reviews with
+# text, so the history and the bare star ratings come from the monthly CSVs in the
+# report bucket, which the service account can read only once it holds
+# "View app information and download bulk reports".
+name: Play reviews
+
+on:
+  workflow_dispatch:
+    inputs:
+      bucket:
+        description: 'report bucket, pubsite_prod_rev_<developer id> (blank = last week only)'
+        default: ''
+      since:
+        description: 'earliest monthly report, YYYYMM (blank = all of them)'
+        default: ''
+
+permissions:
+  contents: read
+
+jobs:
+  reviews:
+    name: collect reviews
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: pip install -r tools/ci/play-requirements.txt
+      - name: Collect
+        # Inputs go through the environment, never interpolated into the script body.
+        env:
+          SA_JSON: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+          BUCKET: ${{ inputs.bucket }}
+          SINCE: ${{ inputs.since }}
+        run: |
+          set -euo pipefail
+          umask 077
+          trap 'rm -f "$RUNNER_TEMP/play-sa.json"' EXIT
+          printf '%s' "$SA_JSON" > "$RUNNER_TEMP/play-sa.json"
+          args=()
+          if [ -n "$SINCE" ]; then args+=(--since "$SINCE"); fi
+          if [ -n "$BUCKET" ]; then
+            python3 tools/ci/play_reviews.py "$RUNNER_TEMP/play-sa.json" all "$BUCKET" "${args[@]}" \
+              > reviews.csv
+          else
+            python3 tools/ci/play_reviews.py "$RUNNER_TEMP/play-sa.json" recent > reviews.csv
+          fi
+          echo "rows: $(($(wc -l < reviews.csv) - 1))" >> "$GITHUB_STEP_SUMMARY"
+      # The reviews name users and quote them, so they stay an artifact rather than a log.
+      - uses: actions/upload-artifact@v4
+        with:
+          name: play-reviews
+          path: reviews.csv
+          if-no-files-found: error

--- a/tools/ci/play_reviews.py
+++ b/tools/ci/play_reviews.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Collect Play reviews for com.httrack.android from both sources Play offers.
+
+Neither source alone is complete. reviews.list carries only reviews created or
+modified in the last week, and only those with text, so a bare star rating never
+appears. The monthly CSVs in the report bucket hold the history, including
+ratings without text, but lag three to seven days.
+
+So "every review" means the bucket for the history and the API for the tail, and
+this merges the two on review id.
+
+Usage:
+  play_reviews.py <sa_json> recent [--json]
+  play_reviews.py <sa_json> bulk <bucket> [--since YYYYMM] [--out DIR]
+  play_reviews.py <sa_json> all <bucket> [--out DIR]
+
+<bucket> is the report bucket, pubsite_prod_rev_<developer id>, whose name the
+Console shows under Download reports as "Copy Cloud Storage URI". Reading it needs
+the service account to hold "View app information and download bulk reports".
+"""
+
+import argparse
+import csv
+import io
+import json
+import sys
+
+import requests
+
+from play_track_admin import PKG, TIMEOUT, access_token
+
+REVIEWS = f"https://androidpublisher.googleapis.com/androidpublisher/v3/applications/{PKG}/reviews"
+STORAGE = "https://storage.googleapis.com/storage/v1/b"
+STORAGE_SCOPE = "https://www.googleapis.com/auth/devstorage.read_only"
+
+
+def fetch_recent(token):
+    """Every review the API will admit to, following pagination to the end."""
+    out, page = [], None
+    while True:
+        params = {"maxResults": 100}
+        if page:
+            params["token"] = page
+        r = requests.get(
+            REVIEWS,
+            headers={"Authorization": f"Bearer {token}"},
+            params=params,
+            timeout=TIMEOUT,
+        )
+        r.raise_for_status()
+        body = r.json()
+        out.extend(body.get("reviews", []))
+        page = body.get("tokenPagination", {}).get("nextPageToken")
+        if not page:
+            return out
+
+
+def list_report_objects(token, bucket, since=None):
+    """Names of the monthly review CSVs, oldest first, optionally from YYYYMM on."""
+    prefix = f"reviews/reviews_{PKG}_"
+    names, page = [], None
+    while True:
+        params = {"prefix": prefix}
+        if page:
+            params["pageToken"] = page
+        r = requests.get(
+            f"{STORAGE}/{bucket}/o",
+            headers={"Authorization": f"Bearer {token}"},
+            params=params,
+            timeout=TIMEOUT,
+        )
+        if r.status_code in (401, 403):
+            raise SystemExit(
+                f"cannot read gs://{bucket}/{prefix}* ({r.status_code}). Grant the service "
+                "account 'View app information and download bulk reports' in the Console."
+            )
+        r.raise_for_status()
+        body = r.json()
+        names.extend(o["name"] for o in body.get("items", []))
+        page = body.get("nextPageToken")
+        if not page:
+            break
+    if since:
+        names = [n for n in names if report_month(n) >= since]
+    return sorted(names)
+
+
+def report_month(name):
+    """The YYYYMM out of reviews_<package>_YYYYMM.csv."""
+    return name.rsplit("_", 1)[-1][:6]
+
+
+def decode_report(raw):
+    """Play writes these CSVs UTF-16, so decoding as UTF-8 yields one wide junk column."""
+    for bom, enc in (
+        (b"\xff\xfe", "utf-16"),
+        (b"\xfe\xff", "utf-16"),
+        (b"\xef\xbb\xbf", "utf-8-sig"),
+    ):
+        if raw.startswith(bom):
+            return raw.decode(enc)
+    return raw.decode("utf-8")
+
+
+def fetch_report(token, bucket, name):
+    r = requests.get(
+        f"{STORAGE}/{bucket}/o/{requests.utils.quote(name, safe='')}",
+        headers={"Authorization": f"Bearer {token}"},
+        params={"alt": "media"},
+        timeout=TIMEOUT,
+    )
+    r.raise_for_status()
+    return list(csv.DictReader(io.StringIO(decode_report(r.content))))
+
+
+def normalise_api(review):
+    """One API review to the flat shape the CSV rows already have."""
+    latest = (review.get("comments") or [{}])[0].get("userComment", {})
+    return {
+        "id": review.get("reviewId", ""),
+        "author": review.get("authorName", ""),
+        "rating": str(latest.get("starRating", "")),
+        "text": (latest.get("text") or "").replace("\n", " ").strip(),
+        "version": str(latest.get("appVersionName") or ""),
+        "device": latest.get("device", ""),
+        "modified": str(latest.get("lastModified", {}).get("seconds", "")),
+        "source": "api",
+    }
+
+
+def normalise_csv(row):
+    def col(*names):
+        for n in names:
+            for k, v in row.items():
+                if k and k.strip().lower() == n:
+                    return (v or "").strip()
+        return ""
+
+    return {
+        "id": col("review link", "review id"),
+        "author": col("reviewer language", "review submit date and time"),
+        "rating": col("star rating"),
+        "text": " ".join(x for x in (col("review title"), col("review text")) if x),
+        "version": col("app version name", "app version code"),
+        "device": col("device"),
+        "modified": col("review last update date and time", "review submit date and time"),
+        "source": "bulk",
+    }
+
+
+def write_rows(rows, out):
+    w = csv.DictWriter(out, fieldnames=list(rows[0].keys()) if rows else ["id"])
+    w.writeheader()
+    w.writerows(rows)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("sa_json")
+    ap.add_argument("command", choices=("recent", "bulk", "all"))
+    ap.add_argument("bucket", nargs="?")
+    ap.add_argument("--since", help="earliest monthly report, YYYYMM")
+    ap.add_argument("--json", action="store_true", help="raw API json instead of csv")
+    args = ap.parse_args()
+
+    with open(args.sa_json, encoding="utf-8") as f:
+        sa = json.load(f)
+    if args.command in ("bulk", "all") and not args.bucket:
+        raise SystemExit(f"{args.command} needs the report bucket name")
+
+    rows = []
+    if args.command in ("recent", "all"):
+        api = fetch_recent(access_token(sa))
+        if args.json:
+            json.dump(api, sys.stdout, indent=2, ensure_ascii=False)
+            return
+        rows += [normalise_api(r) for r in api]
+        print(f"api: {len(api)} review(s) in the last week", file=sys.stderr)
+
+    if args.command in ("bulk", "all"):
+        token = access_token(sa, STORAGE_SCOPE)
+        names = list_report_objects(token, args.bucket, args.since)
+        print(f"bulk: {len(names)} monthly report(s)", file=sys.stderr)
+        for name in names:
+            got = fetch_report(token, args.bucket, name)
+            rows += [normalise_csv(r) for r in got]
+            print(f"  {name}: {len(got)}", file=sys.stderr)
+
+    # The API tail overlaps the newest CSV; the bucket row wins because it carries
+    # the rating even when the user left no text.
+    seen, merged = set(), []
+    for row in sorted(rows, key=lambda r: r["source"]):
+        if row["id"] and row["id"] in seen:
+            continue
+        seen.add(row["id"])
+        merged.append(row)
+    write_rows(merged, sys.stdout)
+    print(f"total: {len(merged)} review(s)", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/ci/play_reviews.py
+++ b/tools/ci/play_reviews.py
@@ -1,28 +1,25 @@
 #!/usr/bin/env python3
 """Collect Play reviews for com.httrack.android from both sources Play offers.
 
-Neither source alone is complete. reviews.list carries only reviews created or
-modified in the last week, and only those with text, so a bare star rating never
-appears. The monthly CSVs in the report bucket hold the history, including
-ratings without text, but lag three to seven days.
-
-So "every review" means the bucket for the history and the API for the tail, and
-this merges the two on review id.
+reviews.list carries only the last week, and only reviews with text. The monthly
+CSVs in the report bucket hold the history and the textless ratings, and lag three
+to seven days. So "every review" means both, merged on review id.
 
 Usage:
   play_reviews.py <sa_json> recent [--json]
-  play_reviews.py <sa_json> bulk <bucket> [--since YYYYMM] [--out DIR]
-  play_reviews.py <sa_json> all <bucket> [--out DIR]
+  play_reviews.py <sa_json> bulk <bucket> [--since YYYYMM]
+  play_reviews.py <sa_json> all <bucket> [--since YYYYMM]
 
-<bucket> is the report bucket, pubsite_prod_rev_<developer id>, whose name the
-Console shows under Download reports as "Copy Cloud Storage URI". Reading it needs
-the service account to hold "View app information and download bulk reports".
+<bucket> is pubsite_prod_rev_<developer id>, shown in the Console under Download
+reports as "Copy Cloud Storage URI". Reading it needs the service account to hold
+"View app information and download bulk reports".
 """
 
 import argparse
 import csv
 import io
 import json
+import re
 import sys
 
 import requests
@@ -32,11 +29,12 @@ from play_track_admin import PKG, TIMEOUT, access_token
 REVIEWS = f"https://androidpublisher.googleapis.com/androidpublisher/v3/applications/{PKG}/reviews"
 STORAGE = "https://storage.googleapis.com/storage/v1/b"
 STORAGE_SCOPE = "https://www.googleapis.com/auth/devstorage.read_only"
+FIELDS = ["id", "author", "rating", "text", "version", "device", "modified", "source"]
 
 
 def fetch_recent(token):
     """Every review the API will admit to, following pagination to the end."""
-    out, page = [], None
+    out, page, seen = [], None, set()
     while True:
         params = {"maxResults": 100}
         if page:
@@ -51,14 +49,15 @@ def fetch_recent(token):
         body = r.json()
         out.extend(body.get("reviews", []))
         page = body.get("tokenPagination", {}).get("nextPageToken")
-        if not page:
+        if not page or page in seen:
             return out
+        seen.add(page)
 
 
 def list_report_objects(token, bucket, since=None):
     """Names of the monthly review CSVs, oldest first, optionally from YYYYMM on."""
     prefix = f"reviews/reviews_{PKG}_"
-    names, page = [], None
+    names, page, pages = [], None, set()
     while True:
         params = {"prefix": prefix}
         if page:
@@ -74,12 +73,20 @@ def list_report_objects(token, bucket, since=None):
                 f"cannot read gs://{bucket}/{prefix}* ({r.status_code}). Grant the service "
                 "account 'View app information and download bulk reports' in the Console."
             )
+        if r.status_code == 404:
+            raise SystemExit(f"no such bucket: gs://{bucket}. Check the Cloud Storage URI.")
         r.raise_for_status()
         body = r.json()
         names.extend(o["name"] for o in body.get("items", []))
         page = body.get("nextPageToken")
-        if not page:
+        if not page or page in pages:
             break
+        pages.add(page)
+    if not names:
+        raise SystemExit(
+            f"no {prefix}* objects in gs://{bucket}. Wrong bucket, or the reports are not "
+            "generated yet. Refusing to report an empty history as no history."
+        )
     if since:
         names = [n for n in names if report_month(n) >= since]
     return sorted(names)
@@ -99,7 +106,10 @@ def decode_report(raw):
     ):
         if raw.startswith(bom):
             return raw.decode(enc)
-    return raw.decode("utf-8")
+    try:
+        return raw.decode("utf-8")
+    except UnicodeDecodeError:
+        return raw.decode("utf-16-le")
 
 
 def fetch_report(token, bucket, name):
@@ -128,6 +138,12 @@ def normalise_api(review):
     }
 
 
+def review_id(link):
+    """The bare reviewId out of a Review Link, so bulk and api rows can meet."""
+    m = re.search(r"[?&]reviewId=([^&]+)", link)
+    return m.group(1) if m else link
+
+
 def normalise_csv(row):
     def col(*names):
         for n in names:
@@ -137,19 +153,34 @@ def normalise_csv(row):
         return ""
 
     return {
-        "id": col("review link", "review id"),
-        "author": col("reviewer language", "review submit date and time"),
+        "id": review_id(col("review link", "review id")),
+        # The export carries no reviewer name, only a locale, so this stays empty.
+        "author": "",
         "rating": col("star rating"),
-        "text": " ".join(x for x in (col("review title"), col("review text")) if x),
-        "version": col("app version name", "app version code"),
+        "text": " ".join(x for x in (col("review title"), col("review text")) if x).replace(
+            "\n", " "
+        ),
+        "version": col("app version name"),
         "device": col("device"),
         "modified": col("review last update date and time", "review submit date and time"),
         "source": "bulk",
     }
 
 
+def merge(rows):
+    """Drop reviews present in both sources, keeping the bucket row: it carries the
+    rating even when the user left no text. Rows with no id are all kept."""
+    seen, merged = set(), []
+    for row in sorted(rows, key=lambda r: r["source"] != "bulk"):
+        if row["id"] and row["id"] in seen:
+            continue
+        seen.add(row["id"])
+        merged.append(row)
+    return merged
+
+
 def write_rows(rows, out):
-    w = csv.DictWriter(out, fieldnames=list(rows[0].keys()) if rows else ["id"])
+    w = csv.DictWriter(out, fieldnames=FIELDS)
     w.writeheader()
     w.writerows(rows)
 
@@ -167,6 +198,8 @@ def main():
         sa = json.load(f)
     if args.command in ("bulk", "all") and not args.bucket:
         raise SystemExit(f"{args.command} needs the report bucket name")
+    if args.json and args.command != "recent":
+        raise SystemExit("--json carries the api shape only, so it fits recent")
 
     rows = []
     if args.command in ("recent", "all"):
@@ -186,14 +219,7 @@ def main():
             rows += [normalise_csv(r) for r in got]
             print(f"  {name}: {len(got)}", file=sys.stderr)
 
-    # The API tail overlaps the newest CSV; the bucket row wins because it carries
-    # the rating even when the user left no text.
-    seen, merged = set(), []
-    for row in sorted(rows, key=lambda r: r["source"]):
-        if row["id"] and row["id"] in seen:
-            continue
-        seen.add(row["id"])
-        merged.append(row)
+    merged = merge(rows)
     write_rows(merged, sys.stdout)
     print(f"total: {len(merged)} review(s)", file=sys.stderr)
 

--- a/tools/ci/play_reviews_test.py
+++ b/tools/ci/play_reviews_test.py
@@ -49,16 +49,31 @@ class Decode(unittest.TestCase):
 
 class Recent(unittest.TestCase):
     def test_follows_pagination_to_the_end(self):
+        """Three pages, so stopping after two fails."""
+        page = {"reviews": [{"reviewId": "a"}], "tokenPagination": {"nextPageToken": "t1"}}
         pages = [
+            Resp(payload=page),
             Resp(
-                payload={"reviews": [{"reviewId": "a"}], "tokenPagination": {"nextPageToken": "t"}}
+                payload={
+                    "reviews": [{"reviewId": "b"}],
+                    "tokenPagination": {"nextPageToken": "t2"},
+                }
             ),
-            Resp(payload={"reviews": [{"reviewId": "b"}]}),
+            Resp(payload={"reviews": [{"reviewId": "c"}]}),
         ]
         with mock.patch.object(pr.requests, "get", side_effect=pages) as g:
             got = pr.fetch_recent("tok")
-        self.assertEqual([r["reviewId"] for r in got], ["a", "b"])
-        self.assertEqual(g.call_args_list[1].kwargs["params"]["token"], "t")
+        self.assertEqual([r["reviewId"] for r in got], ["a", "b", "c"])
+        self.assertEqual(g.call_count, 3)
+        self.assertEqual(g.call_args_list[1].kwargs["params"]["token"], "t1")
+        self.assertEqual(g.call_args_list[2].kwargs["params"]["token"], "t2")
+
+    def test_a_repeated_token_does_not_loop_forever(self):
+        """A server echoing one token must not spin until the mock runs dry."""
+        same = {"reviews": [{"reviewId": "a"}], "tokenPagination": {"nextPageToken": "t"}}
+        with mock.patch.object(pr.requests, "get", side_effect=[Resp(payload=same)] * 50) as g:
+            pr.fetch_recent("tok")
+        self.assertLessEqual(g.call_count, 3)
 
     def test_empty_week_is_not_an_error(self):
         with mock.patch.object(pr.requests, "get", return_value=Resp(payload={})):
@@ -67,10 +82,19 @@ class Recent(unittest.TestCase):
 
 class Bucket(unittest.TestCase):
     def test_denied_names_the_missing_grant(self):
-        with mock.patch.object(pr.requests, "get", return_value=Resp(status=403)):
+        for status in (401, 403):
+            with mock.patch.object(pr.requests, "get", return_value=Resp(status=status)):
+                with self.assertRaises(SystemExit) as e:
+                    pr.list_report_objects("tok", "pubsite_prod_rev_1")
+            self.assertIn("View app information", str(e.exception))
+            self.assertNotEqual(e.exception.code, 0)
+
+    def test_a_readable_bucket_with_no_reports_is_not_reported_as_none(self):
+        """An empty listing must not read as an empty history."""
+        with mock.patch.object(pr.requests, "get", return_value=Resp(payload={})):
             with self.assertRaises(SystemExit) as e:
                 pr.list_report_objects("tok", "pubsite_prod_rev_1")
-        self.assertIn("View app information", str(e.exception))
+        self.assertNotEqual(e.exception.code, 0)
 
     def test_lists_every_page_and_filters_by_month(self):
         name = "reviews/reviews_com.httrack.android_%s.csv"
@@ -85,6 +109,71 @@ class Bucket(unittest.TestCase):
         ):
             got = pr.list_report_objects("tok", "b", since="202000")
         self.assertEqual(got, [name % "202608"])
+
+
+# The header Play actually emits, verbatim. The normalise tests are circular
+# without it: they would pass on names invented to match the code.
+PLAY_HEADER = (
+    "Package Name,App Version Code,App Version Name,Reviewer Language,Device,"
+    "Review Submit Date and Time,Review Submit Millis Since Epoch,"
+    "Review Last Update Date and Time,Review Last Update Millis Since Epoch,"
+    "Star Rating,Review Title,Review Text,Developer Reply Date and Time,"
+    "Developer Reply Millis Since Epoch,Developer Reply Text,Review Link"
+)
+
+
+class RealHeader(unittest.TestCase):
+    """Guards against a schema the code names but Play does not emit."""
+
+    def rows(self, body):
+        raw = (PLAY_HEADER + "\n" + body).encode("utf-16")
+        import csv as _csv
+
+        return list(_csv.DictReader(io.StringIO(pr.decode_report(raw))))
+
+    def test_every_field_the_tool_reads_is_populated(self):
+        link = "https://play.google.com/console/developers/x/app/y/review-details?reviewId=abc123"
+        row = self.rows(
+            "com.httrack.android,99,3.50-beta-7,en,Pixel,2026-08-01T10:00:00Z,1,"
+            "2026-08-02T10:00:00Z,2,4,Nice,Works well,,,," + link
+        )[0]
+        got = pr.normalise_csv(row)
+        self.assertEqual(got["id"], "abc123")
+        self.assertEqual(got["rating"], "4")
+        self.assertEqual(got["text"], "Nice Works well")
+        self.assertEqual(got["version"], "3.50-beta-7")
+        self.assertEqual(got["device"], "Pixel")
+        self.assertEqual(got["modified"], "2026-08-02T10:00:00Z")
+
+    def test_a_rating_with_no_text_still_carries_its_id(self):
+        link = "https://example/review-details?reviewId=zz9"
+        row = self.rows(
+            "com.httrack.android,99,3.50,en,Pixel,2026-08-01T10:00:00Z,1,"
+            "2026-08-02T10:00:00Z,2,5,,,,,," + link
+        )[0]
+        got = pr.normalise_csv(row)
+        self.assertEqual((got["rating"], got["text"], got["id"]), ("5", "", "zz9"))
+
+
+class Merge(unittest.TestCase):
+    """The bucket row must win, because only it carries a textless rating."""
+
+    def test_bulk_wins_and_the_review_is_not_duplicated(self):
+        rows = [
+            {"id": "a1", "source": "api", "text": "from api"},
+            {"id": "a1", "source": "bulk", "text": "from bulk"},
+        ]
+        merged = pr.merge(rows)
+        self.assertEqual(len(merged), 1)
+        self.assertEqual(merged[0]["text"], "from bulk")
+
+    def test_rows_without_an_id_are_all_kept(self):
+        merged = pr.merge([{"id": "", "source": "bulk"}, {"id": "", "source": "bulk"}])
+        self.assertEqual(len(merged), 2)
+
+    def test_a_review_link_and_a_bare_id_meet(self):
+        self.assertEqual(pr.review_id("https://x/review-details?reviewId=q7&hl=en"), "q7")
+        self.assertEqual(pr.review_id("q7"), "q7")
 
 
 class Normalise(unittest.TestCase):

--- a/tools/ci/play_reviews_test.py
+++ b/tools/ci/play_reviews_test.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Tests for play_reviews.py, stubbing what Play really returns, not what is convenient."""
+
+import io
+import os
+import sys
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import play_reviews as pr  # noqa: E402
+
+
+class Resp:
+    def __init__(self, status=200, payload=None, content=b""):
+        self.status_code = status
+        self._payload = payload
+        self.content = content
+
+    def json(self):
+        return self._payload
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise AssertionError(f"unexpected raise_for_status on {self.status_code}")
+
+
+class Decode(unittest.TestCase):
+    """Play writes the bulk CSVs UTF-16; reading them as UTF-8 is the whole trap."""
+
+    def test_utf16_le_with_bom(self):
+        raw = '"Star Rating"\n"5"\n'.encode("utf-16")  # utf-16 emits the LE BOM
+        self.assertEqual(pr.decode_report(raw).splitlines()[0], '"Star Rating"')
+
+    def test_utf16_be_with_bom(self):
+        raw = b"\xfe\xff" + '"Star Rating"'.encode("utf-16-be")
+        self.assertEqual(pr.decode_report(raw), '"Star Rating"')
+
+    def test_utf8_bom_and_plain(self):
+        self.assertEqual(pr.decode_report('"a"'.encode("utf-8-sig")), '"a"')
+        self.assertEqual(pr.decode_report(b'"a"'), '"a"')
+
+    def test_utf16_csv_parses_into_columns(self):
+        raw = "Star Rating,Review Text\n5,good\n".encode("utf-16")
+        rows = list(__import__("csv").DictReader(io.StringIO(pr.decode_report(raw))))
+        self.assertEqual(rows[0]["Star Rating"], "5")
+
+
+class Recent(unittest.TestCase):
+    def test_follows_pagination_to_the_end(self):
+        pages = [
+            Resp(
+                payload={"reviews": [{"reviewId": "a"}], "tokenPagination": {"nextPageToken": "t"}}
+            ),
+            Resp(payload={"reviews": [{"reviewId": "b"}]}),
+        ]
+        with mock.patch.object(pr.requests, "get", side_effect=pages) as g:
+            got = pr.fetch_recent("tok")
+        self.assertEqual([r["reviewId"] for r in got], ["a", "b"])
+        self.assertEqual(g.call_args_list[1].kwargs["params"]["token"], "t")
+
+    def test_empty_week_is_not_an_error(self):
+        with mock.patch.object(pr.requests, "get", return_value=Resp(payload={})):
+            self.assertEqual(pr.fetch_recent("tok"), [])
+
+
+class Bucket(unittest.TestCase):
+    def test_denied_names_the_missing_grant(self):
+        with mock.patch.object(pr.requests, "get", return_value=Resp(status=403)):
+            with self.assertRaises(SystemExit) as e:
+                pr.list_report_objects("tok", "pubsite_prod_rev_1")
+        self.assertIn("View app information", str(e.exception))
+
+    def test_lists_every_page_and_filters_by_month(self):
+        name = "reviews/reviews_com.httrack.android_%s.csv"
+        pages = [
+            Resp(payload={"items": [{"name": name % "201703"}], "nextPageToken": "p"}),
+            Resp(payload={"items": [{"name": name % "202608"}]}),
+        ]
+        with mock.patch.object(pr.requests, "get", side_effect=pages):
+            self.assertEqual(len(pr.list_report_objects("tok", "b")), 2)
+        with mock.patch.object(
+            pr.requests, "get", side_effect=[Resp(payload=p.json()) for p in pages]
+        ):
+            got = pr.list_report_objects("tok", "b", since="202000")
+        self.assertEqual(got, [name % "202608"])
+
+
+class Normalise(unittest.TestCase):
+    def test_csv_columns_match_case_insensitively(self):
+        row = {"Star Rating": "1", "Review Text": "crashes", "App Version Name": "3.49"}
+        got = pr.normalise_csv(row)
+        self.assertEqual((got["rating"], got["text"], got["version"]), ("1", "crashes", "3.49"))
+
+    def test_a_rating_with_no_text_survives(self):
+        """The bucket's reason to exist: the API drops these entirely."""
+        got = pr.normalise_csv({"Star Rating": "4", "Review Text": ""})
+        self.assertEqual(got["rating"], "4")
+        self.assertEqual(got["text"], "")
+
+    def test_api_review_reads_the_latest_comment(self):
+        got = pr.normalise_api(
+            {
+                "reviewId": "x",
+                "authorName": "A",
+                "comments": [
+                    {"userComment": {"starRating": 2, "text": "slow\nstill", "device": "d"}}
+                ],
+            }
+        )
+        self.assertEqual((got["id"], got["rating"], got["device"]), ("x", "2", "d"))
+        self.assertNotIn("\n", got["text"])
+
+    def test_api_review_without_comments_does_not_crash(self):
+        self.assertEqual(pr.normalise_api({"reviewId": "y"})["rating"], "")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tools/ci/play_track_admin.py
+++ b/tools/ci/play_track_admin.py
@@ -75,13 +75,20 @@ def b64url(b):
     return base64.urlsafe_b64encode(b).rstrip(b"=")
 
 
-def access_token(sa):
-    """Mint an OAuth token from the service-account JSON (RS256 JWT bearer flow)."""
+PUBLISHER_SCOPE = "https://www.googleapis.com/auth/androidpublisher"
+
+
+def access_token(sa, scope=PUBLISHER_SCOPE):
+    """Mint an OAuth token from the service-account JSON (RS256 JWT bearer flow).
+
+    The scope is a parameter because the bulk report bucket needs a storage scope,
+    not the publishing one.
+    """
     now = int(time.time())
     header = {"alg": "RS256", "typ": "JWT"}
     claim = {
         "iss": sa["client_email"],
-        "scope": "https://www.googleapis.com/auth/androidpublisher",
+        "scope": scope,
         "aud": sa["token_uri"],
         "iat": now,
         "exp": now + 3600,


### PR DESCRIPTION
Nothing in the repo could read a review. Adding it needs two sources, because neither is complete on its own.

`reviews.list` returns only reviews users wrote or changed in the last week, and only ones carrying text, so a bare star rating with no comment never appears in it. The monthly CSVs in the report bucket hold the history and those textless ratings, and lag three to seven days. `play_reviews.py` reads both and merges on review id, keeping the bucket row where they overlap because it has the rating either way.

The bucket half needs the service account to hold "View app information and download bulk reports". Nobody has made that Console grant, so `recent` works today and `all` says what is missing instead of failing obscurely. The `play-reviews.yml` dispatch takes the bucket name, since only the Console knows it.

Two things worth knowing. The CSVs are UTF-16, and decoding them as UTF-8 gives one wide column of junk rather than an error. And this repo is public, so a workflow artifact is downloadable by anyone: the reviews are already public on the store, but the artifact aggregates them with the device and locale the listing does not show, so it expires after a day.