### PR TITLE
A mirror the engine gave up on was announced as a success

### DIFF
--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -1504,29 +1504,41 @@ public class HTTrackActivity extends FragmentActivity {
         pendingWork = leavesPendingWork(interrupted || engine.wasStopped(), code);
 
         // Result
-        final String aborted = engine.abortReason();
-        if (code == 0) {
-          /* The engine gave up on its own: a full disk reaches here with code 0,
-             and would otherwise be announced as a success. */
-          if (aborted != null) {
-            message = "<b>Aborted</b>! (" + TextUtils.htmlEncode(aborted) + ")";
-          } else if (interrupted) {
-            message = "<b>Interrupted</b>! (" + lastStats.errorsCount
-                + " errors)";
-          } else if (lastStats.errorsCount == 0) {
-            message = "<b>Success</b>!";
-          } else if (lastStats.filesWritten != 0) {
-            message = "<b>Success</b>! (" + lastStats.errorsCount + " errors)";
-          } else {
-            message = "<b>Failed</b>! (" + lastStats.errorsCount
-                + " errors, no files written)";
+        final MirrorOutcome outcome = MirrorOutcome.of(code, interrupted,
+            engine.abortCode(), lastStats.errorsCount, lastStats.filesWritten);
+        if (outcome == MirrorOutcome.ERROR) {
+          message = "<b>Error</b> (<i>code " + code + "</i>)";
+        } else {
+          switch (outcome) {
+            case INTERRUPTED:
+              message = "<b>Interrupted</b>! (" + lastStats.errorsCount
+                  + " errors)";
+              break;
+            case ABORTED_IO:
+              message = "<b>Aborted</b>! (a write failed, most likely a full disk)";
+              break;
+            case ABORTED_ROLLBACK:
+              message = "<b>Aborted</b>! (nothing was transferred, so the previous"
+                  + " mirror was kept)";
+              break;
+            case ABORTED:
+              message = "<b>Aborted</b>! (the engine could not continue)";
+              break;
+            case SUCCESS:
+              message = "<b>Success</b>!";
+              break;
+            case SUCCESS_WITH_ERRORS:
+              message = "<b>Success</b>! (" + lastStats.errorsCount + " errors)";
+              break;
+            default:
+              message = "<b>Failed</b>! (" + lastStats.errorsCount
+                  + " errors, no files written)";
+              break;
           }
           mirrorFolder = target;
           message += "<br /><br />Mirror copied in <i><a href=\""
               + MIRROR_FOLDER_HREF + "\">"
               + TextUtils.htmlEncode(target.getAbsolutePath()) + "</a></i>";
-        } else {
-          message = "<b>Error</b> (<i>code " + code + "</i>)";
         }
 
         // Build top index

--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -1533,6 +1533,9 @@ public class HTTrackActivity extends FragmentActivity {
             message = "<b>Failed</b>! (" + lastStats.errorsCount
                 + " errors, no files written)";
             break;
+          default:
+            // No build-time check catches a new constant; a null message would ship as "null".
+            throw new IllegalStateException(outcome.name());
           }
           mirrorFolder = target;
           message += "<br /><br />Mirror copied in <i><a href=\""

--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -1504,8 +1504,13 @@ public class HTTrackActivity extends FragmentActivity {
         pendingWork = leavesPendingWork(interrupted || engine.wasStopped(), code);
 
         // Result
+        final String aborted = engine.abortReason();
         if (code == 0) {
-          if (interrupted) {
+          /* The engine gave up on its own: a full disk reaches here with code 0,
+             and would otherwise be announced as a success. */
+          if (aborted != null) {
+            message = "<b>Aborted</b>! (" + TextUtils.htmlEncode(aborted) + ")";
+          } else if (interrupted) {
             message = "<b>Interrupted</b>! (" + lastStats.errorsCount
                 + " errors)";
           } else if (lastStats.errorsCount == 0) {

--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -1504,41 +1504,42 @@ public class HTTrackActivity extends FragmentActivity {
         pendingWork = leavesPendingWork(interrupted || engine.wasStopped(), code);
 
         // Result
-        final MirrorOutcome outcome = MirrorOutcome.of(code, interrupted,
-            engine.abortCode(), lastStats.errorsCount, lastStats.filesWritten);
-        if (outcome == MirrorOutcome.ERROR) {
-          message = "<b>Error</b> (<i>code " + code + "</i>)";
-        } else {
+        if (code == 0) {
+          final MirrorOutcome outcome = MirrorOutcome.of(interrupted,
+              engine.abortCode(), lastStats);
           switch (outcome) {
-            case INTERRUPTED:
-              message = "<b>Interrupted</b>! (" + lastStats.errorsCount
-                  + " errors)";
-              break;
-            case ABORTED_IO:
-              message = "<b>Aborted</b>! (a write failed, most likely a full disk)";
-              break;
-            case ABORTED_ROLLBACK:
-              message = "<b>Aborted</b>! (nothing was transferred, so the previous"
-                  + " mirror was kept)";
-              break;
-            case ABORTED:
-              message = "<b>Aborted</b>! (the engine could not continue)";
-              break;
-            case SUCCESS:
-              message = "<b>Success</b>!";
-              break;
-            case SUCCESS_WITH_ERRORS:
-              message = "<b>Success</b>! (" + lastStats.errorsCount + " errors)";
-              break;
-            default:
-              message = "<b>Failed</b>! (" + lastStats.errorsCount
-                  + " errors, no files written)";
-              break;
+          case INTERRUPTED:
+            message = "<b>Interrupted</b>! (" + lastStats.errorsCount
+                + " errors)";
+            break;
+          case ABORTED_FATAL:
+            message = "<b>Aborted</b>! (out of disk space, too many links, or"
+                + " another fatal error)";
+            break;
+          case ABORTED_ROLLBACK:
+            message = "<b>Aborted</b>! (nothing was transferred, so the mirror"
+                + " was left as it was)";
+            break;
+          case ABORTED_OTHER:
+            message = "<b>Aborted</b>! (the engine could not continue)";
+            break;
+          case SUCCESS:
+            message = "<b>Success</b>!";
+            break;
+          case SUCCESS_WITH_ERRORS:
+            message = "<b>Success</b>! (" + lastStats.errorsCount + " errors)";
+            break;
+          case FAILED:
+            message = "<b>Failed</b>! (" + lastStats.errorsCount
+                + " errors, no files written)";
+            break;
           }
           mirrorFolder = target;
           message += "<br /><br />Mirror copied in <i><a href=\""
               + MIRROR_FOLDER_HREF + "\">"
               + TextUtils.htmlEncode(target.getAbsolutePath()) + "</a></i>";
+        } else {
+          message = "<b>Error</b> (<i>code " + code + "</i>)";
         }
 
         // Build top index

--- a/app/src/main/java/com/httrack/android/MirrorOutcome.java
+++ b/app/src/main/java/com/httrack/android/MirrorOutcome.java
@@ -1,71 +1,53 @@
-/*
-HTTrack Android Java Interface.
-
-Copyright (C) 2026 Xavier Roche and other contributors
-
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-as published by the Free Software Foundation; either version 2
-of the License, or any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program; if not, write to the Free Software
-Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-*/
-
 package com.httrack.android;
+
+import com.httrack.android.jni.HTTrackStats;
 
 /**
  * What a finished crawl actually was. Kept free of android.* so the choice can be tested; the
  * wording that goes with each case belongs to the caller.
  */
 enum MirrorOutcome {
-  /** main() itself failed, so nothing below applies. */
-  ERROR,
   /** The user asked for the stop. */
   INTERRUPTED,
-  /** A write failed: exit_xh -1, in practice a full disk. */
-  ABORTED_IO,
-  /** Nothing arrived, so the engine restored the previous session: exit_xh 2. */
+  /** Out of room: a write that failed, or a link the table could not record. */
+  ABORTED_FATAL,
+  /** Nothing arrived, so the engine rolled the session back. */
   ABORTED_ROLLBACK,
-  /** The engine gave up for a reason it does not name. */
-  ABORTED,
+  /** The engine gave up for a reason it does not name. No path is known to reach this. */
+  ABORTED_OTHER,
   SUCCESS,
   SUCCESS_WITH_ERRORS,
   /** Errors, and no file written. */
   FAILED;
 
+  /** The values HTTrackLib.abortCode() reports; anything else is ABORTED_OTHER. */
+  static final int ABORT_NONE = 0;
+  static final int ABORT_FATAL = -1;
+  static final int ABORT_ROLLBACK = 2;
+
   /**
-   * Weigh the engine's ABORTCODE against the return code. INTERRUPTED must come first: a user stop
-   * sets exit_xh two ways of its own, so the engine's verdict alone reads it as an abort nobody
-   * asked for.
+   * Weigh ABORTCODE, from HTTrackLib.abortCode(), against what the run recorded. INTERRUPTED must
+   * come first: a user stop sets the engine's abort flag two ways of its own, so the verdict alone
+   * reads it as an abort nobody asked for.
    */
-  static MirrorOutcome of(final int code, final boolean interrupted, final int abortCode,
-      final long errorsCount, final long filesWritten) {
-    if (code != 0) {
-      return ERROR;
-    }
+  static MirrorOutcome of(final boolean interrupted, final int abortCode,
+      final HTTrackStats stats) {
     if (interrupted) {
       return INTERRUPTED;
     }
     switch (abortCode) {
-      case 0:
+      case ABORT_NONE:
         break;
-      case -1:
-        return ABORTED_IO;
-      case 2:
+      case ABORT_FATAL:
+        return ABORTED_FATAL;
+      case ABORT_ROLLBACK:
         return ABORTED_ROLLBACK;
       default:
-        return ABORTED;
+        return ABORTED_OTHER;
     }
-    if (errorsCount == 0) {
+    if (stats.errorsCount == 0) {
       return SUCCESS;
     }
-    return filesWritten != 0 ? SUCCESS_WITH_ERRORS : FAILED;
+    return stats.filesWritten != 0 ? SUCCESS_WITH_ERRORS : FAILED;
   }
 }

--- a/app/src/main/java/com/httrack/android/MirrorOutcome.java
+++ b/app/src/main/java/com/httrack/android/MirrorOutcome.java
@@ -1,0 +1,71 @@
+/*
+HTTrack Android Java Interface.
+
+Copyright (C) 2026 Xavier Roche and other contributors
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+package com.httrack.android;
+
+/**
+ * What a finished crawl actually was. Kept free of android.* so the choice can be tested; the
+ * wording that goes with each case belongs to the caller.
+ */
+enum MirrorOutcome {
+  /** main() itself failed, so nothing below applies. */
+  ERROR,
+  /** The user asked for the stop. */
+  INTERRUPTED,
+  /** A write failed: exit_xh -1, in practice a full disk. */
+  ABORTED_IO,
+  /** Nothing arrived, so the engine restored the previous session: exit_xh 2. */
+  ABORTED_ROLLBACK,
+  /** The engine gave up for a reason it does not name. */
+  ABORTED,
+  SUCCESS,
+  SUCCESS_WITH_ERRORS,
+  /** Errors, and no file written. */
+  FAILED;
+
+  /**
+   * Weigh the engine's ABORTCODE against the return code. INTERRUPTED must come first: a user stop
+   * sets exit_xh two ways of its own, so the engine's verdict alone reads it as an abort nobody
+   * asked for.
+   */
+  static MirrorOutcome of(final int code, final boolean interrupted, final int abortCode,
+      final long errorsCount, final long filesWritten) {
+    if (code != 0) {
+      return ERROR;
+    }
+    if (interrupted) {
+      return INTERRUPTED;
+    }
+    switch (abortCode) {
+      case 0:
+        break;
+      case -1:
+        return ABORTED_IO;
+      case 2:
+        return ABORTED_ROLLBACK;
+      default:
+        return ABORTED;
+    }
+    if (errorsCount == 0) {
+      return SUCCESS;
+    }
+    return filesWritten != 0 ? SUCCESS_WITH_ERRORS : FAILED;
+  }
+}

--- a/app/src/main/java/com/httrack/android/MirrorOutcome.java
+++ b/app/src/main/java/com/httrack/android/MirrorOutcome.java
@@ -13,7 +13,7 @@ enum MirrorOutcome {
   ABORTED_FATAL,
   /** Nothing arrived, so the engine rolled the session back. */
   ABORTED_ROLLBACK,
-  /** The engine gave up for a reason it does not name. No path is known to reach this. */
+  /** The engine gave up for a reason it does not name. */
   ABORTED_OTHER,
   SUCCESS,
   SUCCESS_WITH_ERRORS,

--- a/app/src/main/java/com/httrack/android/jni/HTTrackLib.java
+++ b/app/src/main/java/com/httrack/android/jni/HTTrackLib.java
@@ -118,6 +118,15 @@ public class HTTrackLib {
   public native boolean wasStopped();
 
   /**
+   * Why the engine gave up, when it did. hts_main2() returns 0 for nearly every
+   * abort, so a run that stopped on a full disk is otherwise indistinguishable
+   * from one that finished.
+   *
+   * @return the engine's reason, or null when the mirror was not aborted
+   */
+  public native String abortReason();
+
+  /**
    * Default constructor.
    */
   public HTTrackLib() {

--- a/app/src/main/java/com/httrack/android/jni/HTTrackLib.java
+++ b/app/src/main/java/com/httrack/android/jni/HTTrackLib.java
@@ -110,21 +110,21 @@ public class HTTrackLib {
   public native boolean stop(boolean force);
 
   /**
+   * How the engine aborted the last run, if it did. main() returns 0 for nearly every abort, so
+   * its return code alone cannot tell a mirror that died from one that finished.
+   *
+   * @return 0 when the mirror was not aborted, -1 on a fatal write such as a full disk, 1 when a
+   * callback refused to continue, 2 when nothing arrived and the previous session was restored
+   */
+  public native int abortCode();
+
+  /**
    * Was the last run cut short ? True for a stop() request, and for the size and time caps the
    * engine enforces itself, which no return code of main() tells apart from a completion.
    *
    * @return true if the engine stopped before draining its queue
    */
   public native boolean wasStopped();
-
-  /**
-   * Why the engine gave up, when it did. hts_main2() returns 0 for nearly every
-   * abort, so a run that stopped on a full disk is otherwise indistinguishable
-   * from one that finished.
-   *
-   * @return the engine's reason, or null when the mirror was not aborted
-   */
-  public native String abortReason();
 
   /**
    * Default constructor.

--- a/app/src/main/jni/htslibjni.c
+++ b/app/src/main/jni/htslibjni.c
@@ -827,6 +827,31 @@ Java_com_httrack_android_jni_HTTrackLib_stop(JNIEnv* env, jobject object,
   return stopped;
 }
 
+JNICALL jstring
+Java_com_httrack_android_jni_HTTrackLib_abortReason(JNIEnv* env, jobject object) {
+  HTTrackLib_context *const context = getNativeOpt(env, object);
+  jstring reason = NULL;
+
+  if (context == NULL) {
+    throwRuntimeException(env, "null context");
+    return NULL;
+  }
+
+  /* The engine reports a full disk, a full link table or a rolled-back session
+     through exit_xh, and hts_main2() still returns 0, so a caller that only reads
+     the code calls a dead mirror a success. */
+  MUTEX_LOCK(context->lock);
+  if (context->opt != NULL && hts_is_exiting(context->opt) != 0) {
+    const char *const msg = hts_errmsg(context->opt);
+
+    reason = (*env)->NewStringUTF(env, msg != NULL && *msg != '\0'
+        ? msg : "mirror aborted");
+  }
+  MUTEX_UNLOCK(context->lock);
+
+  return reason;
+}
+
 JNICALL jboolean
 Java_com_httrack_android_jni_HTTrackLib_wasStopped(JNIEnv* env, jobject object) {
   HTTrackLib_context *const context = getNativeOpt(env, object);

--- a/app/src/main/jni/htslibjni.c
+++ b/app/src/main/jni/htslibjni.c
@@ -827,29 +827,24 @@ Java_com_httrack_android_jni_HTTrackLib_stop(JNIEnv* env, jobject object,
   return stopped;
 }
 
-JNICALL jstring
-Java_com_httrack_android_jni_HTTrackLib_abortReason(JNIEnv* env, jobject object) {
+JNICALL jint
+Java_com_httrack_android_jni_HTTrackLib_abortCode(JNIEnv* env, jobject object) {
   HTTrackLib_context *const context = getNativeOpt(env, object);
-  jstring reason = NULL;
+  jint aborted = 0;
 
   if (context == NULL) {
     throwRuntimeException(env, "null context");
-    return NULL;
+    return 0;
   }
 
-  /* The engine reports a full disk, a full link table or a rolled-back session
-     through exit_xh, and hts_main2() still returns 0, so a caller that only reads
-     the code calls a dead mirror a success. */
   MUTEX_LOCK(context->lock);
-  if (context->opt != NULL && hts_is_exiting(context->opt) != 0) {
-    const char *const msg = hts_errmsg(context->opt);
-
-    reason = (*env)->NewStringUTF(env, msg != NULL && *msg != '\0'
-        ? msg : "mirror aborted");
+  /* exit_xh's own value, not a flag: the three causes want three messages. */
+  if (context->opt != NULL) {
+    aborted = hts_is_exiting(context->opt);
   }
   MUTEX_UNLOCK(context->lock);
 
-  return reason;
+  return aborted;
 }
 
 JNICALL jboolean
@@ -864,8 +859,8 @@ Java_com_httrack_android_jni_HTTrackLib_wasStopped(JNIEnv* env, jobject object) 
 
   MUTEX_LOCK(context->lock);
   /* hts_main2() returns 0 for nearly every abort, so ask the engine instead.
-     stop is a cap or a user stop; exit_xh is a fatal disk error, a full link
-     table, an aborting callback, or a rolled-back session. */
+     stop is a cap or a user stop; exit_xh is a fatal disk error, an aborting
+     callback, or a rolled-back session. */
   if (context->opt != NULL) {
     stopped = context->opt->state.stop != 0
         || hts_is_exiting(context->opt) != 0 ? JNI_TRUE : JNI_FALSE;

--- a/app/src/test/java/com/httrack/android/EngineAbortReportedTest.java
+++ b/app/src/test/java/com/httrack/android/EngineAbortReportedTest.java
@@ -1,0 +1,45 @@
+package com.httrack.android;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import org.junit.Test;
+
+/**
+ * hts_main2() returns 0 for nearly every abort, so the run's own code cannot say
+ * whether the mirror died. Neither half of that contract is reachable from JUnit,
+ * so both are pinned against their sources.
+ */
+public class EngineAbortReportedTest {
+  private static String between(final String body, final String from, final String to) {
+    final int at = body.indexOf(from);
+    assertTrue(from + " is gone", at > 0);
+    final int end = body.indexOf(to, at);
+    assertTrue(to + " is gone", end > at);
+    return body.substring(at, end);
+  }
+
+  /** The engine's own verdict, not the return code, decides that a run aborted. */
+  @Test
+  public void abortReasonAsksTheEngineWhetherItGaveUp() throws Exception {
+    final String jni = TestSources.jniSource("htslibjni.c");
+    final String body = between(jni, "HTTrackLib_abortReason", "\n}");
+    assertTrue("abortReason must ask the engine, not read a return code",
+        body.contains("hts_is_exiting"));
+    assertTrue("abortReason must carry the engine's own message",
+        body.contains("hts_errmsg"));
+  }
+
+  /** A full disk arrives here with code 0, so success must be the last branch. */
+  @Test
+  public void anAbortIsReportedBeforeAnySuccess() throws IOException {
+    final String source = TestSources.javaSource("HTTrackActivity");
+    final String branch = between(source, "final String aborted = engine.abortReason();",
+        "mirrorFolder = target;");
+    assertTrue("the abort must be weighed", branch.contains("if (aborted != null)"));
+    assertTrue("an aborted run must not be announced as a success",
+        branch.indexOf("aborted != null") < branch.indexOf("<b>Success</b>"));
+    assertTrue("the engine's text lands in an HTML pane, so it must be escaped",
+        branch.contains("TextUtils.htmlEncode(aborted)"));
+  }
+}

--- a/app/src/test/java/com/httrack/android/EngineAbortReportedTest.java
+++ b/app/src/test/java/com/httrack/android/EngineAbortReportedTest.java
@@ -1,18 +1,25 @@
 package com.httrack.android;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
 /** MirrorOutcomeTest covers the choice; what it cannot reach is the wiring that feeds it. */
 public class EngineAbortReportedTest {
-  /** exit_xh's value, not its truth: the three causes carry three different messages. */
+  private static String abortCodeBody() throws Exception {
+    return TestSources.between(TestSources.jniSource("htslibjni.c"), "HTTrackLib_abortCode", "\n}");
+  }
+
+  /** The value, not its truth: the causes carry different messages. */
   @Test
   public void abortCodeHandsBackTheEnginesOwnVerdict() throws Exception {
-    final String body = TestSources.between(TestSources.jniSource("htslibjni.c"),
-        "HTTrackLib_abortCode", "\n}");
-    assertTrue("abortCode must return hts_is_exiting()'s value, not a flag derived from it",
-        body.contains("aborted = hts_is_exiting(context->opt);"));
+    final String body = abortCodeBody();
+    assertTrue("abortCode must ask the engine", body.contains("hts_is_exiting"));
+    assertFalse("abortCode must not collapse the value to a flag",
+        body.matches("(?s).*hts_is_exiting\\([^)]*\\)\\s*(!=|==)\\s*0.*"));
+    assertFalse("abortCode must not collapse the value to a flag",
+        body.matches("(?s).*hts_is_exiting.*\\?.*:.*"));
   }
 
   /** Both inputs must reach the choice; the return code alone cannot see either. */
@@ -22,5 +29,15 @@ public class EngineAbortReportedTest {
         "MirrorOutcome.of(", ");");
     assertTrue("the user's own stop must reach the choice", call.contains("interrupted"));
     assertTrue("the engine's verdict must reach the choice", call.contains("engine.abortCode()"));
+  }
+
+  /** Swapping two abort messages is invisible to the enum, so each is pinned to its cause. */
+  @Test
+  public void eachAbortCauseKeepsItsOwnWording() throws Exception {
+    final String source = TestSources.javaSource("HTTrackActivity");
+    assertTrue("a fatal abort must name what ran out",
+        TestSources.between(source, "case ABORTED_FATAL:", "break;").contains("disk space"));
+    assertTrue("a rolled-back session must say the mirror was left alone",
+        TestSources.between(source, "case ABORTED_ROLLBACK:", "break;").contains("left as it was"));
   }
 }

--- a/app/src/test/java/com/httrack/android/EngineAbortReportedTest.java
+++ b/app/src/test/java/com/httrack/android/EngineAbortReportedTest.java
@@ -2,44 +2,25 @@ package com.httrack.android;
 
 import static org.junit.Assert.assertTrue;
 
-import java.io.IOException;
 import org.junit.Test;
 
-/**
- * hts_main2() returns 0 for nearly every abort, so the run's own code cannot say
- * whether the mirror died. Neither half of that contract is reachable from JUnit,
- * so both are pinned against their sources.
- */
+/** MirrorOutcomeTest covers the choice; what it cannot reach is the wiring that feeds it. */
 public class EngineAbortReportedTest {
-  private static String between(final String body, final String from, final String to) {
-    final int at = body.indexOf(from);
-    assertTrue(from + " is gone", at > 0);
-    final int end = body.indexOf(to, at);
-    assertTrue(to + " is gone", end > at);
-    return body.substring(at, end);
+  /** exit_xh's value, not its truth: the three causes carry three different messages. */
+  @Test
+  public void abortCodeHandsBackTheEnginesOwnVerdict() throws Exception {
+    final String body = TestSources.between(TestSources.jniSource("htslibjni.c"),
+        "HTTrackLib_abortCode", "\n}");
+    assertTrue("abortCode must return hts_is_exiting()'s value, not a flag derived from it",
+        body.contains("aborted = hts_is_exiting(context->opt);"));
   }
 
-  /** The engine's own verdict, not the return code, decides that a run aborted. */
+  /** Both inputs must reach the choice; the return code alone cannot see either. */
   @Test
-  public void abortReasonAsksTheEngineWhetherItGaveUp() throws Exception {
-    final String jni = TestSources.jniSource("htslibjni.c");
-    final String body = between(jni, "HTTrackLib_abortReason", "\n}");
-    assertTrue("abortReason must ask the engine, not read a return code",
-        body.contains("hts_is_exiting"));
-    assertTrue("abortReason must carry the engine's own message",
-        body.contains("hts_errmsg"));
-  }
-
-  /** A full disk arrives here with code 0, so success must be the last branch. */
-  @Test
-  public void anAbortIsReportedBeforeAnySuccess() throws IOException {
-    final String source = TestSources.javaSource("HTTrackActivity");
-    final String branch = between(source, "final String aborted = engine.abortReason();",
-        "mirrorFolder = target;");
-    assertTrue("the abort must be weighed", branch.contains("if (aborted != null)"));
-    assertTrue("an aborted run must not be announced as a success",
-        branch.indexOf("aborted != null") < branch.indexOf("<b>Success</b>"));
-    assertTrue("the engine's text lands in an HTML pane, so it must be escaped",
-        branch.contains("TextUtils.htmlEncode(aborted)"));
+  public void theFinishedPaneWeighsBothTheStopAndTheEnginesVerdict() throws Exception {
+    final String call = TestSources.between(TestSources.javaSource("HTTrackActivity"),
+        "MirrorOutcome.of(", ");");
+    assertTrue("the user's own stop must reach the choice", call.contains("interrupted"));
+    assertTrue("the engine's verdict must reach the choice", call.contains("engine.abortCode()"));
   }
 }

--- a/app/src/test/java/com/httrack/android/FinishedMessageTest.java
+++ b/app/src/test/java/com/httrack/android/FinishedMessageTest.java
@@ -46,9 +46,7 @@ public class FinishedMessageTest {
 
   /** The statement building the "Mirror copied in" line. */
   private static String mirrorPathStatement(final String source) {
-    final int at = source.indexOf("Mirror copied in");
-    assertTrue("no mirror path line left in HTTrackActivity", at != -1);
-    return source.substring(at, source.indexOf(';', at));
+    return TestSources.between(source, "Mirror copied in", ";");
   }
 
   /** A base path is user-chosen, so an unescaped '&' or '<' would corrupt the render. */

--- a/app/src/test/java/com/httrack/android/InterruptedLockTest.java
+++ b/app/src/test/java/com/httrack/android/InterruptedLockTest.java
@@ -140,10 +140,8 @@ public class InterruptedLockTest {
      two abort flags are pinned here: stop alone misses a fatal disk error. */
   @Test
   public void wasStoppedWeighsBothOfTheEnginesAbortFlags() throws Exception {
-    final String jni = TestSources.jniSource("htslibjni.c");
-    final int at = jni.indexOf("HTTrackLib_wasStopped");
-    assertTrue("wasStopped is gone", at > 0);
-    final String body = jni.substring(at, jni.indexOf("\n}", at));
+    final String body = TestSources.between(
+        TestSources.jniSource("htslibjni.c"), "HTTrackLib_wasStopped", "\n}");
     assertTrue("wasStopped must read state.stop", body.contains("state.stop"));
     assertTrue("wasStopped must also read exit_xh, which stop never sets",
         body.contains("hts_is_exiting"));

--- a/app/src/test/java/com/httrack/android/MirrorOutcomeTest.java
+++ b/app/src/test/java/com/httrack/android/MirrorOutcomeTest.java
@@ -2,54 +2,60 @@ package com.httrack.android;
 
 import static org.junit.Assert.assertEquals;
 
+import com.httrack.android.jni.HTTrackStats;
 import org.junit.Test;
 
 /** MirrorOutcome.of() has no android.* dependency, so unlike the pane it builds it can be run. */
 public class MirrorOutcomeTest {
-  private static final int NOT_ABORTED = 0;
-  private static final int ABORT_IO = -1;
   private static final int ABORT_CALLBACK = 1;
-  private static final int ABORT_ROLLBACK = 2;
+  private static final int ABORT_UNKNOWN = 3;
 
-  private static void check(final MirrorOutcome expected, final int code, final boolean interrupted,
-      final int abortCode, final long errorsCount, final long filesWritten) {
-    assertEquals("code=" + code + " interrupted=" + interrupted + " abortCode=" + abortCode
-        + " errors=" + errorsCount + " written=" + filesWritten, expected,
-        MirrorOutcome.of(code, interrupted, abortCode, errorsCount, filesWritten));
+  private static HTTrackStats stats(final long errorsCount, final long filesWritten) {
+    final HTTrackStats stats = new HTTrackStats();
+    stats.errorsCount = errorsCount;
+    stats.filesWritten = filesWritten;
+    return stats;
   }
 
-  @Test
-  public void aFailedMainOutranksEverythingElse() {
-    check(MirrorOutcome.ERROR, -1, false, NOT_ABORTED, 0, 12);
-    check(MirrorOutcome.ERROR, -1, true, ABORT_IO, 3, 0);
+  private static void check(final MirrorOutcome expected, final boolean interrupted,
+      final int abortCode, final long errorsCount, final long filesWritten) {
+    assertEquals("interrupted=" + interrupted + " abortCode=" + abortCode + " errors="
+        + errorsCount + " written=" + filesWritten, expected,
+        MirrorOutcome.of(interrupted, abortCode, stats(errorsCount, filesWritten)));
   }
 
   /**
-   * The engine sets exit_xh on its own for two of the commonest ways a user stops a crawl: an early
-   * stop is rolled back for want of data, and a forced stop refuses the loop callback. Weighing the
-   * abort first would report every one of those as an abort the user never asked for.
+   * The engine sets its abort flag on its own for the two commonest ways a user stops a crawl: an
+   * early stop is rolled back for want of data (htscore.c:2088), and a forced stop refuses the loop
+   * callback (htscore.c:951). Weighing the abort first would report both as unwanted aborts.
    */
   @Test
   public void aStopTheUserAskedForIsNeverAnAbort() {
-    check(MirrorOutcome.INTERRUPTED, 0, true, ABORT_ROLLBACK, 0, 0);
-    check(MirrorOutcome.INTERRUPTED, 0, true, ABORT_CALLBACK, 2, 40);
-    check(MirrorOutcome.INTERRUPTED, 0, true, ABORT_IO, 0, 7);
-    check(MirrorOutcome.INTERRUPTED, 0, true, NOT_ABORTED, 0, 7);
+    check(MirrorOutcome.INTERRUPTED, true, MirrorOutcome.ABORT_ROLLBACK, 0, 0);
+    check(MirrorOutcome.INTERRUPTED, true, ABORT_CALLBACK, 2, 40);
+    check(MirrorOutcome.INTERRUPTED, true, MirrorOutcome.ABORT_FATAL, 0, 7);
+    check(MirrorOutcome.INTERRUPTED, true, MirrorOutcome.ABORT_NONE, 0, 7);
   }
 
-  /** main() returns 0 for these, so without exit_xh they would all read as a success. */
+  /** main() returns 0 for these, so without the abort flag they would all read as a success. */
   @Test
   public void anAbortTheUserDidNotAskForIsNamedByItsCause() {
-    check(MirrorOutcome.ABORTED_IO, 0, false, ABORT_IO, 0, 3);
-    check(MirrorOutcome.ABORTED_ROLLBACK, 0, false, ABORT_ROLLBACK, 0, 0);
-    check(MirrorOutcome.ABORTED, 0, false, ABORT_CALLBACK, 0, 0);
+    check(MirrorOutcome.ABORTED_FATAL, false, MirrorOutcome.ABORT_FATAL, 0, 3);
+    check(MirrorOutcome.ABORTED_ROLLBACK, false, MirrorOutcome.ABORT_ROLLBACK, 0, 0);
+  }
+
+  /** An abort code nobody has mapped must still abort, not fall through to success. */
+  @Test
+  public void anUnrecognisedAbortCodeIsStillAnAbort() {
+    check(MirrorOutcome.ABORTED_OTHER, false, ABORT_CALLBACK, 0, 0);
+    check(MirrorOutcome.ABORTED_OTHER, false, ABORT_UNKNOWN, 0, 40);
   }
 
   @Test
   public void aCompletedRunIsStillJudgedOnItsErrorCount() {
-    check(MirrorOutcome.SUCCESS, 0, false, NOT_ABORTED, 0, 40);
-    check(MirrorOutcome.SUCCESS, 0, false, NOT_ABORTED, 0, 0);
-    check(MirrorOutcome.SUCCESS_WITH_ERRORS, 0, false, NOT_ABORTED, 5, 40);
-    check(MirrorOutcome.FAILED, 0, false, NOT_ABORTED, 5, 0);
+    check(MirrorOutcome.SUCCESS, false, MirrorOutcome.ABORT_NONE, 0, 40);
+    check(MirrorOutcome.SUCCESS, false, MirrorOutcome.ABORT_NONE, 0, 0);
+    check(MirrorOutcome.SUCCESS_WITH_ERRORS, false, MirrorOutcome.ABORT_NONE, 5, 40);
+    check(MirrorOutcome.FAILED, false, MirrorOutcome.ABORT_NONE, 5, 0);
   }
 }

--- a/app/src/test/java/com/httrack/android/MirrorOutcomeTest.java
+++ b/app/src/test/java/com/httrack/android/MirrorOutcomeTest.java
@@ -1,0 +1,55 @@
+package com.httrack.android;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+/** MirrorOutcome.of() has no android.* dependency, so unlike the pane it builds it can be run. */
+public class MirrorOutcomeTest {
+  private static final int NOT_ABORTED = 0;
+  private static final int ABORT_IO = -1;
+  private static final int ABORT_CALLBACK = 1;
+  private static final int ABORT_ROLLBACK = 2;
+
+  private static void check(final MirrorOutcome expected, final int code, final boolean interrupted,
+      final int abortCode, final long errorsCount, final long filesWritten) {
+    assertEquals("code=" + code + " interrupted=" + interrupted + " abortCode=" + abortCode
+        + " errors=" + errorsCount + " written=" + filesWritten, expected,
+        MirrorOutcome.of(code, interrupted, abortCode, errorsCount, filesWritten));
+  }
+
+  @Test
+  public void aFailedMainOutranksEverythingElse() {
+    check(MirrorOutcome.ERROR, -1, false, NOT_ABORTED, 0, 12);
+    check(MirrorOutcome.ERROR, -1, true, ABORT_IO, 3, 0);
+  }
+
+  /**
+   * The engine sets exit_xh on its own for two of the commonest ways a user stops a crawl: an early
+   * stop is rolled back for want of data, and a forced stop refuses the loop callback. Weighing the
+   * abort first would report every one of those as an abort the user never asked for.
+   */
+  @Test
+  public void aStopTheUserAskedForIsNeverAnAbort() {
+    check(MirrorOutcome.INTERRUPTED, 0, true, ABORT_ROLLBACK, 0, 0);
+    check(MirrorOutcome.INTERRUPTED, 0, true, ABORT_CALLBACK, 2, 40);
+    check(MirrorOutcome.INTERRUPTED, 0, true, ABORT_IO, 0, 7);
+    check(MirrorOutcome.INTERRUPTED, 0, true, NOT_ABORTED, 0, 7);
+  }
+
+  /** main() returns 0 for these, so without exit_xh they would all read as a success. */
+  @Test
+  public void anAbortTheUserDidNotAskForIsNamedByItsCause() {
+    check(MirrorOutcome.ABORTED_IO, 0, false, ABORT_IO, 0, 3);
+    check(MirrorOutcome.ABORTED_ROLLBACK, 0, false, ABORT_ROLLBACK, 0, 0);
+    check(MirrorOutcome.ABORTED, 0, false, ABORT_CALLBACK, 0, 0);
+  }
+
+  @Test
+  public void aCompletedRunIsStillJudgedOnItsErrorCount() {
+    check(MirrorOutcome.SUCCESS, 0, false, NOT_ABORTED, 0, 40);
+    check(MirrorOutcome.SUCCESS, 0, false, NOT_ABORTED, 0, 0);
+    check(MirrorOutcome.SUCCESS_WITH_ERRORS, 0, false, NOT_ABORTED, 5, 40);
+    check(MirrorOutcome.FAILED, 0, false, NOT_ABORTED, 5, 0);
+  }
+}

--- a/app/src/test/java/com/httrack/android/TestSources.java
+++ b/app/src/test/java/com/httrack/android/TestSources.java
@@ -73,6 +73,20 @@ final class TestSources {
     return new File(dir("src/main/jni/httrack"), name);
   }
 
+  /** SOURCE from STARTMARKER up to the next ENDMARKER, which is left out. */
+  static String between(final String source, final String startMarker,
+      final String endMarker) {
+    final int from = source.indexOf(startMarker);
+    if (from == -1) {
+      throw new IllegalStateException("no " + startMarker);
+    }
+    final int to = source.indexOf(endMarker, from);
+    if (to == -1) {
+      throw new IllegalStateException(startMarker + " has no " + endMarker);
+    }
+    return source.substring(from, to);
+  }
+
   static int occurrences(final String source, final String text) {
     int count = 0;
     for (int at = source.indexOf(text); at != -1; at = source.indexOf(text,


### PR DESCRIPTION
`main()` returns 0 for nearly every abort, so the finished pane could not tell a run that died from one that finished. A full disk, or a session the engine rolled back because nothing arrived, both reached "Success! (N errors)".

`abortCode()` hands back the engine's `exit_xh`, and `MirrorOutcome` decides the wording from it. A stop the user asked for is taken first, because the engine sets that flag on its own for the two commonest ways a crawl ends early. A stop with nothing saved yet is rolled back for want of data, and a forced stop refuses the loop callback. Each remaining cause gets its own message. No engine string crosses JNI: `_hts_errmsg` is only written while the options are parsed, before the mirror starts.

Two limits. A full disk is one of four causes behind the same `-1`, alongside `EMFILE`, `EROFS` and a link table that cannot record a link. The message names all four rather than guessing. And a disk that fills mid-crawl only sets the flag from httrack `5b5e3d25`, which is upstream of the pinned 3.49.23, so that case starts working when the pin moves.

`MirrorOutcome` imports no `android.*`, so a table test pins the branch order and the unmapped-code path instead of a grep over the source.