### PR TITLE
The mirror server answers to any hostname, and never stops

### DIFF
--- a/app/src/main/java/com/httrack/android/CleanupActivity.java
+++ b/app/src/main/java/com/httrack/android/CleanupActivity.java
@@ -224,6 +224,8 @@ public class CleanupActivity extends ListActivity {
     new Thread(new Runnable() {
       @Override
       public void run() {
+        // Stop serving before the files go: nothing may keep reading a mirror being deleted.
+        MirrorServer.stopAll();
         final HashSet<Integer> deleted = new HashSet<Integer>();
         for (final int position : positions) {
           if (deleteRecursively(new File(projectRootFile, projects[position]))) {

--- a/app/src/main/java/com/httrack/android/MirrorServer.java
+++ b/app/src/main/java/com/httrack/android/MirrorServer.java
@@ -68,7 +68,7 @@ final class MirrorServer extends NanoHTTPD {
   private final long idleTimeoutMs;
 
   /** When the last response ended: the only evidence available that something is still reading. */
-  private volatile long lastActivityMs = System.currentTimeMillis();
+  volatile long lastActivityMs = System.currentTimeMillis();
 
   private final AtomicInteger streaming = new AtomicInteger();
 

--- a/app/src/main/java/com/httrack/android/MirrorServer.java
+++ b/app/src/main/java/com/httrack/android/MirrorServer.java
@@ -42,9 +42,9 @@ import fi.iki.elonen.NanoHTTPD;
  * read as an ordinary web site. Filenames come from crawled URLs, so path resolution is hostile
  * input and lives in the unit-tested {@link #resolveWithinRoot(File, String)}.
  *
- * Loopback is not by itself a boundary: any page the user visits can point a name it controls at
- * 127.0.0.1 and read the mirror through the browser, so requests must also name us
- * ({@link #isOwnAuthority}) and the port must not outlive the reading ({@link #watchForIdle}).
+ * Loopback is not by itself a boundary: a page can point a name it controls at 127.0.0.1 and read
+ * the mirror through the browser. So a request must name us ({@link #isOwnAuthority}), and the
+ * port must not outlive the reading ({@link #watchForIdle}).
  *
  * Plain thread (NanoHTTPD owns it): reliability while browsing backgrounded relies on us staying
  * the most-recently-used cached process. A foreground service (needs an Android-14 type) is a
@@ -55,8 +55,8 @@ final class MirrorServer extends NanoHTTPD {
   // ephemeral fallback. Privileged (<1024) ports are omitted: Android forbids binding them.
   private static final int[] PORTS = { 8080, 3128, 8081, 3129, 0 };
 
-  // Long enough to read one page and follow a link, short enough that a forgotten browse does not
-  // leave the port open for the rest of the process's life.
+  // Long enough to read one page and follow a link. Short enough that a forgotten browse does
+  // not leave the port open for the life of the process.
   private static final long IDLE_TIMEOUT_MS = 30 * 60 * 1000L;
 
   // One server per served tree, keyed by canonical path: docs and mirrors live in different trees,
@@ -214,10 +214,9 @@ final class MirrorServer extends NanoHTTPD {
   }
 
   /**
-   * True if {@code host} is the authority this server itself listens on. A browser fills Host in
-   * from the URL and forbids a page to forge it, so refusing every other name is what stops a name
-   * the attacker rebound to 127.0.0.1 from reading the mirror. A missing Host is refused too: the
-   * only clients are browsers, which always send one.
+   * A browser fills Host in from the URL and forbids a page to forge it. Refusing every other
+   * name is what stops a name an attacker rebound to 127.0.0.1 from reading the mirror. A missing
+   * Host is refused too, since the only clients are browsers and they always send one.
    *
    * @param host
    *          the request's Host header, or null when it had none
@@ -242,8 +241,8 @@ final class MirrorServer extends NanoHTTPD {
   }
 
   /**
-   * Holds the idle watchdog off while a response is streaming, however slowly the client reads it:
-   * a server blocked writing to a browser makes no progress of its own to measure.
+   * Holds the idle watchdog off while a response is streaming, however slowly the client reads.
+   * A server blocked writing to a browser makes no progress of its own to measure.
    */
   private final class ActiveStream extends FilterInputStream {
     // NanoHTTPD closes the body both after sending it and again with the response.

--- a/app/src/main/java/com/httrack/android/MirrorServer.java
+++ b/app/src/main/java/com/httrack/android/MirrorServer.java
@@ -24,10 +24,15 @@ package com.httrack.android;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FilterInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URLEncoder;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import fi.iki.elonen.NanoHTTPD;
 
@@ -36,6 +41,10 @@ import fi.iki.elonen.NanoHTTPD;
  * browser file:// access to our scoped storage, so the mirror is served over http://127.0.0.1 and
  * read as an ordinary web site. Filenames come from crawled URLs, so path resolution is hostile
  * input and lives in the unit-tested {@link #resolveWithinRoot(File, String)}.
+ *
+ * Loopback is not by itself a boundary: any page the user visits can point a name it controls at
+ * 127.0.0.1 and read the mirror through the browser, so requests must also name us
+ * ({@link #isOwnAuthority}) and the port must not outlive the reading ({@link #watchForIdle}).
  *
  * Plain thread (NanoHTTPD owns it): reliability while browsing backgrounded relies on us staying
  * the most-recently-used cached process. A foreground service (needs an Android-14 type) is a
@@ -46,15 +55,27 @@ final class MirrorServer extends NanoHTTPD {
   // ephemeral fallback. Privileged (<1024) ports are omitted: Android forbids binding them.
   private static final int[] PORTS = { 8080, 3128, 8081, 3129, 0 };
 
+  // Long enough to read one page and follow a link, short enough that a forgotten browse does not
+  // leave the port open for the rest of the process's life.
+  private static final long IDLE_TIMEOUT_MS = 30 * 60 * 1000L;
+
   // One server per served tree, keyed by canonical path: docs and mirrors live in different trees,
   // and restarting a shared server on every switch would cut off whatever is reading the other one.
   private static final Map<String, MirrorServer> servers = new HashMap<String, MirrorServer>();
 
   private final File root;
 
-  private MirrorServer(final File root, final int port) {
+  private final long idleTimeoutMs;
+
+  /** When the last response ended: the only evidence available that something is still reading. */
+  private volatile long lastActivityMs = System.currentTimeMillis();
+
+  private final AtomicInteger streaming = new AtomicInteger();
+
+  private MirrorServer(final File root, final int port, final long idleTimeoutMs) {
     super("127.0.0.1", port);
     this.root = root;
+    this.idleTimeoutMs = idleTimeoutMs;
   }
 
   /**
@@ -68,11 +89,17 @@ final class MirrorServer extends NanoHTTPD {
    *           if no candidate port could be bound
    */
   static MirrorServer start(final File root) throws IOException {
+    return start(root, IDLE_TIMEOUT_MS);
+  }
+
+  /** Same, with the idle lifetime spelled out, so a test need not wait out the real one. */
+  static MirrorServer start(final File root, final long idleTimeoutMs) throws IOException {
     IOException last = null;
     for (final int port : PORTS) {
-      final MirrorServer server = new MirrorServer(root, port);
+      final MirrorServer server = new MirrorServer(root, port, idleTimeoutMs);
       try {
         server.start(NanoHTTPD.SOCKET_READ_TIMEOUT, true);
+        server.watchForIdle();
         return server;
       } catch (final IOException e) {
         last = e;
@@ -82,24 +109,69 @@ final class MirrorServer extends NanoHTTPD {
   }
 
   /**
-   * Started server for {@code root}, reusing the one already serving that tree. Servers outlive the
-   * activity that opened them: the browser reading a mirror is a separate app, and stopping the
-   * server on our onDestroy would break its page.
+   * Started server for {@code root}, reusing the one already serving that tree unless it has since
+   * gone idle. Servers outlive the activity that opened them: the browser reading a mirror is a
+   * separate app, and stopping the server on our onDestroy would break its page.
    *
    * @param root
    *          the served tree; every request is confined to it
-   * @return a started server, valid until the process exits
+   * @return a started server, valid until it goes idle
    * @throws IOException
    *           if the tree cannot be canonicalised, or no port could be bound
    */
   static synchronized MirrorServer forRoot(final File root) throws IOException {
     final String key = root.getCanonicalPath();
     MirrorServer server = servers.get(key);
-    if (server == null) {
+    if (server == null || !server.isAlive()) {
       server = start(root);
       servers.put(key, server);
     }
     return server;
+  }
+
+  /** Stops serving and drops the registry entry, so the next browse starts a fresh server. */
+  @Override
+  public void stop() {
+    synchronized (MirrorServer.class) {
+      servers.values().remove(this);
+    }
+    super.stop();
+  }
+
+  /** Stops every server; the ports are what an attacker needs open, so none may be left running. */
+  static synchronized void stopAll() {
+    for (final MirrorServer server : new ArrayList<MirrorServer>(servers.values())) {
+      server.stop();
+    }
+    servers.clear();
+  }
+
+  /**
+   * Daemon watchdog stopping us once nothing has read for {@link #idleTimeoutMs}. The reader is
+   * another app, so no callback of ours says it is done; only the absence of requests does.
+   */
+  private void watchForIdle() {
+    final Thread watchdog = new Thread(new Runnable() {
+      @Override
+      public void run() {
+        try {
+          for (;;) {
+            final long left = idleTimeoutMs - (System.currentTimeMillis() - lastActivityMs);
+            if (left <= 0 && streaming.get() == 0) {
+              break;
+            }
+            Thread.sleep(left > 0 ? left : idleTimeoutMs);
+          }
+        } catch (final InterruptedException interrupted) {
+          return;
+        }
+        if (isAlive()) {
+          stop();
+        }
+      }
+    }, "mirror-idle-" + getListeningPort());
+    watchdog.setDaemon(true);
+    watchdog.start();
   }
 
   /** Actual bound port, valid once started. */
@@ -114,12 +186,17 @@ final class MirrorServer extends NanoHTTPD {
 
   @Override
   public Response serve(final IHTTPSession session) {
+    lastActivityMs = System.currentTimeMillis();
     final Method method = session.getMethod();
-    if (method != Method.GET && method != Method.HEAD) {
+    final boolean headOnly = method == Method.HEAD;
+    if (!isOwnAuthority(session.getHeaders().get("host"), getListeningPort())) {
+      // Bodiless: a page probing us through a rebound name is told nothing, not even an error text.
+      return errorResponse(Response.Status.FORBIDDEN, "", headOnly);
+    }
+    if (method != Method.GET && !headOnly) {
       return newFixedLengthResponse(Response.Status.METHOD_NOT_ALLOWED, MIME_PLAINTEXT,
           "405 Method Not Allowed");
     }
-    final boolean headOnly = method == Method.HEAD;
     final File target = resolveWithinRoot(root, session.getUri());
     if (target == null) {
       return errorResponse(Response.Status.FORBIDDEN, "403 Forbidden", headOnly);
@@ -131,7 +208,63 @@ final class MirrorServer extends NanoHTTPD {
     if (!file.exists() || file.isDirectory()) {
       return errorResponse(Response.Status.NOT_FOUND, "404 Not Found", headOnly);
     }
-    return fileResponse(file, headOnly);
+    final Response response = fileResponse(file, headOnly);
+    response.setData(new ActiveStream(response.getData()));
+    return response;
+  }
+
+  /**
+   * True if {@code host} is the authority this server itself listens on. A browser fills Host in
+   * from the URL and forbids a page to forge it, so refusing every other name is what stops a name
+   * the attacker rebound to 127.0.0.1 from reading the mirror. A missing Host is refused too: the
+   * only clients are browsers, which always send one.
+   *
+   * @param host
+   *          the request's Host header, or null when it had none
+   * @param port
+   *          the port this server is listening on
+   * @return true if the request addressed us by a loopback name and our own port
+   */
+  static boolean isOwnAuthority(final String host, final int port) {
+    if (host == null) {
+      return false;
+    }
+    final int colon = host.lastIndexOf(':');
+    // No port means 80, which is privileged and so never ours.
+    if (colon < 0) {
+      return false;
+    }
+    final String name = host.substring(0, colon);
+    if (!"127.0.0.1".equals(name) && !"localhost".equalsIgnoreCase(name)) {
+      return false;
+    }
+    return String.valueOf(port).equals(host.substring(colon + 1));
+  }
+
+  /**
+   * Holds the idle watchdog off while a response is streaming, however slowly the client reads it:
+   * a server blocked writing to a browser makes no progress of its own to measure.
+   */
+  private final class ActiveStream extends FilterInputStream {
+    // NanoHTTPD closes the body both after sending it and again with the response.
+    private final AtomicBoolean done = new AtomicBoolean();
+
+    ActiveStream(final InputStream data) {
+      super(data);
+      streaming.incrementAndGet();
+    }
+
+    @Override
+    public void close() throws IOException {
+      try {
+        super.close();
+      } finally {
+        if (done.compareAndSet(false, true)) {
+          lastActivityMs = System.currentTimeMillis();
+          streaming.decrementAndGet();
+        }
+      }
+    }
   }
 
   /**

--- a/app/src/main/java/com/httrack/android/MirrorServer.java
+++ b/app/src/main/java/com/httrack/android/MirrorServer.java
@@ -126,6 +126,8 @@ final class MirrorServer extends NanoHTTPD {
       server = start(root);
       servers.put(key, server);
     }
+    // Handing one out is use: without this the watchdog can kill it before the browser connects.
+    server.lastActivityMs = System.currentTimeMillis();
     return server;
   }
 
@@ -186,13 +188,14 @@ final class MirrorServer extends NanoHTTPD {
 
   @Override
   public Response serve(final IHTTPSession session) {
-    lastActivityMs = System.currentTimeMillis();
     final Method method = session.getMethod();
     final boolean headOnly = method == Method.HEAD;
     if (!isOwnAuthority(session.getHeaders().get("host"), getListeningPort())) {
       // Bodiless: a page probing us through a rebound name is told nothing, not even an error text.
+      // Stamped only below, so a refused caller cannot hold the port open by poking us.
       return errorResponse(Response.Status.FORBIDDEN, "", headOnly);
     }
+    lastActivityMs = System.currentTimeMillis();
     if (method != Method.GET && !headOnly) {
       return newFixedLengthResponse(Response.Status.METHOD_NOT_ALLOWED, MIME_PLAINTEXT,
           "405 Method Not Allowed");

--- a/app/src/test/java/com/httrack/android/MirrorServerTest.java
+++ b/app/src/test/java/com/httrack/android/MirrorServerTest.java
@@ -470,6 +470,18 @@ public class MirrorServerTest {
 
   /** Docs and mirrors are served at once, so each root must keep its own server. */
   @Test
+  public void handingOutAServerCountsAsUsingIt() throws Exception {
+    // Otherwise one idle since just before the timeout is handed back, then killed
+    // under the browser that was about to connect to it.
+    final MirrorServer first = MirrorServer.forRoot(root);
+    first.lastActivityMs = 0;
+    final MirrorServer again = MirrorServer.forRoot(root);
+    assertSame("the same server should have been handed back", first, again);
+    assertTrue("handing the server out did not count as activity", again.lastActivityMs > 0);
+    again.stop();
+  }
+
+  @Test
   public void forRootKeepsOneServerPerTree() throws Exception {
     final File resources = tmp.newFolder("resources");
     final MirrorServer mirrors = MirrorServer.forRoot(root);

--- a/app/src/test/java/com/httrack/android/MirrorServerTest.java
+++ b/app/src/test/java/com/httrack/android/MirrorServerTest.java
@@ -2,6 +2,7 @@ package com.httrack.android;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
@@ -28,6 +29,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.zip.GZIPInputStream;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -48,6 +50,11 @@ public class MirrorServerTest {
   @Before
   public void setUp() throws Exception {
     root = tmp.newFolder("Websites");
+  }
+
+  @After
+  public void tearDown() {
+    MirrorServer.stopAll();
   }
 
   @Test
@@ -359,7 +366,10 @@ public class MirrorServerTest {
 
     private final OutputStream out;
 
+    private final int port;
+
     Client(final int port) throws IOException {
+      this.port = port;
       socket = new Socket();
       // A small receive window keeps the server blocked mid-body while a test rewrites the file.
       socket.setReceiveBufferSize(4096);
@@ -375,8 +385,14 @@ public class MirrorServerTest {
 
     void send(final String method, final String path, final String extraHeaders)
         throws IOException {
-      final String request =
-          method + " " + path + " HTTP/1.1\r\nHost: 127.0.0.1\r\n" + extraHeaders + "\r\n";
+      sendWithHost(method, path, "127.0.0.1:" + port, extraHeaders);
+    }
+
+    /** Sends whatever Host the caller names, or none at all when {@code host} is null. */
+    void sendWithHost(final String method, final String path, final String host,
+        final String extraHeaders) throws IOException {
+      final String request = method + " " + path + " HTTP/1.1\r\n"
+          + (host == null ? "" : "Host: " + host + "\r\n") + extraHeaders + "\r\n";
       out.write(request.getBytes("US-ASCII"));
       out.flush();
     }
@@ -466,5 +482,128 @@ public class MirrorServerTest {
   @Test
   public void forRootFoldsAliasesOfTheSameTree() throws Exception {
     assertSame(MirrorServer.forRoot(root), MirrorServer.forRoot(new File(root, "html/..")));
+  }
+
+  @Test
+  public void ownAuthorityAcceptsBothLoopbackNamesOnOurPort() {
+    assertTrue(MirrorServer.isOwnAuthority("127.0.0.1:8080", 8080));
+    assertTrue(MirrorServer.isOwnAuthority("localhost:8080", 8080));
+    assertTrue(MirrorServer.isOwnAuthority("LocalHost:8080", 8080));
+  }
+
+  @Test
+  public void ownAuthorityRefusesEverythingElse() {
+    assertFalse(MirrorServer.isOwnAuthority("evil.example.com:8080", 8080));
+    assertFalse(MirrorServer.isOwnAuthority("127.0.0.1:8081", 8080));
+    assertFalse(MirrorServer.isOwnAuthority("127.0.0.1", 8080));
+    assertFalse(MirrorServer.isOwnAuthority("localhost.evil.example.com:8080", 8080));
+    assertFalse(MirrorServer.isOwnAuthority("[::1]:8080", 8080));
+    assertFalse(MirrorServer.isOwnAuthority(null, 8080));
+  }
+
+  @Test
+  public void serverAnswersOurOwnAuthority() throws Exception {
+    assertHostIsServed("127.0.0.1");
+    assertHostIsServed("localhost");
+  }
+
+  private void assertHostIsServed(final String name) throws Exception {
+    final byte[] content = "<html>hello</html>".getBytes("UTF-8");
+    Files.write(new File(root, "index.html").toPath(), content);
+    final MirrorServer server = MirrorServer.start(root);
+    try (Client client = new Client(server.getPort())) {
+      client.sendWithHost("GET", "/index.html", name + ":" + server.getPort(), "");
+      final Reply reply = client.read(false);
+      assertEquals("HTTP/1.1 200 OK", reply.status);
+      assertArrayEquals(content, reply.body);
+    } finally {
+      server.stop();
+    }
+  }
+
+  /** A page on a name rebound to 127.0.0.1 reads the mirror unless a foreign Host is refused. */
+  @Test
+  public void aForeignHostIsRefusedWithoutABody() throws Exception {
+    assertHostIsRefused("evil.example.com:PORT");
+  }
+
+  /** The port is half of the identity: our name on someone else's port is not us. */
+  @Test
+  public void theRightNameOnTheWrongPortIsRefused() throws Exception {
+    assertHostIsRefused("127.0.0.1:1");
+  }
+
+  @Test
+  public void aMissingHostIsRefused() throws Exception {
+    assertHostIsRefused(null);
+  }
+
+  private void assertHostIsRefused(final String host) throws Exception {
+    Files.write(new File(root, "index.html").toPath(), "<html>hello</html>".getBytes("UTF-8"));
+    final MirrorServer server = MirrorServer.start(root);
+    try (Client client = new Client(server.getPort())) {
+      final String sent = host == null ? null
+          : host.replace("PORT", String.valueOf(server.getPort()));
+      client.sendWithHost("GET", "/index.html", sent, "");
+      final Reply reply = client.read(false);
+      assertEquals("HTTP/1.1 403 Forbidden", reply.status);
+      assertEquals(0, reply.body.length);
+    } finally {
+      server.stop();
+    }
+  }
+
+  /** The Host check runs first, so the escape refusal has to stay reachable behind it. */
+  @Test
+  public void traversalIsStillRefusedWithAGoodHost() throws Exception {
+    final File secret = tmp.newFile("secret.txt");
+    Files.write(secret.toPath(), "top secret".getBytes("UTF-8"));
+    final MirrorServer server = MirrorServer.start(root);
+    try (Client client = new Client(server.getPort())) {
+      client.send("GET", "/../secret.txt");
+      final Reply reply = client.read(false);
+      assertEquals("HTTP/1.1 403 Forbidden", reply.status);
+      assertArrayEquals("403 Forbidden".getBytes("US-ASCII"), reply.body);
+    } finally {
+      server.stop();
+    }
+  }
+
+  /** The reader is another app, so nothing but the absence of requests can close the port. */
+  @Test
+  public void anIdleServerStopsItself() throws Exception {
+    final MirrorServer server = MirrorServer.start(root, 100);
+    final long deadline = System.currentTimeMillis() + 10000;
+    while (server.isAlive() && System.currentTimeMillis() < deadline) {
+      Thread.sleep(20);
+    }
+    assertFalse("the idle watchdog never stopped the server", server.isAlive());
+  }
+
+  /** A browser reading slowly must not be cut off, so a live transfer holds the server open. */
+  @Test
+  public void aSlowReadKeepsTheServerAlive() throws Exception {
+    final byte[] content = new byte[2 * 1024 * 1024];
+    Files.write(new File(root, "big.html").toPath(), content);
+    final MirrorServer server = MirrorServer.start(root, 500);
+    try (Client client = new Client(server.getPort())) {
+      client.send("GET", "/big.html");
+      assertEquals("HTTP/1.1 200 OK", client.readHead().status);
+      for (int i = 0; i < 15; i++) {
+        Thread.sleep(100);
+        assertTrue("the server stopped under a reader still asking for bytes",
+            client.readChunk().length > 0);
+      }
+      assertTrue(server.isAlive());
+    } finally {
+      server.stop();
+    }
+  }
+
+  @Test
+  public void stopDropsTheRegistryEntry() throws Exception {
+    final MirrorServer server = MirrorServer.forRoot(root);
+    server.stop();
+    assertNotSame(server, MirrorServer.forRoot(root));
   }
 }

--- a/app/src/test/java/com/httrack/android/MirrorServerTest.java
+++ b/app/src/test/java/com/httrack/android/MirrorServerTest.java
@@ -580,6 +580,25 @@ public class MirrorServerTest {
     assertFalse("the idle watchdog never stopped the server", server.isAlive());
   }
 
+  /** Half the defence is that the port dies; a caller we refuse must not be able to postpone it. */
+  @Test
+  public void aRefusedCallerCannotHoldThePortOpen() throws Exception {
+    Files.write(new File(root, "index.html").toPath(), "<html>hi</html>".getBytes("UTF-8"));
+    final MirrorServer server = MirrorServer.start(root, 400);
+    final long deadline = System.currentTimeMillis() + 10000;
+    while (server.isAlive() && System.currentTimeMillis() < deadline) {
+      // Exactly what a rebound page sends, faster than the watchdog's own timeout.
+      try (Client client = new Client(server.getPort())) {
+        client.sendWithHost("GET", "/index.html", "evil.example.com", "");
+        client.read(false);
+      } catch (final IOException stopped) {
+        break;
+      }
+      Thread.sleep(100);
+    }
+    assertFalse("a refused caller kept the server alive", server.isAlive());
+  }
+
   /** A browser reading slowly must not be cut off, so a live transfer holds the server open. */
   @Test
   public void aSlowReadKeepsTheServerAlive() throws Exception {


### PR DESCRIPTION
The mirror server was reachable by any app on the device and by any web page. It binds loopback and blocks path traversal, but it checked no `Host` header, so a page could point a name it controls at 127.0.0.1 and read every mirrored site, along with `hts-log.txt`, `winprofile.ini` and `cookies.txt`. It now refuses any request that does not name its own loopback authority, before the method and path are looked at. A missing `Host` is refused too: the only clients are browsers and they always send one.

The port also stayed open until the OS killed the process. The browser reading a mirror is a separate app, so no lifecycle callback of ours reports it as finished, and stopping on `onStop` would kill a page still being read. The server now stops itself after thirty minutes without a request, counting a response still streaming as activity so a slow reader is never cut off. The cleanup screen stops it before deleting the files it serves. A test written for that last point caught a real defect in the fix: stamping activity on file reads alone let the watchdog kill a server that was merely blocked writing to a slow client.