### PR TITLE
Mirrors in private storage are deleted with the app, and nothing says so

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,10 +19,13 @@
     <!-- NetworkInterface.getNetworkInterfaces() does not need that apparently, so let's remove the permission. -->
     <!-- uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" -->
 
+    <!-- hasFragileUserData: from Android 10 the Settings uninstall flow offers to keep our data,
+         which is where private-storage mirrors live. Ignored below 29 and by the Play Store flow. -->
     <application
         android:name=".HTTrackApplication"
         android:allowBackup="true"
         android:description="@string/app_description"
+        android:hasFragileUserData="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:requestLegacyExternalStorage="true"

--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -145,6 +145,8 @@ public class HTTrackActivity extends FragmentActivity {
   protected static final String IMPORT_OFFERED_NAME = "LegacyImportOffered";
   // Whether all-files storage access was ever offered; a refusal keeps mirrors in private storage.
   protected static final String STORAGE_ASKED_NAME = "StorageAccessAsked";
+  // The root we left on the last move: nothing is migrated, so the older projects are still there.
+  protected static final String PREVIOUS_BASE_NAME = "PreviousBasePath";
 
   // <br /> Pattern
   protected static final Pattern brHtmlPattern = Pattern.compile(Pattern
@@ -323,6 +325,14 @@ public class HTTrackActivity extends FragmentActivity {
           public void refreshProjectSuggestions() {
             refreshprojectNameSuggests();
           }
+
+          @Override
+          public void noteMovedFrom(final File previousRoot) {
+            getSharedPreferences(PREFS_NAME, 0).edit()
+                .putString(PREVIOUS_BASE_NAME, previousRoot.getAbsolutePath()).apply();
+            showNotification(
+                getString(R.string.storage_previous_root, previousRoot.getAbsolutePath()), true);
+          }
         });
 
     // Always refreshed: the field may have just been inflated.
@@ -348,6 +358,7 @@ public class HTTrackActivity extends FragmentActivity {
     // Load it
     computeStorageTarget();
     refreshprojectNameSuggests();
+    refreshStorageAccessHints();
   }
 
   /*
@@ -478,8 +489,7 @@ public class HTTrackActivity extends FragmentActivity {
     }
     if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
       new AlertDialog.Builder(this)
-          .setMessage("Allow HTTrack all-files access so your mirrors are saved in a public "
-              + "HTTrack folder other apps can open. Without it, mirrors stay private to HTTrack.")
+          .setMessage(R.string.storage_access_prompt)
           .setPositiveButton(android.R.string.ok, (dialog, which) -> {
             getSharedPreferences(PREFS_NAME, 0).edit()
                 .putBoolean(STORAGE_ASKED_NAME, true).apply();
@@ -581,6 +591,40 @@ public class HTTrackActivity extends FragmentActivity {
     final View warning = findViewById(R.id.textStorageWarning);
     if (warning != null) {
       warning.setVisibility(browsable ? View.GONE : View.VISIBLE);
+    }
+    final TextView moved = TextView.class.cast(findViewById(R.id.textPreviousRoot));
+    if (moved != null) {
+      final File previous = getPreviousRootFile();
+      if (previous != null) {
+        moved.setText(getString(R.string.storage_previous_root, previous.getAbsolutePath()));
+      }
+      moved.setVisibility(previous != null ? View.VISIBLE : View.GONE);
+    }
+  }
+
+  /*
+   * The root we left on the last move, or null when there was none or we are back on it. Only a
+   * hint: it is offered, never applied behind the user's back, and nothing was ever migrated.
+   */
+  private File getPreviousRootFile() {
+    final String previous = getSharedPreferences(PREFS_NAME, 0)
+        .getString(PREVIOUS_BASE_NAME, null);
+    if (previous == null) {
+      return null;
+    }
+    final File file = new File(previous);
+    return file.equals(getProjectRootFile()) ? null : file;
+  }
+
+  /*
+   * Base-path panel hint: go back to the root the last move left behind, where the older projects
+   * still are. Refused like any other base path when it is no longer ours to write.
+   */
+  public void onClickUsePreviousRoot(final View view) {
+    final File previous = getPreviousRootFile();
+    if (previous != null) {
+      // setBasePath refreshes the panel, hint included.
+      setBasePath(previous.getAbsolutePath());
     }
   }
 

--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -330,8 +330,8 @@ public class HTTrackActivity extends FragmentActivity {
           public void noteMovedFrom(final File previousRoot) {
             getSharedPreferences(PREFS_NAME, 0).edit()
                 .putString(PREVIOUS_BASE_NAME, previousRoot.getAbsolutePath()).apply();
-            showNotification(
-                getString(R.string.storage_previous_root, previousRoot.getAbsolutePath()), true);
+            showNotification(getString(previousRootText(previousRoot),
+                previousRoot.getAbsolutePath()), true);
           }
         });
 
