### PR TITLE
After a caught native fault the app keeps using the damaged engine

### DIFF
--- a/app/src/main/java/com/httrack/android/CleanupActivity.java
+++ b/app/src/main/java/com/httrack/android/CleanupActivity.java
@@ -262,7 +262,7 @@ public class CleanupActivity extends ListActivity {
           try {
             HTTrackLib.buildTopIndex(projectRootFile, resourceFile);
           } catch (final Throwable t) {
-            // Recovered native fault: a stale top index must not kill the cleanup thread.
+            // The fault is latched; the cleanup still has a deletion to report.
             Log.e(getClass().getSimpleName(), "could not rebuild top index", t);
             HTTrackActivity.emergencyDump(getApplicationContext(), t);
           }

--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -2638,11 +2638,10 @@ public class HTTrackActivity extends FragmentActivity {
   }
 
   private void setPane(final int position) {
-    // Leaving the panel that reported a native fault: the engine is unusable and nothing but a
-    // new process can clear it, so the next screen has to come from one.
-    if (pane_id == LAYOUT_FINISHED && position != LAYOUT_FINISHED
-        && HTTrackLib.hasFaulted()) {
-      exitAfterNativeFault();
+    // Only a new process can clear a fault reported from this panel.
+    if (NativeFaultPolicy.closeOnPaneChange(HTTrackLib.hasFaulted(), pane_id, position,
+        LAYOUT_FINISHED)) {
+      closeAfterNativeFault();
       return;
     }
     if (pane_id != position) {
@@ -2947,13 +2946,11 @@ public class HTTrackActivity extends FragmentActivity {
         // Exit because otherwise we can't recreate the directory (!)
         if (rootWasDeleted
             && android.os.Build.VERSION.SDK_INT >= VERSION_CODES.KITKAT) {
+          // Restarting the activity is not enough; the deleted directory needs a new process.
           Log.w("httrack",
               "exiting because root path was deleted (Android >= Kitkat issue)");
-          // restartActivity();
+          exitWhenDestroyed = true;
           finish();
-          // darn, this is not clean, but otherwise restarting the activity
-          // won't be enough. I suspect FUSE-related issue here
-          System.exit(0);
         }
       }
       break;
@@ -3040,7 +3037,7 @@ public class HTTrackActivity extends FragmentActivity {
   protected void restartActivity() {
     if (HTTrackLib.hasFaulted()) {
       // Restarting the activity keeps the process, which is what the fault poisoned.
-      exitAfterNativeFault();
+      closeAfterNativeFault();
       return;
     }
     final Intent intent = getIntent();
@@ -3049,14 +3046,17 @@ public class HTTrackActivity extends FragmentActivity {
   }
 
   /**
-   * Close the app after a recovered native fault. The next launch then gets a new process, which
-   * is the only way back to a working engine.
+   * Close the app after a recovered native fault, so the next launch gets a working engine.
+   * finish() is asynchronous, so onDestroy() ends the process once it has saved the profile.
    */
-  private void exitAfterNativeFault() {
+  private void closeAfterNativeFault() {
     Log.w(getClass().getSimpleName(), "closing: the native engine faulted");
+    exitWhenDestroyed = true;
     finish();
-    System.exit(0);
   }
+
+  // Set when the process itself has to go, not just the activity.
+  private boolean exitWhenDestroyed;
 
   /**
    * "New project"
@@ -3400,6 +3400,10 @@ public class HTTrackActivity extends FragmentActivity {
       offerLegacyMirrorImportOnce();
     }
     hadStorageAccess = access;
+    if (NativeFaultPolicy.reportOnResume(HTTrackLib.hasFaulted(), pane_id, LAYOUT_FINISHED)) {
+      displayFinishedPanel("<b>Error</b>: "
+          + TextUtils.htmlEncode(getString(R.string.engine_faulted)), 0, null);
+    }
   }
 
   @Override
@@ -3436,10 +3440,11 @@ public class HTTrackActivity extends FragmentActivity {
       }
     }
     super.onDestroy();
-    // The next launch may be handed this very process, latch and all; a configuration change
-    // is not finishing, and has to keep it.
-    if (isFinishing() && HTTrackLib.hasFaulted()) {
-      exitAfterNativeFault();
+    // A relaunch can be handed this very process, latch and all.
+    if (NativeFaultPolicy.exitOnDestroy(isFinishing(), exitWhenDestroyed,
+        HTTrackLib.hasFaulted())) {
+      Log.w(getClass().getSimpleName(), "ending the process");
+      System.exit(0);
     }
   }
 

--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -3049,8 +3049,8 @@ public class HTTrackActivity extends FragmentActivity {
   }
 
   /**
-   * Close the app after a recovered native fault. Android starts a fresh process the next time
-   * the user opens HTTrack, and that is the only way back to a working engine.
+   * Close the app after a recovered native fault. The next launch then gets a new process, which
+   * is the only way back to a working engine.
    */
   private void exitAfterNativeFault() {
     Log.w(getClass().getSimpleName(), "closing: the native engine faulted");
@@ -3436,6 +3436,11 @@ public class HTTrackActivity extends FragmentActivity {
       }
     }
     super.onDestroy();
+    // The next launch may be handed this very process, latch and all; a configuration change
+    // is not finishing, and has to keep it.
+    if (isFinishing() && HTTrackLib.hasFaulted()) {
+      exitAfterNativeFault();
+    }
   }
 
   /** Navigate back to home, without killing us. **/

--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -2946,11 +2946,12 @@ public class HTTrackActivity extends FragmentActivity {
         // Exit because otherwise we can't recreate the directory (!)
         if (rootWasDeleted
             && android.os.Build.VERSION.SDK_INT >= VERSION_CODES.KITKAT) {
-          // Restarting the activity is not enough; the deleted directory needs a new process.
+          // Exit here, not from onDestroy(): its serialize() would mkdirs the tree just
+          // deleted. Restarting the activity is not enough either, a FUSE issue is suspected.
           Log.w("httrack",
               "exiting because root path was deleted (Android >= Kitkat issue)");
-          exitWhenDestroyed = true;
           finish();
+          System.exit(0);
         }
       }
       break;

--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -1216,7 +1216,7 @@ public class HTTrackActivity extends FragmentActivity {
       try {
         return HTTrackLib.buildTopIndex(getProjectRootFile(), rsc);
       } catch (final Throwable t) {
-        // Recovered native fault: a missing top index is not worth the process.
+        // The fault is latched; report it and let the app end the process on its way out.
         Log.e(getClass().getSimpleName(), "could not build top index", t);
         emergencyDump(getApplicationContext(), t);
         return 0;

--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -1339,6 +1339,7 @@ public class HTTrackActivity extends FragmentActivity {
     private String string_creating_project;
     private String string_starting_mirror;
     private String string_self_contained_conflict;
+    private String string_engine_faulted;
     private String string_mirror_finished;
 
     /**
@@ -1388,6 +1389,7 @@ public class HTTrackActivity extends FragmentActivity {
       string_starting_mirror = getParentString(R.string.starting_mirror);
       string_self_contained_conflict = getParentString(
           R.string.self_contained_conflict);
+      string_engine_faulted = getParentString(R.string.engine_faulted);
       string_mirror_finished = getParentString(R.string.mirror_finished);
 
       // Execute pending actions now we are attached
@@ -1443,6 +1445,10 @@ public class HTTrackActivity extends FragmentActivity {
         // Sanity checks
         if (parent == null) {
           throw new IOException("no parent!");
+        }
+        // A recovered fault left the engine mid-operation; only a new process clears it.
+        if (HTTrackLib.hasFaulted()) {
+          throw new IOException(string_engine_faulted);
         }
         final File target = parent.getTargetFile();
         if (target == null) {
@@ -1570,6 +1576,10 @@ public class HTTrackActivity extends FragmentActivity {
         HTTrackActivity.emergencyDump(appContext, t);
         message = "<b>Error</b>: "
             + TextUtils.htmlEncode(HTTrackActivity.describeCrash(t));
+        // Anything else here is an ordinary Java failure, which leaves the engine usable.
+        if (HTTrackLib.hasFaulted()) {
+          message += "<br /><br />" + TextUtils.htmlEncode(string_engine_faulted);
+        }
       } finally {
         // Release inter-thread lock
         if (profile != null) {
@@ -2628,6 +2638,13 @@ public class HTTrackActivity extends FragmentActivity {
   }
 
   private void setPane(final int position) {
+    // Leaving the panel that reported a native fault: the engine is unusable and nothing but a
+    // new process can clear it, so the next screen has to come from one.
+    if (pane_id == LAYOUT_FINISHED && position != LAYOUT_FINISHED
+        && HTTrackLib.hasFaulted()) {
+      exitAfterNativeFault();
+      return;
+    }
     if (pane_id != position) {
       // Leaving a pane: save data
       savePaneFields();
@@ -3021,9 +3038,24 @@ public class HTTrackActivity extends FragmentActivity {
    * Restart activity. (exit current app)
    */
   protected void restartActivity() {
+    if (HTTrackLib.hasFaulted()) {
+      // Restarting the activity keeps the process, which is what the fault poisoned.
+      exitAfterNativeFault();
+      return;
+    }
     final Intent intent = getIntent();
     finish();
     startActivity(intent);
+  }
+
+  /**
+   * Close the app after a recovered native fault. Android starts a fresh process the next time
+   * the user opens HTTrack, and that is the only way back to a working engine.
+   */
+  private void exitAfterNativeFault() {
+    Log.w(getClass().getSimpleName(), "closing: the native engine faulted");
+    finish();
+    System.exit(0);
   }
 
   /**

--- a/app/src/main/java/com/httrack/android/NativeFaultPolicy.java
+++ b/app/src/main/java/com/httrack/android/NativeFaultPolicy.java
@@ -1,0 +1,51 @@
+package com.httrack.android;
+
+/**
+ * What a recovered native fault forces on the UI. These are the decisions the activity would
+ * otherwise bury in lifecycle methods, where no test can reach them: no Android type appears
+ * here, so each one can be checked against its truth table.
+ */
+final class NativeFaultPolicy {
+  private NativeFaultPolicy() {
+  }
+
+  /**
+   * Close the app when the user leaves the panel that reported the fault.
+   *
+   * @param faulted      whether a native fault has been recovered
+   * @param currentPane  the pane being left
+   * @param nextPane     the pane asked for
+   * @param finishedPane the pane the fault is reported on
+   * @return true when the activity must finish instead of switching pane
+   */
+  static boolean closeOnPaneChange(final boolean faulted, final int currentPane,
+      final int nextPane, final int finishedPane) {
+    return faulted && currentPane == finishedPane && nextPane != finishedPane;
+  }
+
+  /**
+   * End the process, once the activity is gone for good and has saved what it holds.
+   *
+   * @param finishing     whether the activity is finishing, false for a configuration change
+   * @param exitRequested whether something already asked for the process to go
+   * @param faulted       whether a native fault has been recovered
+   * @return true when the process must not survive this destruction
+   */
+  static boolean exitOnDestroy(final boolean finishing, final boolean exitRequested,
+      final boolean faulted) {
+    return finishing && (exitRequested || faulted);
+  }
+
+  /**
+   * Report a fault that was latched away from the finished panel, where nothing else shows it.
+   *
+   * @param faulted      whether a native fault has been recovered
+   * @param currentPane  the pane on screen
+   * @param finishedPane the pane the fault is reported on
+   * @return true when the finished panel must be raised
+   */
+  static boolean reportOnResume(final boolean faulted, final int currentPane,
+      final int finishedPane) {
+    return faulted && currentPane != finishedPane;
+  }
+}

--- a/app/src/main/java/com/httrack/android/jni/HTTrackLib.java
+++ b/app/src/main/java/com/httrack/android/jni/HTTrackLib.java
@@ -80,6 +80,20 @@ public class HTTrackLib {
   public static native String getFeatures();
 
   /**
+   * Has a native fault been recovered in this process ? coffeecatch turns a SIGSEGV into a Java
+   * Error by siglongjmp'ing out of the engine, which unwinds nothing: the engine is left
+   * mid-operation and every later call to it is refused, here and natively, until the process
+   * is replaced.
+   *
+   * @return true once a fault has been caught
+   */
+  public static boolean hasFaulted() {
+    return loadDone && loadedSuccessfully() && nativeHasFaulted();
+  }
+
+  private static native boolean nativeHasFaulted();
+
+  /**
    * Build the top-level index.
    *
    * @param path          The target path;
@@ -87,6 +101,10 @@ public class HTTrackLib {
    * @return 1 upon success
    */
   public static int buildTopIndex(final File path, final File templatesPath) {
+    // Refused natively too; stopping here keeps the crash path out of JNI entirely.
+    if (hasFaulted()) {
+      return 0;
+    }
     final String p = path.getAbsolutePath() + "/";
     final String t = templatesPath.getAbsolutePath() + "/";
     return buildTopIndex(p, t);

--- a/app/src/main/java/com/httrack/android/jni/HTTrackLib.java
+++ b/app/src/main/java/com/httrack/android/jni/HTTrackLib.java
@@ -80,12 +80,9 @@ public class HTTrackLib {
   public static native String getFeatures();
 
   /**
-   * Has a native fault been recovered in this process ? coffeecatch turns a SIGSEGV into a Java
-   * Error by siglongjmp'ing out of the engine, which unwinds nothing: the engine is left
-   * mid-operation and every later call to it is refused, here and natively, until the process
-   * is replaced.
+   * Has a native fault been recovered in this process ?
    *
-   * @return true once a fault has been caught
+   * @return true once a fault has been caught, after which every engine call is refused
    */
   public static boolean hasFaulted() {
     return loadDone && loadedSuccessfully() && nativeHasFaulted();
@@ -101,7 +98,7 @@ public class HTTrackLib {
    * @return 1 upon success
    */
   public static int buildTopIndex(final File path, final File templatesPath) {
-    // Refused natively too; stopping here keeps the crash path out of JNI entirely.
+    // Refused natively too; answering here spares the callers a fault they only log.
     if (hasFaulted()) {
       return 0;
     }

--- a/app/src/main/jni/htslibjni.c
+++ b/app/src/main/jni/htslibjni.c
@@ -43,6 +43,11 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #define USE_COFFEECATCH
 
+/* A fault recovered by coffeecatch is a siglongjmp, which unwinds nothing: hts_init() ran,
+ * hts_uninit() never will, and the cache file, the sockets and any lock the faulting frame held
+ * stay as the fault left them. Latched once, refused from then on; only a new process clears it. */
+static volatile int engineFaulted = 0;
+
 #ifdef USE_COFFEECATCH
 #include "coffeecatch.h"
 #include "coffeejni.h"
@@ -56,6 +61,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
     COFFEE_TRY() {                         \
       CODE;                                \
     } COFFEE_CATCH() {                     \
+      engineFaulted = 1;                   \
       coffeecatch_throw_exception(ENV);    \
       coffeecatch_cancel_pending_alarm();  \
     } COFFEE_END();                        \
@@ -268,6 +274,17 @@ static void throwNPException(JNIEnv* env, const char *message) {
   throwException(env, "java/lang/NullPointerException", message);
 }
 
+/* Refuse an engine call made after a recovered fault, and tell Java why.
+ * @return 1 when the caller must return without touching the engine. */
+static int refuseIfFaulted(JNIEnv* env) {
+  if (engineFaulted) {
+    throwException(env, "java/lang/IllegalStateException",
+                   "the native engine faulted; it can not be used again in this process");
+    return 1;
+  }
+  return 0;
+}
+
 /* Static initialization. */
 JNICALL void Java_com_httrack_android_jni_HTTrackLib_initStatic(JNIEnv* env, jclass clazz) {
 #define L_(X) #X
@@ -424,6 +441,9 @@ JNICALL void
 Java_com_httrack_android_jni_HTTrackLib_initRootPath(JNIEnv* env,
                                                      jclass clazz,
                                                      jstring opath) {
+  if (refuseIfFaulted(env)) {
+    return;
+  }
 #ifdef USE_COFFEECATCH
   COFFEE_TRY_JNI_RECOVER(env, HTTrackLib_initRootPath(env, clazz, opath));
 #else
@@ -476,11 +496,22 @@ JNICALL jstring Java_com_httrack_android_jni_HTTrackLib_getFeatures(JNIEnv* env,
   return (*env)->NewStringUTF(env, features);
 }
 
+JNICALL jboolean Java_com_httrack_android_jni_HTTrackLib_nativeHasFaulted(JNIEnv* env,
+                                                                         jclass clazz) {
+  UNUSED(env);
+  UNUSED(clazz);
+  return engineFaulted ? JNI_TRUE : JNI_FALSE;
+}
+
 JNICALL void Java_com_httrack_android_jni_HTTrackLib_init(JNIEnv* env, jobject object) {
-  HTTrackLib_context *const context = (HTTrackLib_context*)
-      calloc(sizeof(HTTrackLib_context), 1);
+  HTTrackLib_context *context;
 
   debug("calling Java_com_httrack_android_jni_HTTrackLib_init");
+
+  if (refuseIfFaulted(env)) {
+    return;
+  }
+  context = (HTTrackLib_context*) calloc(sizeof(HTTrackLib_context), 1);
 
   if (context == NULL) {
     throwRuntimeException(env, "memory exhausted");
@@ -497,6 +528,13 @@ JNICALL void Java_com_httrack_android_jni_HTTrackLib_free(JNIEnv* env, jobject o
   HTTrackLib_context *const context = getNativeOpt(env, object);
 
   debug("calling Java_com_httrack_android_jni_HTTrackLib_free");
+
+  /* Silent, unlike the other entry points: this runs on the finalizer thread, and hts_free_opt()
+     over a faulted opt would take the engine down a second time. Leaking it costs one process. */
+  if (engineFaulted) {
+    error("not freeing the engine context: it faulted");
+    return;
+  }
 
   if (context != NULL) {
     setNativeOpt(env, object, NULL);
@@ -810,6 +848,12 @@ Java_com_httrack_android_jni_HTTrackLib_stop(JNIEnv* env, jobject object,
   HTTrackLib_context *const context = getNativeOpt(env, object);
   jboolean stopped = JNI_FALSE;
 
+  /* The fault may have happened with this very lock held, and the Stop button is a click
+     handler: taking it would hang the UI thread, and throwing would crash it. */
+  if (engineFaulted) {
+    return JNI_FALSE;
+  }
+
   if (context == NULL) {
     throwRuntimeException(env, "null context");
   }
@@ -832,6 +876,11 @@ Java_com_httrack_android_jni_HTTrackLib_abortCode(JNIEnv* env, jobject object) {
   HTTrackLib_context *const context = getNativeOpt(env, object);
   jint aborted = 0;
 
+  /* Same held-lock hazard as stop(); the crash path has its own message anyway. */
+  if (engineFaulted) {
+    return 0;
+  }
+
   if (context == NULL) {
     throwRuntimeException(env, "null context");
     return 0;
@@ -851,6 +900,11 @@ JNICALL jboolean
 Java_com_httrack_android_jni_HTTrackLib_wasStopped(JNIEnv* env, jobject object) {
   HTTrackLib_context *const context = getNativeOpt(env, object);
   jboolean stopped = JNI_FALSE;
+
+  /* Same held-lock hazard as stop(). */
+  if (engineFaulted) {
+    return JNI_FALSE;
+  }
 
   if (context == NULL) {
     throwRuntimeException(env, "null context");
@@ -897,6 +951,12 @@ static jint HTTrackLib_buildTopIndex(JNIEnv* env, jclass clazz, jstring opath,
 JNICALL jint
 Java_com_httrack_android_jni_HTTrackLib_buildTopIndex(JNIEnv* env, jclass clazz,
                                                       jstring opath, jstring otemplates) {
+  /* Refused without a throw: the Java callers dump whatever they catch here, which would
+     overwrite the dump describing the fault itself. */
+  if (engineFaulted) {
+    error("not building the top index: the engine faulted");
+    return -1;
+  }
 #ifdef USE_COFFEECATCH
   volatile jint ret = -1;
   COFFEE_TRY_JNI_RECOVER(env, ret = HTTrackLib_buildTopIndex(env, clazz, opath, otemplates));
@@ -1014,6 +1074,9 @@ jint HTTrackLib_main(JNIEnv* env, jobject object, jobjectArray stringArray) {
 JNICALL jint
 Java_com_httrack_android_jni_HTTrackLib_main(JNIEnv* env, jobject object,
                                              jobjectArray stringArray) {
+  if (refuseIfFaulted(env)) {
+    return -1;
+  }
 #ifdef USE_COFFEECATCH
   volatile jint code = -1;
   COFFEE_TRY_JNI_RECOVER(env, code = HTTrackLib_main(env, object, stringArray));

--- a/app/src/main/jni/htslibjni.c
+++ b/app/src/main/jni/htslibjni.c
@@ -43,8 +43,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #define USE_COFFEECATCH
 
-/* Recovering a fault is a siglongjmp, which unwinds nothing: the engine keeps the state, the open
- * cache file and the held lock it faulted with, so it is refused from here on. */
+/* Recovering a fault is a siglongjmp, which unwinds nothing: the engine's process-wide mutexes
+ * and the heap stay as the faulting frame left them, so the engine is refused from here on. */
 static volatile int engineFaulted = 0;
 
 #ifdef USE_COFFEECATCH
@@ -52,7 +52,7 @@ static volatile int engineFaulted = 0;
 #include "coffeejni.h"
 
 /* COFFEE_TRY_JNI leaves coffeecatch's 30s SIGALRM watchdog armed; we report the
- * fault as a Java Error and keep crawling, so disarm it. Do that after the
+ * fault as a Java Error rather than dying, so disarm it. Do that after the
  * throw: allocating the exception is the hang the watchdog guards.
  * The body is copied from upstream's COFFEE_TRY_JNI: re-copy it if that changes. */
 #define COFFEE_TRY_JNI_RECOVER(ENV, CODE)  \
@@ -60,7 +60,9 @@ static volatile int engineFaulted = 0;
     COFFEE_TRY() {                         \
       CODE;                                \
     } COFFEE_CATCH() {                     \
-      engineFaulted = 1;                   \
+      if (coffeecatch_get_signal() > 0) {  \
+        engineFaulted = 1;                 \
+      }                                    \
       coffeecatch_throw_exception(ENV);    \
       coffeecatch_cancel_pending_alarm();  \
     } COFFEE_END();                        \
@@ -507,8 +509,7 @@ JNICALL void Java_com_httrack_android_jni_HTTrackLib_init(JNIEnv* env, jobject o
 
   debug("calling Java_com_httrack_android_jni_HTTrackLib_init");
 
-  /* Silent: a throw from this constructor would take the activity down before the crawl that
-     faulted ever reports it. Every call on the object is refused anyway. */
+  /* Silent: a throw from this constructor would kill the activity before it reports the fault. */
   if (engineFaulted) {
     error("not creating an engine context: the engine faulted");
     return;
@@ -531,8 +532,8 @@ JNICALL void Java_com_httrack_android_jni_HTTrackLib_free(JNIEnv* env, jobject o
 
   debug("calling Java_com_httrack_android_jni_HTTrackLib_free");
 
-  /* Leaked on purpose: hts_free_opt() over a faulted opt would fault again, on the finalizer
-     thread this time. */
+  /* Leaked on purpose: hts_free_opt() over a faulted opt would fault again, here on the
+     finalizer thread. */
   if (engineFaulted) {
     error("not freeing the engine context: it faulted");
     return;
@@ -850,14 +851,14 @@ Java_com_httrack_android_jni_HTTrackLib_stop(JNIEnv* env, jobject object,
   HTTrackLib_context *const context = getNativeOpt(env, object);
   jboolean stopped = JNI_FALSE;
 
-  /* The fault may have happened with this very lock held, and the Stop button is a click
-     handler: taking it would hang the UI thread, and throwing would crash it. */
+  /* The fault may have left this lock held; stop() runs on the UI thread and must not block. */
   if (engineFaulted) {
     return JNI_FALSE;
   }
 
   if (context == NULL) {
     throwRuntimeException(env, "null context");
+    return JNI_FALSE;
   }
 
   MUTEX_LOCK(context->lock);
@@ -953,8 +954,7 @@ static jint HTTrackLib_buildTopIndex(JNIEnv* env, jclass clazz, jstring opath,
 JNICALL jint
 Java_com_httrack_android_jni_HTTrackLib_buildTopIndex(JNIEnv* env, jclass clazz,
                                                       jstring opath, jstring otemplates) {
-  /* Refused without a throw: the Java callers dump whatever they catch here, which would
-     overwrite the dump describing the fault itself. */
+  /* Refused without a throw: the Java callers dump what they catch, over the fault's own dump. */
   if (engineFaulted) {
     error("not building the top index: the engine faulted");
     return -1;

--- a/app/src/main/jni/htslibjni.c
+++ b/app/src/main/jni/htslibjni.c
@@ -43,9 +43,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #define USE_COFFEECATCH
 
-/* A fault recovered by coffeecatch is a siglongjmp, which unwinds nothing: hts_init() ran,
- * hts_uninit() never will, and the cache file, the sockets and any lock the faulting frame held
- * stay as the fault left them. Latched once, refused from then on; only a new process clears it. */
+/* Recovering a fault is a siglongjmp, which unwinds nothing: the engine keeps the state, the open
+ * cache file and the held lock it faulted with, so it is refused from here on. */
 static volatile int engineFaulted = 0;
 
 #ifdef USE_COFFEECATCH
@@ -508,8 +507,8 @@ JNICALL void Java_com_httrack_android_jni_HTTrackLib_init(JNIEnv* env, jobject o
 
   debug("calling Java_com_httrack_android_jni_HTTrackLib_init");
 
-  /* Silent: this is a constructor, and throwing here would take the activity down before the
-     crawl it belongs to ever gets to report the fault. Every call on the object is refused. */
+  /* Silent: a throw from this constructor would take the activity down before the crawl that
+     faulted ever reports it. Every call on the object is refused anyway. */
   if (engineFaulted) {
     error("not creating an engine context: the engine faulted");
     return;
@@ -532,8 +531,8 @@ JNICALL void Java_com_httrack_android_jni_HTTrackLib_free(JNIEnv* env, jobject o
 
   debug("calling Java_com_httrack_android_jni_HTTrackLib_free");
 
-  /* Silent, unlike the other entry points: this runs on the finalizer thread, and hts_free_opt()
-     over a faulted opt would take the engine down a second time. Leaking it costs one process. */
+  /* Leaked on purpose: hts_free_opt() over a faulted opt would fault again, on the finalizer
+     thread this time. */
   if (engineFaulted) {
     error("not freeing the engine context: it faulted");
     return;
@@ -879,7 +878,7 @@ Java_com_httrack_android_jni_HTTrackLib_abortCode(JNIEnv* env, jobject object) {
   HTTrackLib_context *const context = getNativeOpt(env, object);
   jint aborted = 0;
 
-  /* Same held-lock hazard as stop(); the crash path has its own message anyway. */
+  /* Same held-lock hazard as stop(). */
   if (engineFaulted) {
     return 0;
   }

--- a/app/src/main/jni/htslibjni.c
+++ b/app/src/main/jni/htslibjni.c
@@ -508,7 +508,10 @@ JNICALL void Java_com_httrack_android_jni_HTTrackLib_init(JNIEnv* env, jobject o
 
   debug("calling Java_com_httrack_android_jni_HTTrackLib_init");
 
-  if (refuseIfFaulted(env)) {
+  /* Silent: this is a constructor, and throwing here would take the activity down before the
+     crawl it belongs to ever gets to report the fault. Every call on the object is refused. */
+  if (engineFaulted) {
+    error("not creating an engine context: the engine faulted");
     return;
   }
   context = (HTTrackLib_context*) calloc(sizeof(HTTrackLib_context), 1);

--- a/app/src/main/jni/htslibjni.h
+++ b/app/src/main/jni/htslibjni.h
@@ -38,6 +38,9 @@ Java_com_httrack_android_jni_HTTrackLib_getVersion(JNIEnv* env, jclass clazz);
 JNIEXPORT jstring JNICALL
 Java_com_httrack_android_jni_HTTrackLib_getFeatures(JNIEnv* env, jclass clazz);
 
+JNIEXPORT jboolean JNICALL
+Java_com_httrack_android_jni_HTTrackLib_nativeHasFaulted(JNIEnv* env, jclass clazz);
+
 JNIEXPORT void JNICALL
 Java_com_httrack_android_jni_HTTrackLib_init(JNIEnv* env, jobject object);
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -244,6 +244,7 @@
     <string name="creating_project">Creating the project…</string>
     <string name="starting_mirror">Starting the mirror…</string>
     <string name="self_contained_conflict">The mirror cannot make a self-contained page two ways at once. Untick either \"Build a single-file MHTML archive\" (Log, index, cache) or \"Inline assets as data: URIs\" (Build).</string>
+    <string name="engine_faulted">The copier engine crashed and cannot run again here. HTTrack closes when you leave this screen; open it again to start another mirror.</string>
     <string name="load_default">Load default options</string>
     <string name="save_default">Save default options</string>
     <string name="reset_default">Reset to default options</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -244,7 +244,7 @@
     <string name="creating_project">Creating the project…</string>
     <string name="starting_mirror">Starting the mirror…</string>
     <string name="self_contained_conflict">The mirror cannot make a self-contained page two ways at once. Untick either \"Build a single-file MHTML archive\" (Log, index, cache) or \"Inline assets as data: URIs\" (Build).</string>
-    <string name="engine_faulted">The copier engine crashed and cannot run again here. HTTrack closes when you leave this screen; open it again to start another mirror.</string>
+    <string name="engine_faulted">The copier engine crashed, and it cannot be restarted without restarting HTTrack. The app closes when you leave this screen; open it again to mirror another site.</string>
     <string name="load_default">Load default options</string>
     <string name="save_default">Save default options</string>
     <string name="reset_default">Reset to default options</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -244,7 +244,7 @@
     <string name="creating_project">Creating the project…</string>
     <string name="starting_mirror">Starting the mirror…</string>
     <string name="self_contained_conflict">The mirror cannot make a self-contained page two ways at once. Untick either \"Build a single-file MHTML archive\" (Log, index, cache) or \"Inline assets as data: URIs\" (Build).</string>
-    <string name="engine_faulted">The copier engine crashed, and it cannot be restarted without restarting HTTrack. The app closes when you leave this screen; open it again to mirror another site.</string>
+    <string name="engine_faulted">The copier engine crashed and cannot be used again until HTTrack restarts. The app closes when you leave this screen; open it again to start a new mirror.</string>
     <string name="load_default">Load default options</string>
     <string name="save_default">Save default options</string>
     <string name="reset_default">Reset to default options</string>

--- a/app/src/test/java/com/httrack/android/CleanupActivityTest.java
+++ b/app/src/test/java/com/httrack/android/CleanupActivityTest.java
@@ -15,6 +15,18 @@ public class CleanupActivityTest {
   public final TemporaryFolder tmp = new TemporaryFolder();
 
   @Test
+  public void deletingTheRootExitsBeforeAnythingCanRecreateIt() throws Exception {
+    // onDestroy() serializes a dirty profile, and that mkdirs the project and cache directories,
+    // so this exit must not be deferred to it the way the native-fault one is.
+    final String source = TestSources.javaSource("HTTrackActivity");
+    final String deleted = TestSources.between(source, "rootPathWasDeleted", "break;");
+    assertTrue("the root-deleted path must end the process itself",
+        deleted.contains("System.exit(0)"));
+    assertFalse("deferring this exit lets onDestroy recreate the deleted tree",
+        deleted.contains("exitWhenDestroyed"));
+  }
+
+  @Test
   public void deletesANestedTreeWhole() throws Exception {
     final File root = tmp.newFolder("proj");
     final File deep = new File(new File(root, "a"), "b");

--- a/app/src/test/java/com/httrack/android/JniCallbackExceptionTest.java
+++ b/app/src/test/java/com/httrack/android/JniCallbackExceptionTest.java
@@ -15,14 +15,11 @@ public class JniCallbackExceptionTest {
     return TestSources.jniSource("htslibjni.c");
   }
 
-  /** Body of the top-level function whose signature contains NAME, up to its closing brace. */
+  /** Body of the top-level function whose signature contains NAME. */
   private static String body(final String source, final String name) {
     final int at = source.indexOf(name);
     assertTrue(name + " is gone from htslibjni.c", at != -1);
-    final int from = source.indexOf('{', at);
-    final int to = source.indexOf("\n}", from);
-    assertTrue(name + " has no closing brace", from != -1 && to > from);
-    return source.substring(from, to);
+    return TestSources.balancedBlock(source, at);
   }
 
   /** The refresh path must hand a pending exception over before it returns to the engine. */

--- a/app/src/test/java/com/httrack/android/NativeFaultLatchTest.java
+++ b/app/src/test/java/com/httrack/android/NativeFaultLatchTest.java
@@ -72,7 +72,8 @@ public class NativeFaultLatchTest {
     while (m.find()) {
       seen.add(m.group(1));
     }
-    assertTrue("no entry point parsed", seen.size() > 8);
+    assertTrue("the entry points did not parse: " + seen, seen.containsAll(Arrays.asList(
+        "main", "stop", "buildTopIndex", "init", "free", "initRootPath")));
     for (final String name : seen) {
       if (!body(source, name).contains("engineFaulted")
           && !body(source, name).contains("refuseIfFaulted")) {
@@ -148,5 +149,16 @@ public class NativeFaultLatchTest {
     final String exit = TestSources.between(source,
         "private void exitAfterNativeFault()", "\n  }");
     assertTrue("finish() alone leaves the process alive", exit.contains("System.exit(0)"));
+  }
+
+  @Test
+  public void closingTheAppDoesNotLeaveTheLatchForTheNextLaunch() throws IOException {
+    // Android hands a relaunch whatever process it kept, so finishing has to end this one.
+    // Indented two spaces: the runner fragment overrides onDestroy() as well.
+    final String destroy = TestSources.between(
+        TestSources.javaSource("HTTrackActivity"), "\n  public void onDestroy()", "\n  }");
+    assertTrue("a finished activity leaves the faulted process behind",
+        destroy.contains("isFinishing() && HTTrackLib.hasFaulted()")
+            && destroy.contains("exitAfterNativeFault()"));
   }
 }

--- a/app/src/test/java/com/httrack/android/NativeFaultLatchTest.java
+++ b/app/src/test/java/com/httrack/android/NativeFaultLatchTest.java
@@ -1,0 +1,145 @@
+package com.httrack.android;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.httrack.android.jni.HTTrackLib;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.junit.Test;
+
+/** A fault recovered by coffeecatch is a siglongjmp: the engine keeps whatever state, open cache
+ *  file and held lock it faulted with. Every entry point back into it has to refuse from then on,
+ *  and the app has to end the process rather than run on top of that. */
+public class NativeFaultLatchTest {
+  /** Entry points that may skip the latch: two constants, and the load hook that runs once
+   *  before any of this. */
+  private static final Set<String> UNGUARDED = new TreeSet<String>(Arrays.asList(
+      "getFeatures", "getVersion", "initStatic"));
+
+  private static final Pattern ENTRY_POINT = Pattern.compile(
+      "(?m)^(?:JNICALL\\s+\\w+\\s+)?Java_com_httrack_android_jni_HTTrackLib_(\\w+)\\s*\\(");
+
+  private String jni() throws IOException {
+    return TestSources.jniSource("htslibjni.c");
+  }
+
+  /** Body of the entry point NAME, braces balanced, the outer pair left out. */
+  private static String body(final String source, final String name) {
+    final Matcher m = ENTRY_POINT.matcher(source);
+    while (m.find()) {
+      if (!m.group(1).equals(name)) {
+        continue;
+      }
+      final int from = source.indexOf('{', m.end());
+      int depth = 0;
+      for (int i = from; i < source.length(); i++) {
+        if (source.charAt(i) == '{') {
+          depth++;
+        } else if (source.charAt(i) == '}' && --depth == 0) {
+          return source.substring(from + 1, i);
+        }
+      }
+      throw new IllegalStateException(name + " has no closing brace");
+    }
+    throw new IllegalStateException("no entry point " + name);
+  }
+
+  @Test
+  public void theLatchIsSetBeforeTheExceptionIsAllocated() throws IOException {
+    final String macro = TestSources.between(jni(),
+        "#define COFFEE_TRY_JNI_RECOVER", "#include \"htslibjni.h\"");
+    final int latched = macro.indexOf("engineFaulted = 1");
+    final int thrown = macro.indexOf("coffeecatch_throw_exception(ENV)");
+    assertTrue("the fault must be latched inside COFFEE_CATCH", latched != -1);
+    assertTrue("allocating the exception is what the watchdog may kill us over,"
+        + " and a fault we did not latch is a fault we would keep running on",
+        thrown > latched);
+  }
+
+  @Test
+  public void everyEntryPointReachingTheEngineReadsTheLatch() throws IOException {
+    final String source = jni();
+    final Set<String> unguarded = new TreeSet<String>();
+    final Set<String> seen = new LinkedHashSet<String>();
+    final Matcher m = ENTRY_POINT.matcher(source);
+    while (m.find()) {
+      seen.add(m.group(1));
+    }
+    assertTrue("no entry point parsed", seen.size() > 8);
+    for (final String name : seen) {
+      if (!body(source, name).contains("engineFaulted")
+          && !body(source, name).contains("refuseIfFaulted")) {
+        unguarded.add(name);
+      }
+    }
+    assertEquals(UNGUARDED, unguarded);
+  }
+
+  @Test
+  public void theCallsTheUiThreadMakesRefuseWithoutTakingTheEngineLock()
+      throws IOException {
+    final String source = jni();
+    // Stop is a click handler, and free() runs on the finalizer thread: the fault may have
+    // happened with that very lock held, so neither may take it, and neither may throw.
+    for (final String name : new String[] { "stop", "abortCode", "wasStopped", "free" }) {
+      final String body = body(source, name);
+      final int latch = body.indexOf("engineFaulted");
+      final int locked = body.indexOf("MUTEX_LOCK");
+      assertTrue(name + " must read the latch", latch != -1);
+      assertTrue(name + " must refuse before it takes the lock",
+          locked == -1 || latch < locked);
+      assertFalse(name + " must not throw into a click handler",
+          body.contains("refuseIfFaulted"));
+    }
+  }
+
+  @Test
+  public void buildingTheTopIndexRefusesWithoutThrowing() throws IOException {
+    // Its Java callers dump what they catch, over the dump that describes the fault itself.
+    assertFalse(body(jni(), "buildTopIndex").contains("refuseIfFaulted"));
+    final String java = TestSources.javaSource("jni/HTTrackLib");
+    final String method = TestSources.between(java,
+        "public static int buildTopIndex(final File path", "final String p =");
+    assertTrue("the Java side has to refuse before it enters JNI at all",
+        method.contains("hasFaulted()"));
+  }
+
+  @Test
+  public void theLatchIsReadableBeforeTheLibrariesAreLoaded() {
+    // Called from setPane(), which runs whether or not the native side ever loaded.
+    assertFalse(HTTrackLib.hasFaulted());
+  }
+
+  @Test
+  public void aFaultedEngineIsNeverAskedForAnotherMirror() throws IOException {
+    final String source = TestSources.javaSource("HTTrackActivity");
+    final String run = TestSources.between(source, "protected void runInternal()",
+        "final int code = engine.main(cargs)");
+    assertTrue("runInternal must refuse before it starts the engine",
+        run.contains("HTTrackLib.hasFaulted()"));
+  }
+
+  @Test
+  public void leavingTheErrorPanelEndsTheProcess() throws IOException {
+    final String source = TestSources.javaSource("HTTrackActivity");
+    final String pane = TestSources.between(source, "private void setPane(final int position)",
+        "if (pane_id != position)");
+    assertTrue("nothing may run past the error panel in this process",
+        pane.contains("HTTrackLib.hasFaulted()")
+            && pane.contains("exitAfterNativeFault()"));
+    final String restart = TestSources.between(source, "protected void restartActivity()",
+        "final Intent intent");
+    assertTrue("restarting the activity keeps the process the fault poisoned",
+        restart.contains("exitAfterNativeFault()"));
+    final String exit = TestSources.between(source,
+        "private void exitAfterNativeFault()", "\n  }");
+    assertTrue("finish() alone leaves the process alive", exit.contains("System.exit(0)"));
+  }
+}

--- a/app/src/test/java/com/httrack/android/NativeFaultLatchTest.java
+++ b/app/src/test/java/com/httrack/android/NativeFaultLatchTest.java
@@ -26,41 +26,53 @@ public class NativeFaultLatchTest {
   private static final Pattern ENTRY_POINT = Pattern.compile(
       "(?m)^(?:JNICALL\\s+\\w+\\s+)?Java_com_httrack_android_jni_HTTrackLib_(\\w+)\\s*\\(");
 
+  /** htslibjni.c with comments and string literals blanked, so a commented-out guard cannot
+   *  pass for one. */
   private String jni() throws IOException {
-    return TestSources.jniSource("htslibjni.c");
+    return TestSources.withoutCommentsAndStrings(TestSources.jniSource("htslibjni.c"));
   }
 
   /** Body of the entry point NAME, braces balanced, the outer pair left out. */
   private static String body(final String source, final String name) {
     final Matcher m = ENTRY_POINT.matcher(source);
     while (m.find()) {
-      if (!m.group(1).equals(name)) {
-        continue;
+      if (m.group(1).equals(name)) {
+        return TestSources.balancedBlock(source, m.end());
       }
-      final int from = source.indexOf('{', m.end());
-      int depth = 0;
-      for (int i = from; i < source.length(); i++) {
-        if (source.charAt(i) == '{') {
-          depth++;
-        } else if (source.charAt(i) == '}' && --depth == 0) {
-          return source.substring(from + 1, i);
-        }
-      }
-      throw new IllegalStateException(name + " has no closing brace");
     }
     throw new IllegalStateException("no entry point " + name);
   }
 
+  /** The body of the CONDITION block inside the entry point NAME. */
+  private static String blockBody(final String source, final String name,
+      final String condition) {
+    final String body = body(source, name);
+    final int at = body.indexOf(condition);
+    assertTrue(name + " must test " + condition, at != -1);
+    return TestSources.balancedBlock(body, at);
+  }
+
+  /** The body of NAME's `if (engineFaulted)` block, which is what has to refuse. */
+  private static String guardBody(final String source, final String name) {
+    return blockBody(source, name, "if (engineFaulted)");
+  }
+
   @Test
-  public void theLatchIsSetBeforeTheExceptionIsAllocated() throws IOException {
+  public void theLatchIsSetInTheCatchArmBeforeTheExceptionIsAllocated() throws IOException {
     final String macro = TestSources.between(jni(),
-        "#define COFFEE_TRY_JNI_RECOVER", "#include \"htslibjni.h\"");
+        "#define COFFEE_TRY_JNI_RECOVER", "#endif");
+    final int caught = macro.indexOf("COFFEE_CATCH()");
     final int latched = macro.indexOf("engineFaulted = 1");
     final int thrown = macro.indexOf("coffeecatch_throw_exception(ENV)");
-    assertTrue("the fault must be latched inside COFFEE_CATCH", latched != -1);
+    assertTrue("latching in the COFFEE_TRY arm would refuse the first call",
+        caught != -1 && latched > caught);
     assertTrue("allocating the exception is what the watchdog may kill us over,"
         + " and a fault we did not latch is a fault we would keep running on",
         thrown > latched);
+    // COFFEE_CATCH is also entered when coffeecatch_setup() fails, with no signal delivered.
+    final int signal = macro.indexOf("coffeecatch_get_signal()");
+    assertTrue("a setup failure must not latch an engine that never faulted",
+        signal != -1 && signal < latched);
   }
 
   @Test
@@ -89,8 +101,10 @@ public class NativeFaultLatchTest {
     // stop() is a click handler, free() the finalizer thread, and init() a constructor whose
     // throw would take the activity down before the crawl reports the fault at all.
     for (final String name : new String[] { "stop", "abortCode", "wasStopped", "free", "init" }) {
-      assertFalse(name + " must refuse without an exception",
-          body(source, name).contains("refuseIfFaulted"));
+      final String guard = guardBody(source, name);
+      assertFalse(name + " must refuse without an exception", guard.contains("throw"));
+      assertTrue(name + " must return from the guard, not fall through it",
+          guard.contains("return"));
     }
   }
 
@@ -100,11 +114,23 @@ public class NativeFaultLatchTest {
     // The fault may have happened with that very lock held, and stop() is called from the UI.
     for (final String name : new String[] { "stop", "abortCode", "wasStopped" }) {
       final String body = body(source, name);
-      final int latch = body.indexOf("engineFaulted");
+      final int latch = body.indexOf("if (engineFaulted)");
       final int locked = body.indexOf("MUTEX_LOCK");
-      assertTrue(name + " must read the latch", latch != -1);
+      assertTrue(name + " must refuse on the latch being SET, not cleared", latch != -1);
       assertTrue(name + " must refuse before it takes the lock",
           locked != -1 && latch < locked);
+      assertTrue(name + " must return before the lock",
+          guardBody(source, name).contains("return"));
+    }
+  }
+
+  @Test
+  public void aNullContextNeverReachesTheLock() throws IOException {
+    // Throwing does not return: without one, the next line dereferences the NULL it just refused.
+    final String source = jni();
+    for (final String name : new String[] { "stop", "abortCode", "wasStopped" }) {
+      assertTrue(name + " must return after refusing a null context",
+          blockBody(source, name, "if (context == NULL)").contains("return"));
     }
   }
 
@@ -140,15 +166,36 @@ public class NativeFaultLatchTest {
     final String pane = TestSources.between(source, "private void setPane(final int position)",
         "if (pane_id != position)");
     assertTrue("nothing may run past the error panel in this process",
-        pane.contains("HTTrackLib.hasFaulted()")
-            && pane.contains("exitAfterNativeFault()"));
+        pane.contains("NativeFaultPolicy.closeOnPaneChange(")
+            && pane.contains("closeAfterNativeFault()"));
     final String restart = TestSources.between(source, "protected void restartActivity()",
         "final Intent intent");
     assertTrue("restarting the activity keeps the process the fault poisoned",
-        restart.contains("exitAfterNativeFault()"));
-    final String exit = TestSources.between(source,
-        "private void exitAfterNativeFault()", "\n  }");
-    assertTrue("finish() alone leaves the process alive", exit.contains("System.exit(0)"));
+        restart.contains("closeAfterNativeFault()"));
+    // finish() only schedules the destroy, so exiting here would beat onDestroy's serialize().
+    final String close = TestSources.between(source,
+        "private void closeAfterNativeFault()", "\n  }");
+    assertFalse("the exit belongs in onDestroy, after the profile is saved",
+        close.contains("System.exit"));
+  }
+
+  @Test
+  public void everyNativeDeclarationHasItsCDefinition() throws IOException {
+    // A name that does not match is an UnsatisfiedLinkError on the first call, and hasFaulted()
+    // is now called from setPane() and onDestroy() on an ordinary run.
+    final String java = TestSources.javaSource("jni/HTTrackLib");
+    final Matcher declared = Pattern.compile(
+        "native\\s+(?:\\w+\\s+)*?(\\w+)\\s*\\(").matcher(java);
+    final Set<String> names = new TreeSet<String>();
+    while (declared.find()) {
+      names.add(declared.group(1));
+    }
+    assertTrue("no native declaration parsed", names.size() >= 8);
+    final String source = jni();
+    for (final String name : names) {
+      assertTrue("no C definition for native " + name,
+          source.contains("Java_com_httrack_android_jni_HTTrackLib_" + name + "("));
+    }
   }
 
   @Test
@@ -158,7 +205,9 @@ public class NativeFaultLatchTest {
     final String destroy = TestSources.between(
         TestSources.javaSource("HTTrackActivity"), "\n  public void onDestroy()", "\n  }");
     assertTrue("a finished activity leaves the faulted process behind",
-        destroy.contains("isFinishing() && HTTrackLib.hasFaulted()")
-            && destroy.contains("exitAfterNativeFault()"));
+        destroy.contains("NativeFaultPolicy.exitOnDestroy(")
+            && destroy.contains("System.exit(0)"));
+    assertTrue("the exit must follow the profile save, not precede it",
+        destroy.indexOf("serialize()") < destroy.indexOf("System.exit(0)"));
   }
 }

--- a/app/src/test/java/com/httrack/android/NativeFaultLatchTest.java
+++ b/app/src/test/java/com/httrack/android/NativeFaultLatchTest.java
@@ -83,20 +83,27 @@ public class NativeFaultLatchTest {
   }
 
   @Test
-  public void theCallsTheUiThreadMakesRefuseWithoutTakingTheEngineLock()
-      throws IOException {
+  public void theEntryPointsThatCannotThrowRefuseQuietly() throws IOException {
     final String source = jni();
-    // Stop is a click handler, and free() runs on the finalizer thread: the fault may have
-    // happened with that very lock held, so neither may take it, and neither may throw.
-    for (final String name : new String[] { "stop", "abortCode", "wasStopped", "free" }) {
+    // stop() is a click handler, free() the finalizer thread, and init() a constructor whose
+    // throw would take the activity down before the crawl reports the fault at all.
+    for (final String name : new String[] { "stop", "abortCode", "wasStopped", "free", "init" }) {
+      assertFalse(name + " must refuse without an exception",
+          body(source, name).contains("refuseIfFaulted"));
+    }
+  }
+
+  @Test
+  public void theEngineLockIsNeverTakenAfterAFault() throws IOException {
+    final String source = jni();
+    // The fault may have happened with that very lock held, and stop() is called from the UI.
+    for (final String name : new String[] { "stop", "abortCode", "wasStopped" }) {
       final String body = body(source, name);
       final int latch = body.indexOf("engineFaulted");
       final int locked = body.indexOf("MUTEX_LOCK");
       assertTrue(name + " must read the latch", latch != -1);
       assertTrue(name + " must refuse before it takes the lock",
-          locked == -1 || latch < locked);
-      assertFalse(name + " must not throw into a click handler",
-          body.contains("refuseIfFaulted"));
+          locked != -1 && latch < locked);
     }
   }
 

--- a/app/src/test/java/com/httrack/android/NativeFaultPolicyTest.java
+++ b/app/src/test/java/com/httrack/android/NativeFaultPolicyTest.java
@@ -1,0 +1,71 @@
+package com.httrack.android;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/** Truth tables for the decisions a recovered fault forces. The source-text tests next door
+ *  prove the activity delegates here; these prove the answers. */
+public class NativeFaultPolicyTest {
+  private static final int FINISHED = 4;
+  private static final int SETUP = 1;
+  private static final int PROGRESS = 3;
+
+  @Test
+  public void nothingClosesWhileTheEngineIsHealthy() {
+    for (final int from : new int[] { SETUP, PROGRESS, FINISHED }) {
+      for (final int to : new int[] { SETUP, PROGRESS, FINISHED }) {
+        assertFalse(from + "->" + to,
+            NativeFaultPolicy.closeOnPaneChange(false, from, to, FINISHED));
+      }
+    }
+  }
+
+  @Test
+  public void onlyLeavingTheReportingPanelCloses() {
+    assertTrue(NativeFaultPolicy.closeOnPaneChange(true, FINISHED, SETUP, FINISHED));
+    assertTrue(NativeFaultPolicy.closeOnPaneChange(true, FINISHED, PROGRESS, FINISHED));
+    // Raising the panel, and re-entering it after a rotation, must both survive.
+    assertFalse(NativeFaultPolicy.closeOnPaneChange(true, FINISHED, FINISHED, FINISHED));
+    assertFalse(NativeFaultPolicy.closeOnPaneChange(true, PROGRESS, FINISHED, FINISHED));
+    // A recreated activity restores its pane from -1, before it has one.
+    assertFalse(NativeFaultPolicy.closeOnPaneChange(true, -1, FINISHED, FINISHED));
+    assertFalse(NativeFaultPolicy.closeOnPaneChange(true, -1, SETUP, FINISHED));
+  }
+
+  @Test
+  public void aConfigurationChangeKeepsTheProcess() {
+    // isFinishing() is false for a rotation, whatever else is true.
+    assertFalse(NativeFaultPolicy.exitOnDestroy(false, true, true));
+    assertFalse(NativeFaultPolicy.exitOnDestroy(false, false, true));
+    assertFalse(NativeFaultPolicy.exitOnDestroy(false, true, false));
+  }
+
+  @Test
+  public void aFinishAfterAFaultOrOnRequestEndsTheProcess() {
+    assertTrue(NativeFaultPolicy.exitOnDestroy(true, false, true));
+    assertTrue(NativeFaultPolicy.exitOnDestroy(true, true, false));
+    assertTrue(NativeFaultPolicy.exitOnDestroy(true, true, true));
+    // An ordinary exit from a healthy app is still an ordinary exit.
+    assertFalse(NativeFaultPolicy.exitOnDestroy(true, false, false));
+  }
+
+  @Test
+  public void aFaultLatchedAwayFromTheReportingPanelIsRaised() {
+    // A cleanup or a browse-all rebuild latches with nothing on screen to say so.
+    assertTrue(NativeFaultPolicy.reportOnResume(true, SETUP, FINISHED));
+    assertTrue(NativeFaultPolicy.reportOnResume(true, PROGRESS, FINISHED));
+    // Already reported: raising it again would loop on every resume.
+    assertFalse(NativeFaultPolicy.reportOnResume(true, FINISHED, FINISHED));
+    assertFalse(NativeFaultPolicy.reportOnResume(false, SETUP, FINISHED));
+  }
+
+  @Test
+  public void closingAndExitingAreNotTheSameQuestion() {
+    // Leaving the panel closes the activity; only the destruction ends the process.
+    assertTrue(NativeFaultPolicy.closeOnPaneChange(true, FINISHED, SETUP, FINISHED));
+    assertEquals(false, NativeFaultPolicy.exitOnDestroy(false, true, true));
+  }
+}

--- a/app/src/test/java/com/httrack/android/TestSources.java
+++ b/app/src/test/java/com/httrack/android/TestSources.java
@@ -105,6 +105,58 @@ final class TestSources {
     return source.substring(from, to);
   }
 
+  /** SOURCE from the first '{' at or after AT up to its matching '}', both left out. Comments
+   *  and string literals must be blanked first, or their braces are counted. */
+  static String balancedBlock(final String source, final int at) {
+    final int from = source.indexOf('{', at);
+    if (from == -1) {
+      throw new IllegalStateException("no block at offset " + at);
+    }
+    int depth = 0;
+    for (int i = from; i < source.length(); i++) {
+      if (source.charAt(i) == '{') {
+        depth++;
+      } else if (source.charAt(i) == '}' && --depth == 0) {
+        return source.substring(from + 1, i);
+      }
+    }
+    throw new IllegalStateException("block at offset " + from + " never closes");
+  }
+
+  /** SOURCE with C comments and string and character literals replaced by spaces, keeping every
+   *  offset and line. A commented-out statement then reads as what it is, not as code. */
+  static String withoutCommentsAndStrings(final String source) {
+    final char[] out = source.toCharArray();
+    for (int i = 0; i < out.length; i++) {
+      final char c = out[i];
+      final int start = i;
+      if (c == '/' && i + 1 < out.length && out[i + 1] == '/') {
+        while (i < out.length && out[i] != '\n') {
+          i++;
+        }
+      } else if (c == '/' && i + 1 < out.length && out[i + 1] == '*') {
+        for (i += 2; i < out.length
+            && !(out[i] == '*' && i + 1 < out.length && out[i + 1] == '/'); i++) {
+        }
+        i = Math.min(i + 1, out.length - 1);
+      } else if (c == '"' || c == '\'') {
+        for (i++; i < out.length && out[i] != c; i++) {
+          if (out[i] == '\\') {
+            i++;
+          }
+        }
+      } else {
+        continue;
+      }
+      for (int j = start; j <= i && j < out.length; j++) {
+        if (out[j] != '\n') {
+          out[j] = ' ';
+        }
+      }
+    }
+    return new String(out);
+  }
+
   static int occurrences(final String source, final String text) {
     int count = 0;
     for (int at = source.indexOf(text); at != -1; at = source.indexOf(text,


### PR DESCRIPTION
A recovered native fault is a `siglongjmp`: nothing unwinds. The engine's process-wide mutexes and the heap stay as the faulting frame left them, and the lock the crawl held is never released. We reported the fault and went on using that engine.

The fault is now latched where it is caught, and every entry point back into the engine refuses from then on. The ones that cannot throw refuse quietly and without taking that lock: `stop()` (click handler), `free()` (finalizer) and `init()` (constructor). A crawl is refused before it starts, the panel says why, and the process ends when the activity finishes, after `onDestroy()` has saved the profile.

`NativeFaultPolicy` holds the three decisions this puts on the UI, so a truth table can reach them without a device. One pre-existing bug came along: `stop()` threw "null context" without returning, then dereferenced it on the next line.

Closes #161