### PR TITLE
coffeecatch_cancel_pending_alarm() left the 30s watchdog armed after the block exited

### DIFF
--- a/app/src/main/jni/htslibjni.c
+++ b/app/src/main/jni/htslibjni.c
@@ -48,8 +48,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "coffeejni.h"
 
 /* COFFEE_TRY_JNI leaves coffeecatch's 30s SIGALRM watchdog armed; we report the
- * fault as a Java Error and keep running, so disarm it. After the throw, whose
- * allocations are the hang it guards, and before COFFEE_END() frees its state.
+ * fault as a Java Error and keep running, so disarm it after the throw, whose
+ * allocations are the hang it guards.
  * The body is copied from upstream's COFFEE_TRY_JNI: re-copy it if that changes. */
 #define COFFEE_TRY_JNI_RECOVER(ENV, CODE)  \
   do {                                     \

--- a/app/src/main/jni/htslibjni.c
+++ b/app/src/main/jni/htslibjni.c
@@ -48,8 +48,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "coffeejni.h"
 
 /* COFFEE_TRY_JNI leaves coffeecatch's 30s SIGALRM watchdog armed; we report the
- * fault as a Java Error and keep running, so disarm it after the throw, whose
- * allocations are the hang it guards.
+ * fault as a Java Error and keep crawling, so disarm it. Do that after the
+ * throw: allocating the exception is the hang the watchdog guards.
  * The body is copied from upstream's COFFEE_TRY_JNI: re-copy it if that changes. */
 #define COFFEE_TRY_JNI_RECOVER(ENV, CODE)  \
   do {                                     \

--- a/app/src/test/java/com/httrack/android/CoffeeCatchAlarmTest.java
+++ b/app/src/test/java/com/httrack/android/CoffeeCatchAlarmTest.java
@@ -40,7 +40,7 @@ public class CoffeeCatchAlarmTest {
     final int end = source.indexOf("COFFEE_END()");
     assertTrue("cancel must not disarm the watchdog before the throw allocates",
         thrown != -1 && cancel > thrown);
-    assertTrue("COFFEE_END() frees the state the cancel reads",
+    assertTrue("the cancel belongs inside the catch block",
         end != -1 && cancel < end);
   }
 }

--- a/app/src/test/java/com/httrack/android/CoffeeCatchAlarmTest.java
+++ b/app/src/test/java/com/httrack/android/CoffeeCatchAlarmTest.java
@@ -4,6 +4,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.junit.Test;
 
 /** A caught native fault arms coffeecatch's 30s alarm(), and SIGALRM kills the
@@ -16,8 +18,13 @@ public class CoffeeCatchAlarmTest {
 
   @Test
   public void noEntryPointUsesTheBareMacro() throws IOException {
-    assertEquals("upstream COFFEE_TRY_JNI leaves the alarm armed", 0,
-        TestSources.occurrences(jni(), "COFFEE_TRY_JNI("));
+    // "COFFEE_TRY_JNI (" is legal C, so match the call rather than a literal.
+    final Matcher m = Pattern.compile("COFFEE_TRY_JNI\\s*\\(").matcher(jni());
+    int count = 0;
+    while (m.find()) {
+      count++;
+    }
+    assertEquals("upstream COFFEE_TRY_JNI leaves the alarm armed", 0, count);
   }
 
   @Test
@@ -40,7 +47,9 @@ public class CoffeeCatchAlarmTest {
     final int end = source.indexOf("COFFEE_END()");
     assertTrue("cancel must not disarm the watchdog before the throw allocates",
         thrown != -1 && cancel > thrown);
-    assertTrue("the cancel belongs inside the catch block",
+    assertTrue("a cancel past COFFEE_END() would run on success too, and the"
+        + " pending flag is process-wide, so it would clear another thread's"
+        + " watchdog mid-throw",
         end != -1 && cancel < end);
   }
 }


### PR DESCRIPTION
Bumps the coffeecatch submodule to b934c22, which fixes `coffeecatch_cancel_pending_alarm()` returning -1 and leaving the 30-second SIGALRM armed once the protected block has exited. The pending flag lived in the per-thread state that `COFFEE_END()` frees; it now sits in the process-wide structure, next to the `alarm()` it tracks.

Nothing changes at runtime here, since `COFFEE_TRY_JNI_RECOVER` already cancels inside the catch. The reason for that placement does change, and it inverts: with a process-wide flag, a cancel moved past `COFFEE_END()` would fire on successful calls too and clear another thread's live watchdog. The comment and the test assertion message now say that instead of citing the freed state.

Fixed in passing: `noEntryPointUsesTheBareMacro` matched the literal `COFFEE_TRY_JNI(`, so writing `COFFEE_TRY_JNI (env, ...)` with a space put the alarm-leaking upstream macro back and the test still passed. It matches the call shape now. The literal form survives that mutation and the regex kills it, checked both ways.

Checked that `coffeecatch.c` and `coffeejni.c` still compile warning-clean under the module's `-W -Wall -Wextra -Werror` for arm64-v8a and x86_64 (NDK r26d), and the coffeecatch and crash unit tests pass.