@@ -599,14 +599,18 @@ public class HTTrackActivity extends FragmentActivity {
       final boolean offer = previous != null
           && Boolean.TRUE.equals(isWritableProjectPath(previous));
       if (offer) {
-        // The mirrors left behind in a private root are the ones an uninstall takes.
-        final int text = StoragePaths.externalStorageDocId(previous,
-            Environment.getExternalStorageDirectory()) == null
-                ? R.string.storage_previous_root_private : R.string.storage_previous_root;
-        moved.setText(getString(text, previous.getAbsolutePath()));
+        moved.setText(getString(previousRootText(previous), previous.getAbsolutePath())
+            + " " + getString(R.string.storage_previous_root_tap));
       }
       moved.setVisibility(offer ? View.VISIBLE : View.GONE);
     }
+  }
+
+  /* The mirrors left behind in a private root are the ones an uninstall takes. */
+  private int previousRootText(final File previous) {
+    return StoragePaths.externalStorageDocId(previous,
+        Environment.getExternalStorageDirectory()) == null
+            ? R.string.storage_previous_root_private : R.string.storage_previous_root;
   }
 
   /*

--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -594,11 +594,18 @@ public class HTTrackActivity extends FragmentActivity {
     }
     final TextView moved = TextView.class.cast(findViewById(R.id.textPreviousRoot));
     if (moved != null) {
+      // Offer it only while we could actually take it back, or the tap just toasts a refusal.
       final File previous = getPreviousRootFile();
-      if (previous != null) {
-        moved.setText(getString(R.string.storage_previous_root, previous.getAbsolutePath()));
+      final boolean offer = previous != null
+          && Boolean.TRUE.equals(isWritableProjectPath(previous));
+      if (offer) {
+        // The mirrors left behind in a private root are the ones an uninstall takes.
+        final int text = StoragePaths.externalStorageDocId(previous,
+            Environment.getExternalStorageDirectory()) == null
+                ? R.string.storage_previous_root_private : R.string.storage_previous_root;
+        moved.setText(getString(text, previous.getAbsolutePath()));
       }
-      moved.setVisibility(previous != null ? View.VISIBLE : View.GONE);
+      moved.setVisibility(offer ? View.VISIBLE : View.GONE);
     }
   }
 

--- a/app/src/main/java/com/httrack/android/StoragePaths.java
+++ b/app/src/main/java/com/httrack/android/StoragePaths.java
@@ -98,6 +98,9 @@ final class StoragePaths {
 
     /** The listed projects are the ones under the root, so the suggestions went stale. */
     void refreshProjectSuggestions();
