### PR TITLE
A mirror cut short at a size or time cap reported Success

### DIFF
--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -1501,16 +1501,23 @@ public class HTTrackActivity extends FragmentActivity {
         // Run engine
         engineRan = true;
         final int code = engine.main(cargs);
-        pendingWork = leavesPendingWork(interrupted || engine.wasStopped(), code);
+        // One reading of the engine's verdict, so the pane and the resume offer cannot disagree.
+        final MirrorOutcome.Stop stop = interrupted ? MirrorOutcome.Stop.USER
+            : engine.wasStopped() ? MirrorOutcome.Stop.ENGINE : MirrorOutcome.Stop.NONE;
+        pendingWork = leavesPendingWork(stop != MirrorOutcome.Stop.NONE, code);
 
         // Result
         if (code == 0) {
-          final MirrorOutcome outcome = MirrorOutcome.of(interrupted,
-              engine.abortCode(), lastStats);
+          final MirrorOutcome outcome = MirrorOutcome.of(stop, engine.abortCode(),
+              lastStats);
           switch (outcome) {
           case INTERRUPTED:
             message = "<b>Interrupted</b>! (" + lastStats.errorsCount
                 + " errors)";
+            break;
+          case STOPPED_AT_LIMIT:
+            message = "<b>Stopped</b>! (size or time limit reached, "
+                + lastStats.errorsCount + " errors)";
             break;
           case ABORTED_FATAL:
             message = "<b>Aborted</b>! (out of disk space, too many links, or"

--- a/app/src/main/java/com/httrack/android/MirrorOutcome.java
+++ b/app/src/main/java/com/httrack/android/MirrorOutcome.java
@@ -9,14 +9,14 @@ import com.httrack.android.jni.HTTrackStats;
 enum MirrorOutcome {
   /** The user asked for the stop. */
   INTERRUPTED,
-  /** A size or time cap the user set was reached, so the mirror is short. */
-  STOPPED_AT_LIMIT,
   /** Out of room: a write that failed, or a link the table could not record. */
   ABORTED_FATAL,
   /** Nothing arrived, so the engine rolled the session back. */
   ABORTED_ROLLBACK,
   /** The engine gave up for a reason it does not name. */
   ABORTED_OTHER,
+  /** A size or time cap the user set was reached, so the mirror is short. */
+  STOPPED_AT_LIMIT,
   SUCCESS,
   SUCCESS_WITH_ERRORS,
   /** Errors, and no file written. */
@@ -27,7 +27,7 @@ enum MirrorOutcome {
     NONE,
     /** The user tapped Stop. */
     USER,
-    /** back_checkmirror() hit the max-size or max-time cap and asked for a smooth stop. */
+    /** The engine stopped itself, at a cap or on an abort; of() tells the two apart. */
     ENGINE
   }
 

--- a/app/src/main/java/com/httrack/android/MirrorOutcome.java
+++ b/app/src/main/java/com/httrack/android/MirrorOutcome.java
@@ -9,6 +9,8 @@ import com.httrack.android.jni.HTTrackStats;
 enum MirrorOutcome {
   /** The user asked for the stop. */
   INTERRUPTED,
+  /** A size or time cap the user set was reached, so the mirror is short. */
+  STOPPED_AT_LIMIT,
   /** Out of room: a write that failed, or a link the table could not record. */
   ABORTED_FATAL,
   /** Nothing arrived, so the engine rolled the session back. */
@@ -20,19 +22,28 @@ enum MirrorOutcome {
   /** Errors, and no file written. */
   FAILED;
 
+  /** Who asked the run to end early, if anyone. */
+  enum Stop {
+    NONE,
+    /** The user tapped Stop. */
+    USER,
+    /** back_checkmirror() hit the max-size or max-time cap and asked for a smooth stop. */
+    ENGINE
+  }
+
   /** The values HTTrackLib.abortCode() reports; anything else is ABORTED_OTHER. */
   static final int ABORT_NONE = 0;
   static final int ABORT_FATAL = -1;
   static final int ABORT_ROLLBACK = 2;
 
   /**
-   * Weigh ABORTCODE, from HTTrackLib.abortCode(), against what the run recorded. INTERRUPTED must
-   * come first: a user stop sets the engine's abort flag two ways of its own, so the verdict alone
-   * reads it as an abort nobody asked for.
+   * Weigh STOP and ABORTCODE, from HTTrackLib.abortCode(), against what the run recorded. A user
+   * stop must come first: it sets the engine's abort flag two ways of its own, so the verdict
+   * alone reads it as an abort nobody asked for. An abort outranks a cap, because reaching a cap
+   * also makes the engine report itself stopped.
    */
-  static MirrorOutcome of(final boolean interrupted, final int abortCode,
-      final HTTrackStats stats) {
-    if (interrupted) {
+  static MirrorOutcome of(final Stop stop, final int abortCode, final HTTrackStats stats) {
+    if (stop == Stop.USER) {
       return INTERRUPTED;
     }
     switch (abortCode) {
@@ -44,6 +55,9 @@ enum MirrorOutcome {
         return ABORTED_ROLLBACK;
       default:
         return ABORTED_OTHER;
+    }
+    if (stop == Stop.ENGINE) {
+      return STOPPED_AT_LIMIT;
     }
     if (stats.errorsCount == 0) {
       return SUCCESS;

--- a/app/src/test/java/com/httrack/android/EngineAbortReportedTest.java
+++ b/app/src/test/java/com/httrack/android/EngineAbortReportedTest.java
@@ -1,5 +1,6 @@
 package com.httrack.android;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -25,23 +26,22 @@ public class EngineAbortReportedTest {
   /** Both inputs must reach the choice; the return code alone cannot see either. */
   @Test
   public void theFinishedPaneWeighsBothTheStopAndTheEnginesVerdict() throws Exception {
-    final String call = TestSources.between(TestSources.javaSource("HTTrackActivity"),
-        "MirrorOutcome.of(", ");");
-    assertTrue("the stop source must reach the choice", call.contains("stop"));
+    final String call = TestSources.arguments(TestSources.javaSource("HTTrackActivity"),
+        "MirrorOutcome.of");
+    assertEquals("the pane must weigh the same stop the resume offer does", "stop",
+        call.split(",")[0].trim());
     assertTrue("the engine's verdict must reach the choice", call.contains("engine.abortCode()"));
   }
 
-  /** The pane and the resume offer must read one verdict, or they contradict each other. */
+  /** Transposing the two branches is invisible to the enum, so each is pinned to its source. */
   @Test
-  public void oneStopSourceFeedsBoththePaneAndTheResumeOffer() throws Exception {
-    final String source = TestSources.javaSource("HTTrackActivity");
-    final String assigned = TestSources.between(source, "final MirrorOutcome.Stop stop", ";");
-    assertTrue("a user stop must outrank the engine's", assigned.contains("interrupted ?"));
-    assertTrue("a cap the engine hit must be told apart from a clean run",
-        assigned.contains("engine.wasStopped()"));
-    assertTrue("the resume offer must read the same stop the pane does",
-        TestSources.between(source, "pendingWork = leavesPendingWork(", ";")
-            .contains("stop != MirrorOutcome.Stop.NONE"));
+  public void theStopSourceNamesWhoAskedForIt() throws Exception {
+    final String assigned = TestSources.between(TestSources.javaSource("HTTrackActivity"),
+        "final MirrorOutcome.Stop stop", ";");
+    assertTrue("the user's own tap must be the USER stop",
+        assigned.matches("(?s).*interrupted\\s*\\?\\s*MirrorOutcome\\.Stop\\.USER.*"));
+    assertTrue("the engine stopping itself must be the ENGINE stop",
+        assigned.matches("(?s).*wasStopped\\(\\)\\s*\\?\\s*MirrorOutcome\\.Stop\\.ENGINE.*"));
   }
 
   /** Swapping two abort messages is invisible to the enum, so each is pinned to its cause. */
@@ -52,5 +52,7 @@ public class EngineAbortReportedTest {
         TestSources.between(source, "case ABORTED_FATAL:", "break;").contains("disk space"));
     assertTrue("a rolled-back session must say the mirror was left alone",
         TestSources.between(source, "case ABORTED_ROLLBACK:", "break;").contains("left as it was"));
+    assertTrue("a capped run must name the cap, not an abort",
+        TestSources.between(source, "case STOPPED_AT_LIMIT:", "break;").contains("limit reached"));
   }
 }

--- a/app/src/test/java/com/httrack/android/EngineAbortReportedTest.java
+++ b/app/src/test/java/com/httrack/android/EngineAbortReportedTest.java
@@ -27,8 +27,21 @@ public class EngineAbortReportedTest {
   public void theFinishedPaneWeighsBothTheStopAndTheEnginesVerdict() throws Exception {
     final String call = TestSources.between(TestSources.javaSource("HTTrackActivity"),
         "MirrorOutcome.of(", ");");
-    assertTrue("the user's own stop must reach the choice", call.contains("interrupted"));
+    assertTrue("the stop source must reach the choice", call.contains("stop"));
     assertTrue("the engine's verdict must reach the choice", call.contains("engine.abortCode()"));
+  }
+
+  /** The pane and the resume offer must read one verdict, or they contradict each other. */
+  @Test
+  public void oneStopSourceFeedsBoththePaneAndTheResumeOffer() throws Exception {
+    final String source = TestSources.javaSource("HTTrackActivity");
+    final String assigned = TestSources.between(source, "final MirrorOutcome.Stop stop", ";");
+    assertTrue("a user stop must outrank the engine's", assigned.contains("interrupted ?"));
+    assertTrue("a cap the engine hit must be told apart from a clean run",
+        assigned.contains("engine.wasStopped()"));
+    assertTrue("the resume offer must read the same stop the pane does",
+        TestSources.between(source, "pendingWork = leavesPendingWork(", ";")
+            .contains("stop != MirrorOutcome.Stop.NONE"));
   }
 
   /** Swapping two abort messages is invisible to the enum, so each is pinned to its cause. */

--- a/app/src/test/java/com/httrack/android/InterruptedLockTest.java
+++ b/app/src/test/java/com/httrack/android/InterruptedLockTest.java
@@ -129,7 +129,9 @@ public class InterruptedLockTest {
         from != -1 && to > from);
     final String body = source.substring(from, to);
     assertTrue("runInternal must weigh the engine's own stop, not just the user's",
-        body.contains("leavesPendingWork(interrupted || engine.wasStopped(), code)"));
+        body.contains("engine.wasStopped()"));
+    assertFalse("the resume offer must not be decided by the user's stop alone",
+        TestSources.between(body, "leavesPendingWork(", ",").endsWith("interrupted"));
     assertTrue("runInternal must write the verdict before the finished pane opens",
         body.contains("setInterruptedProfile(pendingWork)"));
     assertTrue("ended must be set before the finished pane asks for a stop",

--- a/app/src/test/java/com/httrack/android/InterruptedLockTest.java
+++ b/app/src/test/java/com/httrack/android/InterruptedLockTest.java
@@ -128,10 +128,13 @@ public class InterruptedLockTest {
     assertTrue("runInternal no longer bounded by its displayFinishedPanel call",
         from != -1 && to > from);
     final String body = source.substring(from, to);
-    assertTrue("runInternal must weigh the engine's own stop, not just the user's",
-        body.contains("engine.wasStopped()"));
-    assertFalse("the resume offer must not be decided by the user's stop alone",
-        TestSources.between(body, "leavesPendingWork(", ",").endsWith("interrupted"));
+    final String resumeOffer = TestSources.arguments(body, "leavesPendingWork");
+    assertTrue("the resume offer must read the run's own stop verdict",
+        resumeOffer.contains("stop"));
+    assertFalse("the resume offer must not read the user's flag alone",
+        resumeOffer.contains("interrupted"));
+    assertFalse("the resume offer must not narrow to one kind of stop",
+        resumeOffer.contains("=="));
     assertTrue("runInternal must write the verdict before the finished pane opens",
         body.contains("setInterruptedProfile(pendingWork)"));
     assertTrue("ended must be set before the finished pane asks for a stop",

--- a/app/src/test/java/com/httrack/android/MirrorOutcomeTest.java
+++ b/app/src/test/java/com/httrack/android/MirrorOutcomeTest.java
@@ -17,11 +17,11 @@ public class MirrorOutcomeTest {
     return stats;
   }
 
-  private static void check(final MirrorOutcome expected, final boolean interrupted,
+  private static void check(final MirrorOutcome expected, final MirrorOutcome.Stop stop,
       final int abortCode, final long errorsCount, final long filesWritten) {
-    assertEquals("interrupted=" + interrupted + " abortCode=" + abortCode + " errors="
-        + errorsCount + " written=" + filesWritten, expected,
-        MirrorOutcome.of(interrupted, abortCode, stats(errorsCount, filesWritten)));
+    assertEquals("stop=" + stop + " abortCode=" + abortCode + " errors=" + errorsCount
+        + " written=" + filesWritten, expected,
+        MirrorOutcome.of(stop, abortCode, stats(errorsCount, filesWritten)));
   }
 
   /**
@@ -31,31 +31,46 @@ public class MirrorOutcomeTest {
    */
   @Test
   public void aStopTheUserAskedForIsNeverAnAbort() {
-    check(MirrorOutcome.INTERRUPTED, true, MirrorOutcome.ABORT_ROLLBACK, 0, 0);
-    check(MirrorOutcome.INTERRUPTED, true, ABORT_CALLBACK, 2, 40);
-    check(MirrorOutcome.INTERRUPTED, true, MirrorOutcome.ABORT_FATAL, 0, 7);
-    check(MirrorOutcome.INTERRUPTED, true, MirrorOutcome.ABORT_NONE, 0, 7);
+    check(MirrorOutcome.INTERRUPTED, MirrorOutcome.Stop.USER, MirrorOutcome.ABORT_ROLLBACK, 0, 0);
+    check(MirrorOutcome.INTERRUPTED, MirrorOutcome.Stop.USER, ABORT_CALLBACK, 2, 40);
+    check(MirrorOutcome.INTERRUPTED, MirrorOutcome.Stop.USER, MirrorOutcome.ABORT_FATAL, 0, 7);
+    check(MirrorOutcome.INTERRUPTED, MirrorOutcome.Stop.USER, MirrorOutcome.ABORT_NONE, 0, 7);
   }
 
   /** main() returns 0 for these, so without the abort flag they would all read as a success. */
   @Test
   public void anAbortTheUserDidNotAskForIsNamedByItsCause() {
-    check(MirrorOutcome.ABORTED_FATAL, false, MirrorOutcome.ABORT_FATAL, 0, 3);
-    check(MirrorOutcome.ABORTED_ROLLBACK, false, MirrorOutcome.ABORT_ROLLBACK, 0, 0);
+    check(MirrorOutcome.ABORTED_FATAL, MirrorOutcome.Stop.ENGINE, MirrorOutcome.ABORT_FATAL, 0, 3);
+    check(MirrorOutcome.ABORTED_ROLLBACK, MirrorOutcome.Stop.ENGINE, MirrorOutcome.ABORT_ROLLBACK, 0, 0);
   }
 
   /** An abort code nobody has mapped must still abort, not fall through to success. */
   @Test
   public void anUnrecognisedAbortCodeIsStillAnAbort() {
-    check(MirrorOutcome.ABORTED_OTHER, false, ABORT_CALLBACK, 0, 0);
-    check(MirrorOutcome.ABORTED_OTHER, false, ABORT_UNKNOWN, 0, 40);
+    check(MirrorOutcome.ABORTED_OTHER, MirrorOutcome.Stop.ENGINE, ABORT_CALLBACK, 0, 0);
+    check(MirrorOutcome.ABORTED_OTHER, MirrorOutcome.Stop.ENGINE, ABORT_UNKNOWN, 0, 40);
+  }
+
+  /**
+   * back_checkmirror() asks for a smooth stop on the max-size and max-time caps, which sets the
+   * engine's stop flag but no abort flag. The mirror is short, so a clean error count is not a
+   * success, and pendingWork already offers the resume that says so.
+   */
+  @Test
+  public void aCapTheEngineHitIsNotASuccess() {
+    check(MirrorOutcome.STOPPED_AT_LIMIT, MirrorOutcome.Stop.ENGINE, MirrorOutcome.ABORT_NONE,
+        0, 400);
+    check(MirrorOutcome.STOPPED_AT_LIMIT, MirrorOutcome.Stop.ENGINE, MirrorOutcome.ABORT_NONE,
+        5, 400);
+    check(MirrorOutcome.STOPPED_AT_LIMIT, MirrorOutcome.Stop.ENGINE, MirrorOutcome.ABORT_NONE,
+        5, 0);
   }
 
   @Test
   public void aCompletedRunIsStillJudgedOnItsErrorCount() {
-    check(MirrorOutcome.SUCCESS, false, MirrorOutcome.ABORT_NONE, 0, 40);
-    check(MirrorOutcome.SUCCESS, false, MirrorOutcome.ABORT_NONE, 0, 0);
-    check(MirrorOutcome.SUCCESS_WITH_ERRORS, false, MirrorOutcome.ABORT_NONE, 5, 40);
-    check(MirrorOutcome.FAILED, false, MirrorOutcome.ABORT_NONE, 5, 0);
+    check(MirrorOutcome.SUCCESS, MirrorOutcome.Stop.NONE, MirrorOutcome.ABORT_NONE, 0, 40);
+    check(MirrorOutcome.SUCCESS, MirrorOutcome.Stop.NONE, MirrorOutcome.ABORT_NONE, 0, 0);
+    check(MirrorOutcome.SUCCESS_WITH_ERRORS, MirrorOutcome.Stop.NONE, MirrorOutcome.ABORT_NONE, 5, 40);
+    check(MirrorOutcome.FAILED, MirrorOutcome.Stop.NONE, MirrorOutcome.ABORT_NONE, 5, 0);
   }
 }

--- a/app/src/test/java/com/httrack/android/MirrorOutcomeTest.java
+++ b/app/src/test/java/com/httrack/android/MirrorOutcomeTest.java
@@ -37,18 +37,25 @@ public class MirrorOutcomeTest {
     check(MirrorOutcome.INTERRUPTED, MirrorOutcome.Stop.USER, MirrorOutcome.ABORT_NONE, 0, 7);
   }
 
-  /** main() returns 0 for these, so without the abort flag they would all read as a success. */
+  /**
+   * main() returns 0 for these, so without the abort flag they would all read as a success. An
+   * abort sets wasStopped() as well, but must be named by its cause whether or not it did.
+   */
   @Test
   public void anAbortTheUserDidNotAskForIsNamedByItsCause() {
     check(MirrorOutcome.ABORTED_FATAL, MirrorOutcome.Stop.ENGINE, MirrorOutcome.ABORT_FATAL, 0, 3);
+    check(MirrorOutcome.ABORTED_FATAL, MirrorOutcome.Stop.NONE, MirrorOutcome.ABORT_FATAL, 0, 3);
     check(MirrorOutcome.ABORTED_ROLLBACK, MirrorOutcome.Stop.ENGINE, MirrorOutcome.ABORT_ROLLBACK, 0, 0);
+    check(MirrorOutcome.ABORTED_ROLLBACK, MirrorOutcome.Stop.NONE, MirrorOutcome.ABORT_ROLLBACK, 0, 0);
   }
 
   /** An abort code nobody has mapped must still abort, not fall through to success. */
   @Test
   public void anUnrecognisedAbortCodeIsStillAnAbort() {
     check(MirrorOutcome.ABORTED_OTHER, MirrorOutcome.Stop.ENGINE, ABORT_CALLBACK, 0, 0);
+    check(MirrorOutcome.ABORTED_OTHER, MirrorOutcome.Stop.NONE, ABORT_CALLBACK, 0, 0);
     check(MirrorOutcome.ABORTED_OTHER, MirrorOutcome.Stop.ENGINE, ABORT_UNKNOWN, 0, 40);
+    check(MirrorOutcome.ABORTED_OTHER, MirrorOutcome.Stop.NONE, ABORT_UNKNOWN, 0, 40);
   }
 
   /**

--- a/app/src/test/java/com/httrack/android/TestSources.java
+++ b/app/src/test/java/com/httrack/android/TestSources.java
@@ -73,6 +73,24 @@ final class TestSources {
     return new File(dir("src/main/jni/httrack"), name);
   }
 
+  /** Arguments of the call to NAME, parentheses balanced and the outer pair left out. */
+  static String arguments(final String source, final String name) {
+    final int at = source.indexOf(name + "(");
+    if (at == -1) {
+      throw new IllegalStateException("no call to " + name);
+    }
+    final int from = source.indexOf('(', at);
+    int depth = 0;
+    for (int i = from; i < source.length(); i++) {
+      if (source.charAt(i) == '(') {
+        depth++;
+      } else if (source.charAt(i) == ')' && --depth == 0) {
+        return source.substring(from + 1, i);
+      }
+    }
+    throw new IllegalStateException(name + "( is never closed");
+  }
+
   /** SOURCE from STARTMARKER up to the next ENDMARKER, which is left out. */
   static String between(final String source, final String startMarker,
       final String endMarker) {


### PR DESCRIPTION
A mirror the engine cut short at a size or time cap still reported "Success!". `back_checkmirror()` asks for a smooth stop when `maxsite` or `maxtime` is reached. That sets the engine's stop flag but no abort flag, and the user tapped nothing, so the pane saw a clean run. The line above it disagreed: `pendingWork` already counted the run as resumable and offered to continue it.

The stop source is read once now, as `MirrorOutcome.Stop`, and feeds both the pane and the resume offer. A cap reports "Stopped!" and says a limit was reached. A user stop and a real abort still outrank it, because reaching a cap also makes the engine report itself stopped. Reading the source once closes a second gap: `interrupted` is volatile and was read twice, so a stop landing between the two reads could leave the pane and the resume offer disagreeing.

`InterruptedLockTest` pinned the old expression verbatim, so a behaviour-preserving rewrite failed it. It pins the property instead: the resume offer must read the run's verdict, without narrowing it to one kind of stop.