### PR TITLE
Bump the vendored engine to eeba324c

### DIFF
--- a/app/src/main/jni/Android.mk
+++ b/app/src/main/jni/Android.mk
@@ -76,6 +76,7 @@ LOCAL_SRC_FILES := httrack/src/htscore.c httrack/src/htsparse.c 			\
 	httrack/src/htscache_selftest.c httrack/src/htsdns_selftest.c			\
 	httrack/src/htscodec.c httrack/src/htsproxy.c							\
 	httrack/src/htsurlport.c httrack/src/htswarc.c							\
+	httrack/src/htsescape.c										\
 	httrack/src/htsnet.c httrack/src/htsrandom.c							\
 	httrack/src/htssitemap.c httrack/src/htssinglefile.c					\
 	httrack/src/htschanges.c httrack/src/htscmdline.c						\

--- a/tools/build_strings.sh
+++ b/tools/build_strings.sh
@@ -22,12 +22,7 @@ if test $(head -5 $i | tail -1 | tr -d '\r') != "LANGUAGE_ISO"; then
 echo "bad file $i: LANGUAGE_ISO expected"
 exit 1
 fi
-if test $(head -9 $i | tail -1 | tr -d '\r') != "LANGUAGE_CHARSET"; then
-echo "bad file $i: LANGUAGE_CHARSET expected"
-exit 1
-fi
 iso=$(head -6 $i | tail -1 | tr -d '\r' | tr '_' '-' | sed -e 's/-/-r/')
-cp=$(head -10 $i | tail -1 | tr -d '\r')
 #if test "$iso" = "en"; then
 #echo "skipped"
 #continue;
@@ -35,12 +30,11 @@ cp=$(head -10 $i | tail -1 | tr -d '\r')
 dest=$2/values-${iso}
 mkdir -p $dest
 
-# read strings, converted to UTF-8, stripping CR,
+# read strings, stripping CR,
 # removing : at the end
 # replacing real & by &amp; and stripping the other ones
 # and replacing WinHTTrack by HTTrack
-cat "$i" | \
-	iconv -f "$cp" -t "utf-8" \
+cat "$i" \
 	| tr -d '\r' \
 	| sed -e 's/\\r//g' \
 	| sed -e 's/:$//' -e 's/\* //g' -e 's/\.\.\.$//g' -e 's/\([[:space:]]\)[[:space:]]*/\1/g' -e 's/[[:space:]]*$//' \


### PR DESCRIPTION
Moves the vendored engine to eeba324c, 43 commits past the current pin.

Two things in the tree have to move with it. The engine's new htsescape.c joins Android.mk's hand-maintained source list, because htstools.c is built on Android and calls into it; without the line ld.lld leaves hts_unescapehttp and hts_unescapeini undefined. And with all 30 catalogs now UTF-8 and LANGUAGE_CHARSET retired, tools/build_strings.sh loses its charset assertion, the charset read below it, and the iconv stage they fed. The iconv goes rather than being retargeted at utf-8, since macOS ships a Citrus iconv that rejects valid UTF-8.

The three parts land together by necessity: the assertion fires against the new catalogs, and dropping it ahead of the pin would let the old ones be read as UTF-8 and silently produce mojibake.

Not a release cut: versionCode and versionName are untouched, and the engine VERSIONID is still 3.49.23. If the freeze lands on a later engine commit, this branch takes a follow-up pointer move rather than a new PR.