+
+    /** Nothing is migrated, so the projects made before a move stay where they were. */
+    void noteMovedFrom(final File previous);
   }
 
   /**
@@ -126,6 +129,7 @@ final class StoragePaths {
     if (previous != null) {
       // Nothing was listed before the first resolution.
       actions.refreshProjectSuggestions();
+      actions.noteMovedFrom(previous);
     }
     return true;
   }

--- a/app/src/main/res/layout/activity_proj_name.xml
+++ b/app/src/main/res/layout/activity_proj_name.xml
@@ -142,6 +142,16 @@
             android:text="@string/storage_private_warning"
             android:textStyle="italic"
             android:visibility="gone" />
+
+        <TextView
+            android:id="@+id/textPreviousRoot"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:clickable="true"
+            android:onClick="onClickUsePreviousRoot"
+            android:paddingTop="4dp"
+            android:textStyle="italic"
+            android:visibility="gone" />
     </LinearLayout>
 
     <LinearLayout

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -232,8 +232,9 @@
     <string name="enable_all_files_access">Grant all-files access</string>
     <string name="storage_private_warning">Without all-files access, mirrors are saved in a private folder that other apps and file managers can\'t open. Android also erases that folder if you uninstall HTTrack or clear its storage. Grant access to keep mirrors in a public HTTrack folder instead.</string>
     <string name="storage_access_prompt">Allow HTTrack all-files access so your mirrors are saved in a public HTTrack folder other apps can open. Without it, mirrors stay in a private folder that Android erases if you uninstall HTTrack or clear its storage.</string>
-    <string name="storage_previous_root">Mirrors used to be saved in %1$s. Older projects are still there. Tap to switch back.</string>
-    <string name="storage_previous_root_private">Mirrors used to be saved in %1$s. Older projects are still there, and Android erases that folder if you uninstall HTTrack. Tap to switch back.</string>
+    <string name="storage_previous_root">Mirrors used to be saved in %1$s. Older projects are still there.</string>
+    <string name="storage_previous_root_private">Mirrors used to be saved in %1$s. Older projects are still there, and Android erases that folder if you uninstall HTTrack.</string>
+    <string name="storage_previous_root_tap">Tap to switch back.</string>
     <string name="base_path_toast">Folder path copied to clipboard: %s</string>
     <string name="title_activity_file_chooser">FileChooserActivity</string>
     <string name="apply_base_path">Save prefs</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -230,7 +230,9 @@
     <string name="base_path">Base path</string>
     <string name="open_base_folder">Open folder</string>
     <string name="enable_all_files_access">Grant all-files access</string>
-    <string name="storage_private_warning">Without all-files access, mirrors are saved in a private folder that other apps and file managers can\'t open. Grant access to keep them in a public HTTrack folder.</string>
+    <string name="storage_private_warning">Without all-files access, mirrors are saved in a private folder that other apps and file managers can\'t open, and Android erases that folder if you uninstall HTTrack or clear its storage. Grant access to keep them in a public HTTrack folder instead.</string>
+    <string name="storage_access_prompt">Allow HTTrack all-files access so your mirrors are saved in a public HTTrack folder other apps can open. Without it, mirrors stay in a private folder that Android erases if you uninstall HTTrack or clear its storage.</string>
+    <string name="storage_previous_root">HTTrack was using %1$s before. Projects made there are still there; tap here to switch back to it.</string>
     <string name="base_path_toast">Folder path copied to clipboard: %s</string>
     <string name="title_activity_file_chooser">FileChooserActivity</string>
     <string name="apply_base_path">Save prefs</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -230,9 +230,10 @@
     <string name="base_path">Base path</string>
     <string name="open_base_folder">Open folder</string>
     <string name="enable_all_files_access">Grant all-files access</string>
-    <string name="storage_private_warning">Without all-files access, mirrors are saved in a private folder that other apps and file managers can\'t open, and Android erases that folder if you uninstall HTTrack or clear its storage. Grant access to keep them in a public HTTrack folder instead.</string>
+    <string name="storage_private_warning">Without all-files access, mirrors are saved in a private folder that other apps and file managers can\'t open. Android also erases that folder if you uninstall HTTrack or clear its storage. Grant access to keep mirrors in a public HTTrack folder instead.</string>
     <string name="storage_access_prompt">Allow HTTrack all-files access so your mirrors are saved in a public HTTrack folder other apps can open. Without it, mirrors stay in a private folder that Android erases if you uninstall HTTrack or clear its storage.</string>
-    <string name="storage_previous_root">HTTrack was using %1$s before. Projects made there are still there; tap here to switch back to it.</string>
+    <string name="storage_previous_root">Mirrors used to be saved in %1$s. Older projects are still there. Tap to switch back.</string>
+    <string name="storage_previous_root_private">Mirrors used to be saved in %1$s. Older projects are still there, and Android erases that folder if you uninstall HTTrack. Tap to switch back.</string>
     <string name="base_path_toast">Folder path copied to clipboard: %s</string>
     <string name="title_activity_file_chooser">FileChooserActivity</string>
     <string name="apply_base_path">Save prefs</string>

--- a/app/src/test/java/com/httrack/android/ProjectRootResolutionTest.java
+++ b/app/src/test/java/com/httrack/android/ProjectRootResolutionTest.java
@@ -144,6 +144,11 @@ public class ProjectRootResolutionTest {
     public void refreshProjectSuggestions() {
       calls.add("refresh");
     }
+
+    @Override
+    public void noteMovedFrom(final File previous) {
+      calls.add("from " + previous);
+    }
   }
 
   /**
@@ -158,9 +163,14 @@ public class ProjectRootResolutionTest {
 
   /** A base that is merely unreachable now must survive, or a remount cannot bring it back. */
   @Test
