### PR TITLE
Tests that pass whatever the option wiring says

### DIFF
--- a/app/src/test/java/com/httrack/android/TestSources.java
+++ b/app/src/test/java/com/httrack/android/TestSources.java
@@ -77,24 +77,61 @@ final class TestSources {
     return count;
   }
 
-  /** The winprofile.ini keys fieldsSerializer declares, in order. The table
-   *  pulls in R.id, which the stub android.jar cannot load, and three of its
-   *  entries wrap across two lines. */
-  static List<String> serializerKeys() throws IOException {
+  /** Body of the OptionsMapper table NAME, comments dropped. */
+  static String tableBody(final String name) throws IOException {
     final String source = javaSource("OptionsMapper");
-    final String declaration = "new Pair<Integer, String>(R.id.";
-    final Matcher m = Pattern.compile(
-        "new Pair<Integer, String>\\(R\\.id\\.\\w+,\\s*\"([^\"]+)\"\\)")
-        .matcher(source);
+    final int head = source.indexOf(name + "[] = new Pair[] {");
+    if (head == -1) {
+      throw new IllegalStateException("no " + name + " table");
+    }
+    final int from = source.indexOf('{', head) + 1;
+    int depth = 1;
+    int at = from;
+    for (; at < source.length() && depth > 0; at++) {
+      final char c = source.charAt(at);
+      if (c == '"') {
+        // A footer default holds {url}, which must not close the table.
+        while (++at < source.length() && source.charAt(at) != '"') {
+          if (source.charAt(at) == '\\') {
+            at++;
+          }
+        }
+      } else if (c == '{') {
+        depth++;
+      } else if (c == '}') {
+        depth--;
+      }
+    }
+    if (depth != 0) {
+      throw new IllegalStateException(name + " table does not end");
+    }
+    return source.substring(from, at - 1).replaceAll("(?s)/\\*.*?\\*/", "")
+        .replaceAll("(?m)^\\s*//.*$", "");
+  }
+
+  /** Keys the table NAME declares, in order; PATTERN captures one entry's key.
+   *  Entries are counted by a "new Pair" no line break can split, so a
+   *  declaration PATTERN cannot read fails the scrape instead of vanishing. */
+  static List<String> tableKeys(final String name, final String pattern)
+      throws IOException {
+    final String body = tableBody(name);
+    final Matcher m = Pattern.compile(pattern).matcher(body);
     final List<String> keys = new ArrayList<String>();
     while (m.find()) {
       keys.add(m.group(1));
     }
-    // A regex that quietly stopped matching would shorten every list built here.
-    if (keys.size() != occurrences(source, declaration)) {
+    final int declared = occurrences(body, "new Pair");
+    if (keys.size() != declared) {
       throw new IllegalStateException("parsed " + keys.size() + " of "
-          + occurrences(source, declaration) + " fieldsSerializer entries");
+          + declared + " " + name + " entries");
     }
     return keys;
+  }
+
+  /** The winprofile.ini keys fieldsSerializer declares, in order. The table
+   *  pulls in R.id, which the stub android.jar cannot load. */
+  static List<String> serializerKeys() throws IOException {
+    return tableKeys("fieldsSerializer",
+        "new Pair<Integer, String>\\(\\s*R\\.id\\.\\w+\\s*,\\s*\"([^\"]+)\"\\s*\\)");
   }
 }

