### PR TITLE
A recovered native fault still kills the app 30 seconds later

### DIFF
--- a/app/src/main/jni/htslibjni.c
+++ b/app/src/main/jni/htslibjni.c
@@ -49,7 +49,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 /* COFFEE_TRY_JNI leaves coffeecatch's 30s SIGALRM watchdog armed; we report the
  * fault as a Java Error and keep running, so disarm it. After the throw, whose
- * allocations are the hang it guards, and before COFFEE_END() frees its state. */
+ * allocations are the hang it guards, and before COFFEE_END() frees its state.
+ * The body is copied from upstream's COFFEE_TRY_JNI: re-copy it if that changes. */
 #define COFFEE_TRY_JNI_RECOVER(ENV, CODE)  \
   do {                                     \
     COFFEE_TRY() {                         \

--- a/app/src/main/jni/htslibjni.c
+++ b/app/src/main/jni/htslibjni.c
@@ -46,6 +46,19 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #ifdef USE_COFFEECATCH
 #include "coffeecatch.h"
 #include "coffeejni.h"
+
+/* COFFEE_TRY_JNI leaves coffeecatch's 30s SIGALRM watchdog armed; we report the
+ * fault as a Java Error and keep running, so disarm it. After the throw, whose
+ * allocations are the hang it guards, and before COFFEE_END() frees its state. */
+#define COFFEE_TRY_JNI_RECOVER(ENV, CODE)  \
+  do {                                     \
+    COFFEE_TRY() {                         \
+      CODE;                                \
+    } COFFEE_CATCH() {                     \
+      coffeecatch_throw_exception(ENV);    \
+      coffeecatch_cancel_pending_alarm();  \
+    } COFFEE_END();                        \
+  } while(0)
 #endif
 
 #include "htslibjni.h"
@@ -411,7 +424,7 @@ Java_com_httrack_android_jni_HTTrackLib_initRootPath(JNIEnv* env,
                                                      jclass clazz,
                                                      jstring opath) {
 #ifdef USE_COFFEECATCH
-  COFFEE_TRY_JNI(env, HTTrackLib_initRootPath(env, clazz, opath));
+  COFFEE_TRY_JNI_RECOVER(env, HTTrackLib_initRootPath(env, clazz, opath));
 #else
   HTTrackLib_initRootPath(env, clazz, opath);
 #endif
@@ -814,7 +827,7 @@ Java_com_httrack_android_jni_HTTrackLib_buildTopIndex(JNIEnv* env, jclass clazz,
                                                       jstring opath, jstring otemplates) {
 #ifdef USE_COFFEECATCH
   volatile jint ret = -1;
-  COFFEE_TRY_JNI(env, ret = HTTrackLib_buildTopIndex(env, clazz, opath, otemplates));
+  COFFEE_TRY_JNI_RECOVER(env, ret = HTTrackLib_buildTopIndex(env, clazz, opath, otemplates));
   return ret;
 #else
   return HTTrackLib_buildTopIndex(env, clazz, opath, otemplates);
@@ -922,7 +935,7 @@ Java_com_httrack_android_jni_HTTrackLib_main(JNIEnv* env, jobject object,
                                              jobjectArray stringArray) {
 #ifdef USE_COFFEECATCH
   volatile jint code = -1;
-  COFFEE_TRY_JNI(env, code = HTTrackLib_main(env, object, stringArray));
+  COFFEE_TRY_JNI_RECOVER(env, code = HTTrackLib_main(env, object, stringArray));
   return code;
 #else
   return HTTrackLib_main(env, object, stringArray);

--- a/app/src/test/java/com/httrack/android/CoffeeCatchAlarmTest.java
+++ b/app/src/test/java/com/httrack/android/CoffeeCatchAlarmTest.java
@@ -1,0 +1,46 @@
+package com.httrack.android;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import org.junit.Test;
+
+/** A caught native fault arms coffeecatch's 30s alarm(), and SIGALRM kills the
+ *  process; we recover the fault as a Java Error and keep crawling, so every
+ *  protected entry point has to disarm it. */
+public class CoffeeCatchAlarmTest {
+  private String jni() throws IOException {
+    return TestSources.jniSource("htslibjni.c");
+  }
+
+  @Test
+  public void noEntryPointUsesTheBareMacro() throws IOException {
+    assertEquals("upstream COFFEE_TRY_JNI leaves the alarm armed", 0,
+        TestSources.occurrences(jni(), "COFFEE_TRY_JNI("));
+  }
+
+  @Test
+  public void everyProtectedBlockGoesThroughTheWrapper() throws IOException {
+    final String source = jni();
+    // The lone COFFEE_TRY() is the wrapper's own; a hand-rolled one would skip
+    // the cancel.
+    assertEquals(1, TestSources.occurrences(source, "COFFEE_TRY()"));
+    assertTrue(TestSources.occurrences(source, "COFFEE_TRY_JNI_RECOVER(") > 1);
+  }
+
+  @Test
+  public void cancelsAfterTheThrowAndBeforeCleanup() throws IOException {
+    final String all = jni();
+    final int at = all.indexOf("#define COFFEE_TRY_JNI_RECOVER");
+    assertTrue(at != -1);
+    final String source = all.substring(at);
+    final int thrown = source.indexOf("coffeecatch_throw_exception(ENV)");
+    final int cancel = source.indexOf("coffeecatch_cancel_pending_alarm()");
+    final int end = source.indexOf("COFFEE_END()");
+    assertTrue("cancel must not disarm the watchdog before the throw allocates",
+        thrown != -1 && cancel > thrown);
+    assertTrue("COFFEE_END() frees the state the cancel reads",
+        end != -1 && cancel < end);
+  }
+}

--- a/app/src/test/java/com/httrack/android/TestSources.java
+++ b/app/src/test/java/com/httrack/android/TestSources.java
@@ -63,6 +63,11 @@ final class TestSources {
         + ".java"));
   }
 
+  /** Source of the JNI glue file NAME, such as "htslibjni.c". */
+  static String jniSource(final String name) throws IOException {
+    return read(new File(dir("src/main/jni"), name));
+  }
+
   /** A file of the pinned engine submodule, such as "winprofile-keys.tsv". */
   static File engineFile(final String name) {
     return new File(dir("src/main/jni/httrack"), name);


### PR DESCRIPTION
coffeecatch arms `alarm(30)` when it catches a fault, as a watchdog against a handler wedged inside a function that is not signal safe. The caller is expected to disarm it if it intends to keep running, and we never did. `COFFEE_TRY_JNI` reports the fault as a `java.lang.Error`, `HTTrackActivity` catches it, shows the error panel, and the app carries on until SIGALRM kills the process half a minute later. To the user that looks like an unrelated crash.

The three protected JNI entry points now go through a local wrapper that cancels the alarm inside the catch block. Placement matters in both directions: after `coffeecatch_throw_exception()`, because the throw allocates and that is the hang the watchdog covers, and before `COFFEE_END()`, which frees the per-thread state the cancel reads. A host probe confirms the behaviour, with a recovered SIGSEGV killing the process at t+30 without the cancel and surviving with it. Upstream coffeecatch has the matching defect that a cancel placed after the block silently does nothing (xroche/coffeecatch#71), so the submodule pin bump is a separate step once that lands.