-  public void computeStorageTargetNeverWritesTheSettings() throws Exception {
-    assertFalse("resolving the root must not edit the stored BasePath, however spelled",
-        computeStorageTargetBody().contains(".edit()"));
+  public void computeStorageTargetNeverWritesTheStoredBasePath() throws Exception {
+    final String body = computeStorageTargetBody();
+    assertFalse("resolving the root must not rewrite the stored BasePath, however spelled",
+        body.contains("putString(BASE_NAME") || body.contains("remove(BASE_NAME"));
+    // Counted, so a second edit has to come back through this test.
+    assertEquals("only the previous-root hint may be persisted while resolving", 1,
+        body.split("\\.edit\\(\\)", -1).length - 1);
+    assertTrue(body.contains("PREVIOUS_BASE_NAME"));
   }
 
   /** Wiring, not behaviour: the recorder tests below cannot see the call site at all. */
@@ -175,7 +185,7 @@ public class ProjectRootResolutionTest {
   public void aMoveReinitsAtTheNewRoot() {
     final Recorder rec = new Recorder();
     assertTrue(StoragePaths.applyRootMove(fallback, base, false, rec));
-    assertEquals(Arrays.asList("init " + base, "refresh"), rec.calls);
+    assertEquals(Arrays.asList("init " + base, "refresh", "from " + fallback), rec.calls);
   }
 
   /** initRootPath leaks a buffer per call, so a re-resolve that moved nothing must do nothing. */
@@ -199,10 +209,26 @@ public class ProjectRootResolutionTest {
   public void theMissingDirectoryWarningRidesTheMove() {
     final Recorder moved = new Recorder();
     assertTrue(StoragePaths.applyRootMove(fallback, base, true, moved));
-    assertEquals(Arrays.asList("warn", "init " + base, "refresh"), moved.calls);
+    assertEquals(Arrays.asList("warn", "init " + base, "refresh", "from " + fallback), moved.calls);
 
     final Recorder stayed = new Recorder();
     assertFalse(StoragePaths.applyRootMove(base, base, true, stayed));
     assertEquals(Collections.emptyList(), stayed.calls);
+  }
+
+  /**
+   * Granting all-files access re-points the root and migrates nothing, so the move must name the
+   * root it left; a resume that moved nothing must stay silent, or the offer would toast forever.
+   */
+  @Test
+  public void aMoveNamesTheRootItLeft() {
+    final Recorder moved = new Recorder();
+    assertTrue(StoragePaths.applyRootMove(fallback, base, false, moved));
+    assertTrue(moved.calls.contains("from " + fallback));
+
+    final Recorder first = new Recorder();
+    assertTrue(StoragePaths.applyRootMove(null, fallback, false, first));
+    assertFalse("there is no earlier root on the first resolution",
+        first.calls.contains("from null"));
   }
 }

--- a/app/src/test/java/com/httrack/android/ProjectRootResolutionTest.java
+++ b/app/src/test/java/com/httrack/android/ProjectRootResolutionTest.java
@@ -166,11 +166,14 @@ public class ProjectRootResolutionTest {
   public void computeStorageTargetNeverWritesTheStoredBasePath() throws Exception {
     final String body = computeStorageTargetBody();
     assertFalse("resolving the root must not rewrite the stored BasePath, however spelled",
-        body.contains("putString(BASE_NAME") || body.contains("remove(BASE_NAME"));
+        body.contains("putString(BASE_NAME") || body.contains("remove(BASE_NAME")
+            || body.contains("\"BasePath\"") || body.contains(".clear()"));
     // Counted, so a second edit has to come back through this test.
     assertEquals("only the previous-root hint may be persisted while resolving", 1,
         body.split("\\.edit\\(\\)", -1).length - 1);
-    assertTrue(body.contains("PREVIOUS_BASE_NAME"));
+    // The one edit chain must be the hint, not something that happens to mention it later.
+    assertTrue("the only edit while resolving must write the previous-root hint",
+        body.matches("(?s).*\\.edit\\(\\)\\s*\\.putString\\(PREVIOUS_BASE_NAME.*"));
   }
 
   /** Wiring, not behaviour: the recorder tests below cannot see the call site at all. */


### PR DESCRIPTION
Mirrors kept without all-files access live in a private folder Android erases on uninstall or on "Clear storage", and nothing in the app said so: the existing warning only said the folder was not browsable. It now names the consequence, in the warning and in the first-run prompt, which was a hardcoded English literal and is now a resource. The manifest gains `hasFragileUserData`, which is partial rather than a fix: Android ignores it below 10, only the Settings uninstall flow offers to keep the data, and it does nothing for "Clear storage".

Granting access later re-points the root and migrates nothing, so older projects drop out of the list, Browse and Cleanup. They were always recoverable by typing the old path back, but the app recorded it nowhere. It now remembers the previous root, offers it as a tappable line while that path is still one we could take, and says plainly that Android erases it when it is a private folder. Nothing is migrated and the default root is unchanged.

One note for whoever next regenerates translations: `tools/build_strings.sh` joins on the English value text rather than the key, so the reworded `storage_private_warning` will no longer match its old translation line. No `res/values-<lang>/` is checked in today, so nothing breaks now.