--- a/app/src/test/java/com/httrack/android/WinProfileParityTest.java
+++ b/app/src/test/java/com/httrack/android/WinProfileParityTest.java
@@ -46,24 +46,23 @@ public class WinProfileParityTest {
 
   /* -x turns external links into error pages, and the engine defaults it off. */
   @Test
-  public void noExternalPagesEmitsWhenChecked() {
-    assertEquals(Arrays.asList("-x"), emit(new SimpleOptionFlag("x"), "1"));
-    assertTrue(emit(new SimpleOptionFlag("x"), "0").isEmpty());
+  public void noExternalPagesEmitsWhenChecked() throws IOException {
+    assertEquals(Arrays.asList("-x"), emit(wiredMapper("NoExternalPages"), "1"));
+    assertTrue(emit(wiredMapper("NoExternalPages"), "0").isEmpty());
   }
 
   /* -%q includes query strings and -%q0 drops them; the box hides them. */
   @Test
-  public void hideQueryStringsEmitsTheDisablingForm() {
-    assertEquals(Arrays.asList("-%q0"), emit(new SimpleOptionFlag("%q0"), "1"));
-    assertTrue(emit(new SimpleOptionFlag("%q0"), "0").isEmpty());
+  public void hideQueryStringsEmitsTheDisablingForm() throws IOException {
+    assertEquals(Arrays.asList("-%q0"), emit(wiredMapper("NoQueryStrings"), "1"));
+    assertTrue(emit(wiredMapper("NoQueryStrings"), "0").isEmpty());
   }
 
   /* Bare -j re-asserts the engine default, so unticking the box needs -j0. */
   @Test
-  public void parseJavaTurnsOffWithTheZeroForm() {
-    assertEquals(Arrays.asList("-j0"),
-        emit(new SimpleOptionFlag("j0", true), "0"));
-    assertTrue(emit(new SimpleOptionFlag("j0", true), "1").isEmpty());
+  public void parseJavaTurnsOffWithTheZeroForm() throws IOException {
+    assertEquals(Arrays.asList("-j0"), emit(wiredMapper("ParseJava"), "0"));
+    assertTrue(emit(wiredMapper("ParseJava"), "1").isEmpty());
   }
 
   @Test

--- a/app/src/test/java/com/httrack/android/WinProfileParityTest.java
+++ b/app/src/test/java/com/httrack/android/WinProfileParityTest.java
@@ -5,10 +5,12 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import com.httrack.android.OptionsMapper.MultipleChoicesOption;
 import com.httrack.android.OptionsMapper.OptionMapper;
 import com.httrack.android.OptionsMapper.ProfileFormat;
+import com.httrack.android.OptionsMapper.SimpleOption0;
 import com.httrack.android.OptionsMapper.SimpleOptionFlag;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -62,15 +64,6 @@ public class WinProfileParityTest {
     assertEquals(Arrays.asList("-j0"),
         emit(new SimpleOptionFlag("j0", true), "0"));
     assertTrue(emit(new SimpleOptionFlag("j0", true), "1").isEmpty());
-  }
-
-  /* Checked must revalidate, which is -C2; the engine's own default is -C1. */
-  @Test
-  public void cacheChecksForUpdatesWhenChecked() {
-    final OptionMapper cache = new MultipleChoicesOption(new String[] { "C0",
-        "C2" });
-    assertEquals(Arrays.asList("-C2"), emit(cache, "1"));
-    assertEquals(Arrays.asList("-C0"), emit(cache, "0"));
   }
 
   @Test
@@ -172,19 +165,54 @@ public class WinProfileParityTest {
     return TestSources.javaSource("OptionsMapper");
   }
 
-  /* Counting the declarations separately keeps a regex that quietly stops
-     matching from passing every key test on a short list. */
-  private static List<String> keysOf(final String declaration,
-      final String pattern) throws IOException {
-    final String source = mapperTable();
-    final Matcher m = Pattern.compile(pattern).matcher(source);
-    final List<String> keys = new ArrayList<String>();
-    while (m.find()) {
-      keys.add(m.group(1));
+  /* The mapper fieldsMapper declares for KEY, source text, spacing squeezed. */
+  private static String mapperDeclaration(final String key) throws IOException {
+    final String body = TestSources.tableBody("fieldsMapper");
+    final String head = "new Pair<String, OptionMapper>(\"" + key + "\"";
+    final int at = body.indexOf(head);
+    assertTrue(key + " is not in fieldsMapper", at != -1);
+    int depth = 1;
+    int from = -1;
+    int i = at + head.length();
+    for (; i < body.length() && depth > 0; i++) {
+      final char c = body.charAt(i);
+      if (c == '(') {
+        depth++;
+      } else if (c == ')') {
+        depth--;
+      } else if (c == ',' && depth == 1 && from == -1) {
+        from = i + 1;
+      }
     }
-    assertEquals(declaration + " entries parsed",
-        TestSources.occurrences(source, declaration), keys.size());
-    return keys;
+    assertTrue(key + " declares no mapper", from != -1 && depth == 0);
+    return body.substring(from, i - 1).trim().replaceAll("\\s+", " ");
+  }
+
+  /* Rebuilds what fieldsMapper wires KEY to, so the emission tests below run
+     production's choice of primitive rather than one this file picked. */
+  private static OptionMapper wiredMapper(final String key) throws IOException {
+    final String declaration = mapperDeclaration(key);
+    Matcher m = Pattern.compile("new (SimpleOptionFlag|SimpleOption0)\\(\\s*"
+        + "\"([^\"]+)\"\\s*(?:,\\s*(true|false)\\s*)?\\)").matcher(declaration);
+    if (m.matches()) {
+      if ("SimpleOption0".equals(m.group(1))) {
+        return new SimpleOption0(m.group(2));
+      }
+      return new SimpleOptionFlag(m.group(2), "true".equals(m.group(3)));
+    }
+    m = Pattern.compile("new MultipleChoicesOption\\(\\s*new String\\[\\]"
+        + "\\s*\\{(.*)\\}\\s*\\)").matcher(declaration);
+    if (m.matches()) {
+      final List<String> choices = new ArrayList<String>();
+      final Matcher choice = Pattern.compile("\"([^\"]*)\"").matcher(m.group(1));
+      while (choice.find()) {
+        choices.add(choice.group(1));
+      }
+      return new MultipleChoicesOption(choices.toArray(new String[0]));
+    }
+    fail(key + " is wired to " + declaration + ", which this test cannot "
+        + "rebuild; assert its emission by hand or widen this helper");
+    return null;
   }
 
   private static List<String> serializerKeys() throws IOException {
@@ -192,8 +220,8 @@ public class WinProfileParityTest {
   }
 
   private static List<String> mapperKeys() throws IOException {
-    return keysOf("new Pair<String, OptionMapper>(",
-        "new Pair<String, OptionMapper>\\(\"([^\"]+)\"");
+    return TestSources.tableKeys("fieldsMapper",
+        "new Pair<String, OptionMapper>\\(\\s*\"([^\"]+)\"");
   }
 
   /* The two tables are halves of one wiring: a key stored with no mapper never
@@ -275,12 +303,10 @@ public class WinProfileParityTest {
      argv decides the cache mode instead of the action radio. */
   @Test
   public void tickedCacheSaysNothingAboutTheCacheMode() throws IOException {
-    assertTrue("Cache must emit nothing when ticked", mapperTable().contains(
-        "new Pair<String, OptionMapper>(\"Cache\",\n"
-            + "          new SimpleOptionFlag(\"C0\", true)),"));
-    final OptionMapper cache = new SimpleOptionFlag("C0", true);
-    assertTrue(emit(cache, "1").isEmpty());
-    assertEquals(Arrays.asList("-C0"), emit(cache, "0"));
+    final OptionMapper cache = wiredMapper("Cache");
+    assertEquals("ticked Cache must leave the mode to the action token",
+        Arrays.asList(), emit(cache, "1"));
+    assertEquals("unticked Cache", Arrays.asList("-C0"), emit(cache, "0"));
   }
 
   /* Each value is withheld until its box is ticked, as WinHTTrack does, and


### PR DESCRIPTION
WinProfileParityTest asserted that the Cache checkbox emits -C2, which PR #139 made false. The test built its own MultipleChoicesOption rather than reading the wiring, so it stayed green describing behaviour production no longer has, and would have stayed green through a regression too. It is deleted. Its successor used to match the production source down to its indentation; it now rebuilds whatever mapper `fieldsMapper` declares for a key and drives that, so putting Cache back to the pre-#139 MultipleChoicesOption fails with `expected:<[]> but was:<[-C2]>`.

The scrape both files share slices the table body and counts entries by the `new Pair` that no line break can split, instead of matching a regex shaped like one line. On master, rewrapping a single `fieldsSerializer` entry across two lines makes it vanish from every list built off the scrape while the count guard agrees with itself, and four unrelated tests go red over a change that does nothing. Here that rewrap is quiet, and renaming a key from KeepWww back to KeepWwwPrefix still fails. Swapping two R.ids in `fieldsSerializer` remains invisible to the suite, which would need the wiring extraction this PR deliberately leaves alone.
