### PR TITLE
The app asks every new user about mirrors that do not exist

### DIFF
--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -800,7 +800,8 @@ public class HTTrackActivity extends FragmentActivity {
     }
 
     // First launch only, so a rotation does not bring the offer back; and not stacked on top
-    // of the native-load failure dialog.
+    // of the native-load failure dialog. Silent unless mirrors are already visible; onResume()
+    // asks again once a storage grant makes them so.
     if (savedInstanceState == null && HTTrackLib.loadedSuccessfully()) {
       offerLegacyMirrorImportOnce();
     }
@@ -2790,6 +2791,11 @@ public class HTTrackActivity extends FragmentActivity {
     if (settings.getBoolean(IMPORT_OFFERED_NAME, false)) {
       return;
     }
+    // Nothing found means nothing asked: without access we cannot look, and a question the user
+    // has no way to answer is worse than never offering the import at all.
+    if (StoragePaths.legacyMirrors(sharedStorageRoot()) == null) {
+      return;
+    }
     new AlertDialog.Builder(this)
         .setMessage(R.string.import_mirrors_offer)
         .setPositiveButton(R.string.import_mirrors_offer_yes, (dialog, which) -> {
@@ -3352,6 +3358,10 @@ public class HTTrackActivity extends FragmentActivity {
     }
     // A grant made on the settings screen flips the button/warning off (no-op off this panel).
     refreshStorageAccessHints();
+    // A grant is the first moment we can see the legacy folder, so this is where the offer belongs.
+    if (runner == null) {
+      offerLegacyMirrorImportOnce();
+    }
   }
 
   @Override

--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -143,6 +143,9 @@ public class HTTrackActivity extends FragmentActivity {
   protected static final String NOTIFY_ASKED_NAME = "NotificationPermissionAsked";
   // Whether the one-time "import your old mirrors" offer has been shown and dismissed for good.
   protected static final String IMPORT_OFFERED_NAME = "LegacyImportOffered";
+
+  /* Access as of the last resume, so a grant can be told from a plain return to the app. */
+  private boolean hadStorageAccess;
   // Whether all-files storage access was ever offered; a refusal keeps mirrors in private storage.
   protected static final String STORAGE_ASKED_NAME = "StorageAccessAsked";
   // The root we left on the last move: nothing is migrated, so the older projects are still there.
@@ -802,6 +805,7 @@ public class HTTrackActivity extends FragmentActivity {
     // First launch only, so a rotation does not bring the offer back; and not stacked on top
     // of the native-load failure dialog. Silent unless mirrors are already visible; onResume()
     // asks again once a storage grant makes them so.
+    hadStorageAccess = hasAllFilesAccess();
     if (savedInstanceState == null && HTTrackLib.loadedSuccessfully()) {
       offerLegacyMirrorImportOnce();
     }
@@ -2791,9 +2795,8 @@ public class HTTrackActivity extends FragmentActivity {
     if (settings.getBoolean(IMPORT_OFFERED_NAME, false)) {
       return;
     }
-    // Nothing found means nothing asked: without access we cannot look, and a question the user
-    // has no way to answer is worse than never offering the import at all.
-    if (StoragePaths.legacyMirrors(sharedStorageRoot()) == null) {
+    // Null both without access and with nothing to import; either way, stay silent.
+    if (StoragePaths.legacyMirrorRoot(sharedStorageRoot()) == null) {
       return;
     }
     new AlertDialog.Builder(this)
@@ -3358,10 +3361,13 @@ public class HTTrackActivity extends FragmentActivity {
     }
     // A grant made on the settings screen flips the button/warning off (no-op off this panel).
     refreshStorageAccessHints();
-    // A grant is the first moment we can see the legacy folder, so this is where the offer belongs.
-    if (runner == null) {
+    // Ask again once a grant may have surfaced the folder; not mid-crawl, and not on a plain
+    // resume, which onCreate has already covered.
+    final boolean access = hasAllFilesAccess();
+    if (runner == null && StoragePaths.accessJustAppeared(hadStorageAccess, access)) {
       offerLegacyMirrorImportOnce();
     }
+    hadStorageAccess = access;
   }
 
   @Override

--- a/app/src/main/java/com/httrack/android/StoragePaths.java
+++ b/app/src/main/java/com/httrack/android/StoragePaths.java
@@ -78,6 +78,32 @@ final class StoragePaths {
   }
 
   /**
+   * Mirrors left by builds before versionCode 61, which wrote under Download/ rather than the
+   * shared HTTrack/ root every build since uses. Returns the folder only when it holds at least
+   * one project, so a caller can stay silent rather than ask about nothing.
+   *
+   * @param shared
+   *          the shared storage root, null when we have no access to look
+   * @return the legacy folder, or null when there is nothing to offer
+   */
+  static File legacyMirrors(final File shared) {
+    if (shared == null) {
+      return null;
+    }
+    final File legacy = new File(new File(new File(shared, "Download"), "HTTrack"), "Websites");
+    final File[] entries = legacy.listFiles();
+    if (entries == null) {
+      return null;
+    }
+    for (final File entry : entries) {
+      if (entry.isDirectory()) {
+        return legacy;
+      }
+    }
+    return null;
+  }
+
+  /**
    * Whether the freshly resolved root differs from the one in use, the first resolution counting
    * as a move. Gates the work that must happen once per move, not once per resume.
    *

--- a/app/src/main/java/com/httrack/android/StoragePaths.java
+++ b/app/src/main/java/com/httrack/android/StoragePaths.java
@@ -78,29 +78,16 @@ final class StoragePaths {
   }
 
   /**
-   * Mirrors left by builds before versionCode 61, which wrote under Download/ rather than the
-   * shared HTTrack/ root every build since uses. Returns the folder only when it holds at least
-   * one project, so a caller can stay silent rather than ask about nothing.
+   * Whether a resume is the moment storage access appeared, which is the only resume that can
+   * newly reveal anything. Every other one must stay silent rather than re-ask.
    *
-   * @param shared
-   *          the shared storage root, null when we have no access to look
-   * @return the legacy folder, or null when there is nothing to offer
+   * @param hadAccess
+   *          access as it stood at the previous check
+   * @param hasAccess
+   *          access as it stands now
    */
-  static File legacyMirrors(final File shared) {
-    if (shared == null) {
-      return null;
-    }
-    final File legacy = new File(new File(new File(shared, "Download"), "HTTrack"), "Websites");
-    final File[] entries = legacy.listFiles();
-    if (entries == null) {
-      return null;
-    }
-    for (final File entry : entries) {
-      if (entry.isDirectory()) {
-        return legacy;
-      }
-    }
-    return null;
+  static boolean accessJustAppeared(final boolean hadAccess, final boolean hasAccess) {
+    return hasAccess && !hadAccess;
   }
 
   /**
@@ -179,6 +166,33 @@ final class StoragePaths {
       return base;
     }
     return defaultRoot;
+  }
+
+  /**
+   * Mirrors left by builds before versionCode 61, which wrote under Download/ rather than the
+   * shared HTTrack/ root every build since uses. Returns the folder only when it holds a project
+   * with something in it, so a caller can stay silent rather than ask about nothing.
+   *
+   * @param shared
+   *          the shared storage root, null when we have no access to look
+   * @return the legacy folder, or null when there is nothing to offer
+   */
+  static File legacyMirrorRoot(final File shared) {
+    if (shared == null) {
+      return null;
+    }
+    final File legacy = new File(new File(new File(shared, "Download"), "HTTrack"), "Websites");
+    final File[] entries = legacy.listFiles();
+    if (entries == null) {
+      return null;
+    }
+    for (final File entry : entries) {
+      final String[] project = entry.list();
+      if (project != null && project.length != 0) {
+        return legacy;
+      }
+    }
+    return null;
   }
 
   /**

--- a/app/src/test/java/com/httrack/android/LegacyMirrorImportTest.java
+++ b/app/src/test/java/com/httrack/android/LegacyMirrorImportTest.java
@@ -376,12 +376,23 @@ public class LegacyMirrorImportTest {
    * appear. Only the wiring can say that; the detector alone cannot tell "no access" from "empty".
    */
   @Test
-  public void theOfferIsGatedOnFindingSomething() throws IOException {
+  public void findingNothingReturnsBeforeTheDialog() throws IOException {
     final String body = TestSources.between(TestSources.javaSource("HTTrackActivity"),
         "private void offerLegacyMirrorImportOnce", "new AlertDialog.Builder");
-    assertTrue("the offer must ask the detector before it shows anything",
-        body.contains("StoragePaths.legacyMirrors(sharedStorageRoot())"));
-    assertTrue("finding nothing must return before the dialog is built",
-        body.contains("== null") && body.contains("return;"));
+    // One pattern, so the test cannot be satisfied by a stray "== null" and the pref check's
+    // own "return;" the way two independent substrings could.
+    assertTrue("finding nothing must return before the dialog is built", body.matches(
+        "(?s).*StoragePaths\\.legacyMirrorRoot\\(sharedStorageRoot\\(\\)\\)\\s*==\\s*null\\)\\s*\\{\\s*return;.*"));
+  }
+
+  /** The resume that brings access is the only one that can reveal the folder. */
+  @Test
+  public void theResumeOfferIsGatedOnTheGrant() throws IOException {
+    final String body = TestSources.between(TestSources.javaSource("HTTrackActivity"),
+        "protected void onResume", "\n  }");
+    assertTrue("a plain resume must not re-ask", body.matches(
+        "(?s).*StoragePaths\\.accessJustAppeared\\([^)]*\\)\\)\\s*\\{\\s*offerLegacyMirrorImportOnce\\(\\);.*"));
+    assertTrue("the next resume must compare against this one",
+        body.contains("hadStorageAccess = access;"));
   }
 }

--- a/app/src/test/java/com/httrack/android/LegacyMirrorImportTest.java
+++ b/app/src/test/java/com/httrack/android/LegacyMirrorImportTest.java
@@ -370,4 +370,18 @@ public class LegacyMirrorImportTest {
 
     assertArrayEquals(raw, Files.readAllBytes(new File(dest, "blob.bin").toPath()));
   }
+
+  /**
+   * Without access the shared root is null, so the detector cannot look and the offer must not
+   * appear. Only the wiring can say that; the detector alone cannot tell "no access" from "empty".
+   */
+  @Test
+  public void theOfferIsGatedOnFindingSomething() throws IOException {
+    final String body = TestSources.between(TestSources.javaSource("HTTrackActivity"),
+        "private void offerLegacyMirrorImportOnce", "new AlertDialog.Builder");
+    assertTrue("the offer must ask the detector before it shows anything",
+        body.contains("StoragePaths.legacyMirrors(sharedStorageRoot())"));
+    assertTrue("finding nothing must return before the dialog is built",
+        body.contains("== null") && body.contains("return;"));
+  }
 }

--- a/app/src/test/java/com/httrack/android/StoragePathsTest.java
+++ b/app/src/test/java/com/httrack/android/StoragePathsTest.java
@@ -1,6 +1,7 @@
 package com.httrack.android;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -131,42 +132,66 @@ public class StoragePathsTest {
     assertNull(StoragePaths.externalStorageDocId(new File(shared, "HTTrack"), null));
   }
 
-  private static File legacyTree(final File shared, final boolean withProject) throws IOException {
+  /** The path builds before versionCode 61 wrote to, spelled out so a change to it fails here. */
+  private static File legacyTree(final File shared) throws IOException {
     final File websites = new File(new File(new File(shared, "Download"), "HTTrack"), "Websites");
     assertTrue(websites.mkdirs());
-    if (withProject) {
-      assertTrue(new File(websites, "someproject").mkdir());
-    }
     return websites;
+  }
+
+  private static void project(final File websites, final String name) throws IOException {
+    final File dir = new File(websites, name);
+    assertTrue(dir.mkdir());
+    assertTrue(new File(dir, "index.html").createNewFile());
   }
 
   /** A question the user cannot answer is worse than no question, so silence is the default. */
   @Test
   public void anAbsentLegacyFolderIsNotOffered() throws IOException {
-    assertNull(StoragePaths.legacyMirrors(tmp.newFolder("bare")));
+    assertNull(StoragePaths.legacyMirrorRoot(tmp.newFolder("bare")));
   }
 
   /** Builds before versionCode 61 wrote here; an empty folder is not a reason to ask. */
   @Test
   public void anEmptyLegacyFolderIsNotOffered() throws IOException {
     final File shared = tmp.newFolder("empty");
-    legacyTree(shared, false);
-    assertNull(StoragePaths.legacyMirrors(shared));
+    legacyTree(shared);
+    assertNull(StoragePaths.legacyMirrorRoot(shared));
+  }
+
+  /** An empty project would import nothing, so it is not worth a question either. */
+  @Test
+  public void anEmptyProjectIsNotOffered() throws IOException {
+    final File shared = tmp.newFolder("hollow");
+    assertTrue(new File(legacyTree(shared), "someproject").mkdir());
+    assertNull(StoragePaths.legacyMirrorRoot(shared));
   }
 
   /** A stray file is not a project; only a project directory earns the question. */
   @Test
   public void aFileIsNotAProject() throws IOException {
     final File shared = tmp.newFolder("stray");
-    final File websites = legacyTree(shared, false);
-    assertTrue(new File(websites, "notes.txt").createNewFile());
-    assertNull(StoragePaths.legacyMirrors(shared));
+    assertTrue(new File(legacyTree(shared), "notes.txt").createNewFile());
+    assertNull(StoragePaths.legacyMirrorRoot(shared));
   }
 
+  /** The one test that pins the path itself: every negative case passes on a wrong path too. */
   @Test
   public void aLegacyProjectIsOffered() throws IOException {
     final File shared = tmp.newFolder("real");
-    final File websites = legacyTree(shared, true);
-    assertEquals(websites, StoragePaths.legacyMirrors(shared));
+    final File websites = legacyTree(shared);
+    project(websites, "someproject");
+    assertEquals(websites, StoragePaths.legacyMirrorRoot(shared));
+  }
+
+  /** Only the resume that brings access can reveal anything; every other must stay silent. */
+  @Test
+  public void onlyTheGrantItselfRaisesTheOffer() {
+    assertTrue(StoragePaths.accessJustAppeared(false, true));
+    assertFalse("a plain resume with access must not re-ask",
+        StoragePaths.accessJustAppeared(true, true));
+    assertFalse(StoragePaths.accessJustAppeared(false, false));
+    assertFalse("access going away is not an invitation",
+        StoragePaths.accessJustAppeared(true, false));
   }
 }

--- a/app/src/test/java/com/httrack/android/StoragePathsTest.java
+++ b/app/src/test/java/com/httrack/android/StoragePathsTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Files;
 
 import org.junit.Before;
@@ -128,5 +129,44 @@ public class StoragePathsTest {
     assertNull(StoragePaths.externalStorageDocId(new File(tmp.getRoot(), "elsewhere"), shared));
     assertNull(StoragePaths.externalStorageDocId(shared, shared)); // the root itself, no sub-path
     assertNull(StoragePaths.externalStorageDocId(new File(shared, "HTTrack"), null));
+  }
+
+  private static File legacyTree(final File shared, final boolean withProject) throws IOException {
+    final File websites = new File(new File(new File(shared, "Download"), "HTTrack"), "Websites");
+    assertTrue(websites.mkdirs());
+    if (withProject) {
+      assertTrue(new File(websites, "someproject").mkdir());
+    }
+    return websites;
+  }
+
+  /** A question the user cannot answer is worse than no question, so silence is the default. */
+  @Test
+  public void anAbsentLegacyFolderIsNotOffered() throws IOException {
+    assertNull(StoragePaths.legacyMirrors(tmp.newFolder("bare")));
+  }
+
+  /** Builds before versionCode 61 wrote here; an empty folder is not a reason to ask. */
+  @Test
+  public void anEmptyLegacyFolderIsNotOffered() throws IOException {
+    final File shared = tmp.newFolder("empty");
+    legacyTree(shared, false);
+    assertNull(StoragePaths.legacyMirrors(shared));
+  }
+
+  /** A stray file is not a project; only a project directory earns the question. */
+  @Test
+  public void aFileIsNotAProject() throws IOException {
+    final File shared = tmp.newFolder("stray");
+    final File websites = legacyTree(shared, false);
+    assertTrue(new File(websites, "notes.txt").createNewFile());
+    assertNull(StoragePaths.legacyMirrors(shared));
+  }
+
+  @Test
+  public void aLegacyProjectIsOffered() throws IOException {
+    final File shared = tmp.newFolder("real");
+    final File websites = legacyTree(shared, true);
+    assertEquals(websites, StoragePaths.legacyMirrors(shared));
   }
 }


### PR DESCRIPTION
The import offer was gated on a "have I asked before" preference and nothing else. A fresh install therefore got a question about 2017 mirrors it could not have, stacked on the storage-permission dialog beside it, and answering yes before settling that permission copied into app-private storage that an uninstall erases. Existing users were never cut off from their mirrors, so this is a question worth not asking rather than data worth recovering.

`StoragePaths.legacyMirrorRoot()` looks for the `Download/HTTrack/Websites` folder that builds before versionCode 61 wrote to, and returns it only when it holds a project with something in it. Without access the shared root is null, so it finds nothing and nothing is asked. `onResume()` asks again only when access has just appeared, the one resume that can reveal the folder, and by then the destination resolves to shared storage.