### PR TITLE
A crawl killed by a throwing progress callback reports Success

### DIFF
--- a/app/src/main/jni/htslibjni-private.h
+++ b/app/src/main/jni/htslibjni-private.h
@@ -118,6 +118,9 @@ typedef struct jni_context_t {
   jobject callbacks;
   /* Context */
   HTTrackLib_context *context;
+  /* First exception a callback threw (global ref); non-NULL also gates the
+     callbacks off until the engine has unwound. */
+  jthrowable pendingException;
 } jni_context_t;
 
 typedef enum hts_state_id_t {

--- a/app/src/main/jni/htslibjni.c
+++ b/app/src/main/jni/htslibjni.c
@@ -692,6 +692,23 @@ static jobject build_stats(jni_context_t *const t, httrackp * opt,
   return ostats;
 }
 
+/* Almost every JNI call is illegal while an exception is pending, so clear it
+   here and keep the first one for the caller to rethrow. */
+static void capturePendingException(jni_context_t *const t) {
+  if ((*t->env)->ExceptionCheck(t->env)) {
+    jthrowable exc = (*t->env)->ExceptionOccurred(t->env);
+    (*t->env)->ExceptionDescribe(t->env);
+    (*t->env)->ExceptionClear(t->env);
+    if (exc != NULL) {
+      if (t->pendingException == NULL) {
+        t->pendingException = (jthrowable) (*t->env)->NewGlobalRef(t->env, exc);
+      }
+      (*t->env)->DeleteLocalRef(t->env, exc);
+    }
+    error("progress callback threw, aborting the mirror");
+  }
+}
+
 static int htsshow_loop_internal(jni_context_t *t, httrackp * opt,
   lien_back * back, int back_max, int back_index, int lien_n,
   int lien_tot, int stat_time, hts_stat_struct * stats) {
@@ -714,6 +731,11 @@ static int htsshow_loop_internal(jni_context_t *t, httrackp * opt,
     return 1;
   }
 
+  /* a callback already threw: stay out of Java, and keep asking for the abort */
+  if (t->pendingException != NULL) {
+    return 0;
+  }
+
   /* create a new local frame for local objects (stats, strings ...) */
   if ((*t->env)->PushLocalFrame(t->env, capacity) == 0) {
     /* build stats object */
@@ -725,19 +747,23 @@ static int htsshow_loop_internal(jni_context_t *t, httrackp * opt,
     }
 
     /* Call refresh method */
-    if (ostats != NULL || stats == NULL) {
+    if (ostats != NULL) {
       (*t->env)->CallVoidMethod(t->env, t->callbacks,
                                 meth_HTTrackCallbacks_onRefresh, ostats);
-      if ((*t->env)->ExceptionOccurred(t->env)) {
-        code = 0;
-      }
     } else {
+      code = 0;  /* build_stats failed, usually with an exception pending */
+    }
+
+    /* Clear before returning to the engine, which keeps making JNI calls. */
+    capturePendingException(t);
+    if (t->pendingException != NULL) {
       code = 0;
     }
 
     /* wipe local frame */
     (void) (*t->env)->PopLocalFrame(t->env, NULL);
   } else {
+    capturePendingException(t);  /* PushLocalFrame threw OutOfMemoryError */
     return 0;  /* error */
   }
 
@@ -838,6 +864,7 @@ jint HTTrackLib_main(JNIEnv* env, jobject object, jobjectArray stringArray) {
     t.env = env;
     t.callbacks = (*env)->GetObjectField(env, object, field_callbacks);
     t.context = context;
+    t.pendingException = NULL;
 
     /* Create options and reference it */
     MUTEX_LOCK(context->lock);
@@ -878,7 +905,7 @@ jint HTTrackLib_main(JNIEnv* env, jobject object, jobjectArray stringArray) {
           (hts_stat_struct*) stats);
 
       /* Raise error if suitable */
-      if (code == -1) {
+      if (code == -1 && t.pendingException == NULL) {
         const char *message = hts_errmsg(context->opt);
         if (message != NULL && *message != '\0') {
           throwIOException(env, message);
@@ -904,6 +931,14 @@ jint HTTrackLib_main(JNIEnv* env, jobject object, jobjectArray stringArray) {
       } else {
         throwRuntimeException(env, "not enough native memory to create an httrack context");
       }
+    }
+
+    /* A callback threw: the engine aborted, and hts_main2 returns the same 0 as
+       a completed mirror, so the exception is the only honest outcome. */
+    if (t.pendingException != NULL) {
+      (*env)->Throw(env, t.pendingException);
+      (*env)->DeleteGlobalRef(env, t.pendingException);
+      code = -1;
     }
 
     /* Return exit code. */

--- a/app/src/main/jni/htslibjni.c
+++ b/app/src/main/jni/htslibjni.c
@@ -693,8 +693,9 @@ static jobject build_stats(jni_context_t *const t, httrackp * opt,
 }
 
 /* Almost every JNI call is illegal while an exception is pending, so clear it
-   here and keep the first one for the caller to rethrow. */
-static void capturePendingException(jni_context_t *const t) {
+   here and keep the first one for the caller to rethrow. Returns whether one was
+   seen: keeping it can fail under OOM, and the abort must not hinge on that. */
+static int capturePendingException(jni_context_t *const t) {
   if ((*t->env)->ExceptionCheck(t->env)) {
     jthrowable exc = (*t->env)->ExceptionOccurred(t->env);
     (*t->env)->ExceptionDescribe(t->env);
@@ -706,7 +707,9 @@ static void capturePendingException(jni_context_t *const t) {
       (*t->env)->DeleteLocalRef(t->env, exc);
     }
     error("progress callback threw, aborting the mirror");
+    return 1;
   }
+  return 0;
 }
 
 static int htsshow_loop_internal(jni_context_t *t, httrackp * opt,
@@ -755,8 +758,7 @@ static int htsshow_loop_internal(jni_context_t *t, httrackp * opt,
     }
 
     /* Clear before returning to the engine, which keeps making JNI calls. */
-    capturePendingException(t);
-    if (t->pendingException != NULL) {
+    if (capturePendingException(t)) {
       code = 0;
     }
 

--- a/app/src/test/java/com/httrack/android/JniCallbackExceptionTest.java
+++ b/app/src/test/java/com/httrack/android/JniCallbackExceptionTest.java
@@ -1,5 +1,6 @@
 package com.httrack.android;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
@@ -39,7 +40,7 @@ public class JniCallbackExceptionTest {
   /** NewGlobalRef is not one of the calls allowed while an exception is pending. */
   @Test
   public void theCaptureClearsBeforeItAllocates() throws Exception {
-    final String capture = body(glue(), "static void capturePendingException(");
+    final String capture = body(glue(), "static int capturePendingException(");
     final int clear = capture.indexOf("ExceptionClear");
     final int global = capture.indexOf("NewGlobalRef");
     assertTrue("the capture no longer clears", clear != -1);
@@ -52,5 +53,16 @@ public class JniCallbackExceptionTest {
     final String main = body(glue(), "jint HTTrackLib_main(");
     assertTrue("a callback exception no longer reaches Java",
         main.contains("Throw(env, t.pendingException)"));
+  }
+
+  /* Keeping the throwable can fail under OOM. If the abort hangs off that, the
+     whole fix evaporates exactly when memory is short. */
+  @Test
+  public void theAbortDoesNotHangOnKeepingTheThrowable() throws Exception {
+    final String loop = body(glue(), "static int htsshow_loop_internal(");
+    assertTrue("the abort must follow capturePendingException's own verdict",
+        loop.contains("if (capturePendingException(t)) {"));
+    assertFalse("the abort must not hang on NewGlobalRef having succeeded",
+        loop.contains("if (t->pendingException != NULL) {\n      code = 0;"));
   }
 }

--- a/app/src/test/java/com/httrack/android/JniCallbackExceptionTest.java
+++ b/app/src/test/java/com/httrack/android/JniCallbackExceptionTest.java
@@ -1,0 +1,56 @@
+package com.httrack.android;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import org.junit.Test;
+
+/** A callback exception left pending makes every following JNI call illegal, and the engine
+ *  abort it triggers returns the same 0 as a finished mirror. Nothing here is reachable from
+ *  a unit-test JVM (no native library, no JVM to throw into), so these read the glue: they
+ *  pin the shape a regression would have to undo, not the runtime behaviour. */
+public class JniCallbackExceptionTest {
+  private static String glue() throws IOException {
+    return TestSources.jniSource("htslibjni.c");
+  }
+
+  /** Body of the top-level function whose signature contains NAME, up to its closing brace. */
+  private static String body(final String source, final String name) {
+    final int at = source.indexOf(name);
+    assertTrue(name + " is gone from htslibjni.c", at != -1);
+    final int from = source.indexOf('{', at);
+    final int to = source.indexOf("\n}", from);
+    assertTrue(name + " has no closing brace", from != -1 && to > from);
+    return source.substring(from, to);
+  }
+
+  /** The refresh path must hand a pending exception over before it returns to the engine. */
+  @Test
+  public void theRefreshPathClearsBeforeItReturns() throws Exception {
+    final String loop = body(glue(), "static int htsshow_loop_internal(");
+    final int call = loop.indexOf("meth_HTTrackCallbacks_onRefresh");
+    final int capture = loop.indexOf("capturePendingException(t)", call);
+    final int pop = loop.indexOf("->PopLocalFrame(", call);
+    assertTrue("no onRefresh call left in htsshow_loop_internal", call != -1);
+    assertTrue("nothing captures the exception after onRefresh", capture != -1);
+    assertTrue("PopLocalFrame runs before the exception is captured", pop > capture);
+  }
+
+  /** NewGlobalRef is not one of the calls allowed while an exception is pending. */
+  @Test
+  public void theCaptureClearsBeforeItAllocates() throws Exception {
+    final String capture = body(glue(), "static void capturePendingException(");
+    final int clear = capture.indexOf("ExceptionClear");
+    final int global = capture.indexOf("NewGlobalRef");
+    assertTrue("the capture no longer clears", clear != -1);
+    assertTrue("NewGlobalRef runs before the clear", global == -1 || global > clear);
+  }
+
+  /** hts_main2 returns 0 on abort, so only the rethrow keeps the run from reporting success. */
+  @Test
+  public void theCrawlEntryPointRethrows() throws Exception {
+    final String main = body(glue(), "jint HTTrackLib_main(");
+    assertTrue("a callback exception no longer reaches Java",
+        main.contains("Throw(env, t.pendingException)"));
+  }
+}

--- a/app/src/test/java/com/httrack/android/TestSources.java
+++ b/app/src/test/java/com/httrack/android/TestSources.java
@@ -63,6 +63,11 @@ final class TestSources {
         + ".java"));
   }
 
+  /** Source of the JNI glue file NAME, such as "htslibjni.c". */
+  static String jniSource(final String name) throws IOException {
+    return read(new File(dir("src/main/jni"), name));
+  }
+
   /** A file of the pinned engine submodule, such as "winprofile-keys.tsv". */
   static File engineFile(final String name) {
     return new File(dir("src/main/jni/httrack"), name);


### PR DESCRIPTION
A Java progress callback that throws leaves the exception pending on the crawl thread. The glue noticed it and asked the engine to stop, but never cleared it, so every JNI call after that point was illegal: the engine ticks the loop callback a few more times while it unwinds, and `HTTrackLib_main` then builds one last stats object and calls `onRefresh` again. A host probe that compiles the real `htslibjni.c` against an instrumented `JNIEnv` counts 72 such calls, starting at `NewObject`.

`hts_main2` also returns 0 for an aborted mirror exactly as it does for a finished one, and the exception never reached Java, so the finish panel said "Success!". The glue now clears the exception where it detects it, keeps the first one in a global ref, leaves Java alone for the rest of the run, and rethrows it from `HTTrackLib_main` so the crawl runner reports the failure. On the same probe the illegal calls drop to zero, the exception reaches Java and `main()` returns -1; with nothing thrown, before and after behave identically. The three new unit tests only guard the shape of the C source, since nothing across the JNI boundary is reachable from a unit-test JVM.
