### PR TITLE
Bump the vendored engine, whose aborted mirrors now exit 3 instead of 0

### DIFF
--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -1517,9 +1517,9 @@ public class HTTrackActivity extends FragmentActivity {
             : engine.wasStopped() ? MirrorOutcome.Stop.ENGINE : MirrorOutcome.Stop.NONE;
         pendingWork = leavesPendingWork(stop != MirrorOutcome.Stop.NONE, code);
 
-        // Result
-        if (code == 0) {
-          final MirrorOutcome outcome = MirrorOutcome.of(stop, engine.abortCode(),
+        // An aborted mirror still ran, so it earns a verdict and the folder link.
+        if (code == 0 || code == MirrorOutcome.EXIT_MIRROR_ABORTED) {
+          final MirrorOutcome outcome = MirrorOutcome.of(stop, code, engine.abortCode(),
               lastStats);
           switch (outcome) {
           case INTERRUPTED:

--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -1518,9 +1518,9 @@ public class HTTrackActivity extends FragmentActivity {
         pendingWork = leavesPendingWork(stop != MirrorOutcome.Stop.NONE, code);
 
         // An aborted mirror still ran, so it earns a verdict and the folder link.
-        if (code == 0 || code == MirrorOutcome.EXIT_MIRROR_ABORTED) {
-          final MirrorOutcome outcome = MirrorOutcome.of(stop, code, engine.abortCode(),
-              lastStats);
+        if (MirrorOutcome.mirrorRan(code)) {
+          final MirrorOutcome outcome = MirrorOutcome.of(stop, MirrorOutcome.mirrorAborted(code),
+              engine.abortCode(), lastStats);
           switch (outcome) {
           case INTERRUPTED:
             message = "<b>Interrupted</b>! (" + lastStats.errorsCount

--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -1517,50 +1517,14 @@ public class HTTrackActivity extends FragmentActivity {
             : engine.wasStopped() ? MirrorOutcome.Stop.ENGINE : MirrorOutcome.Stop.NONE;
         pendingWork = leavesPendingWork(stop != MirrorOutcome.Stop.NONE, code);
 
-        // An aborted mirror still ran, so it earns a verdict and the folder link.
-        if (MirrorOutcome.mirrorRan(code)) {
-          final MirrorOutcome outcome = MirrorOutcome.of(stop, MirrorOutcome.mirrorAborted(code),
-              engine.abortCode(), lastStats);
-          switch (outcome) {
-          case INTERRUPTED:
-            message = "<b>Interrupted</b>! (" + lastStats.errorsCount
-                + " errors)";
-            break;
-          case STOPPED_AT_LIMIT:
-            message = "<b>Stopped</b>! (size or time limit reached, "
-                + lastStats.errorsCount + " errors)";
-            break;
-          case ABORTED_FATAL:
-            message = "<b>Aborted</b>! (out of disk space, too many links, or"
-                + " another fatal error)";
-            break;
-          case ABORTED_ROLLBACK:
-            message = "<b>Aborted</b>! (nothing was transferred, so the mirror"
-                + " was left as it was)";
-            break;
-          case ABORTED_OTHER:
-            message = "<b>Aborted</b>! (the engine could not continue)";
-            break;
-          case SUCCESS:
-            message = "<b>Success</b>!";
-            break;
-          case SUCCESS_WITH_ERRORS:
-            message = "<b>Success</b>! (" + lastStats.errorsCount + " errors)";
-            break;
-          case FAILED:
-            message = "<b>Failed</b>! (" + lastStats.errorsCount
-                + " errors, no files written)";
-            break;
-          default:
-            // No build-time check catches a new constant; a null message would ship as "null".
-            throw new IllegalStateException(outcome.name());
-          }
+        final MirrorOutcome.Verdict verdict = MirrorOutcome.decide(code, stop,
+            engine.abortCode(), lastStats);
+        message = verdict.text();
+        if (verdict.showsFolderLink()) {
           mirrorFolder = target;
           message += "<br /><br />Mirror copied in <i><a href=\""
               + MIRROR_FOLDER_HREF + "\">"
               + TextUtils.htmlEncode(target.getAbsolutePath()) + "</a></i>";
-        } else {
-          message = "<b>Error</b> (<i>code " + code + "</i>)";
         }
 
         // Build top index

--- a/app/src/main/java/com/httrack/android/MirrorOutcome.java
+++ b/app/src/main/java/com/httrack/android/MirrorOutcome.java
@@ -1,5 +1,6 @@
 package com.httrack.android;
 
+import com.httrack.android.jni.HTTrackLib;
 import com.httrack.android.jni.HTTrackStats;
 
 /**
@@ -36,19 +37,23 @@ enum MirrorOutcome {
   static final int ABORT_FATAL = -1;
   static final int ABORT_ROLLBACK = 2;
 
-  /**
-   * The engine's HTS_EXIT_MIRROR_ABORTED, since 3.50: a mirror started and did not finish. A
-   * channel of its own, which abortCode() contradicts where the engine named no cause.
-   */
-  static final int EXIT_MIRROR_ABORTED = 3;
+  /** Whether the engine ran a mirror at all, rather than refusing the command line. */
+  static boolean mirrorRan(final int engineCode) {
+    return engineCode == 0 || engineCode == HTTrackLib.EXIT_MIRROR_ABORTED;
+  }
+
+  /** Whether the engine gave up on a mirror it had started. */
+  static boolean mirrorAborted(final int engineCode) {
+    return engineCode == HTTrackLib.EXIT_MIRROR_ABORTED;
+  }
 
   /**
-   * Weigh STOP, ENGINECODE from HTTrackLib.main() and ABORTCODE from HTTrackLib.abortCode()
+   * Weigh STOP, ENGINEABORTED from mirrorAborted() and ABORTCODE from HTTrackLib.abortCode()
    * against what the run recorded. A user stop must come first: it sets the engine's abort flag
    * two ways of its own, so the verdict alone reads it as an abort nobody asked for. An abort
    * outranks a cap, because reaching a cap also makes the engine report itself stopped.
    */
-  static MirrorOutcome of(final Stop stop, final int engineCode, final int abortCode,
+  static MirrorOutcome of(final Stop stop, final boolean engineAborted, final int abortCode,
       final HTTrackStats stats) {
     if (stop == Stop.USER) {
       return INTERRUPTED;
@@ -63,8 +68,8 @@ enum MirrorOutcome {
       default:
         return ABORTED_OTHER;
     }
-    // Some startup failures abort without setting a cause, leaving the code the only witness.
-    if (engineCode == EXIT_MIRROR_ABORTED) {
+    // A few engine guards give up without setting a cause; only the exit code shows it.
+    if (engineAborted) {
       return ABORTED_OTHER;
     }
     if (stop == Stop.ENGINE) {

--- a/app/src/main/java/com/httrack/android/MirrorOutcome.java
+++ b/app/src/main/java/com/httrack/android/MirrorOutcome.java
@@ -37,12 +37,19 @@ enum MirrorOutcome {
   static final int ABORT_ROLLBACK = 2;
 
   /**
-   * Weigh STOP and ABORTCODE, from HTTrackLib.abortCode(), against what the run recorded. A user
-   * stop must come first: it sets the engine's abort flag two ways of its own, so the verdict
-   * alone reads it as an abort nobody asked for. An abort outranks a cap, because reaching a cap
-   * also makes the engine report itself stopped.
+   * The engine's HTS_EXIT_MIRROR_ABORTED, since 3.50: a mirror started and did not finish. A
+   * channel of its own, which abortCode() contradicts where the engine named no cause.
    */
-  static MirrorOutcome of(final Stop stop, final int abortCode, final HTTrackStats stats) {
+  static final int EXIT_MIRROR_ABORTED = 3;
+
+  /**
+   * Weigh STOP, ENGINECODE from HTTrackLib.main() and ABORTCODE from HTTrackLib.abortCode()
+   * against what the run recorded. A user stop must come first: it sets the engine's abort flag
+   * two ways of its own, so the verdict alone reads it as an abort nobody asked for. An abort
+   * outranks a cap, because reaching a cap also makes the engine report itself stopped.
+   */
+  static MirrorOutcome of(final Stop stop, final int engineCode, final int abortCode,
+      final HTTrackStats stats) {
     if (stop == Stop.USER) {
       return INTERRUPTED;
     }
@@ -55,6 +62,10 @@ enum MirrorOutcome {
         return ABORTED_ROLLBACK;
       default:
         return ABORTED_OTHER;
+    }
+    // Some startup failures abort without setting a cause, leaving the code the only witness.
+    if (engineCode == EXIT_MIRROR_ABORTED) {
+      return ABORTED_OTHER;
     }
     if (stop == Stop.ENGINE) {
       return STOPPED_AT_LIMIT;

--- a/app/src/main/java/com/httrack/android/MirrorOutcome.java
+++ b/app/src/main/java/com/httrack/android/MirrorOutcome.java
@@ -37,6 +37,62 @@ enum MirrorOutcome {
   static final int ABORT_FATAL = -1;
   static final int ABORT_ROLLBACK = 2;
 
+  /** What the finish pane says about a run, and whether a mirror exists for it to link to. */
+  static final class Verdict {
+    private final String text;
+    private final boolean showsFolderLink;
+
+    Verdict(final String text, final boolean showsFolderLink) {
+      this.text = text;
+      this.showsFolderLink = showsFolderLink;
+    }
+
+    String text() {
+      return text;
+    }
+
+    boolean showsFolderLink() {
+      return showsFolderLink;
+    }
+  }
+
+  /**
+   * Weigh the run and say what the pane shows. A command line the engine refused mirrored
+   * nothing, so it gets its bare code and no link; everything else ran, an abort included.
+   */
+  static Verdict decide(final int engineCode, final Stop stop, final int abortCode,
+      final HTTrackStats stats) {
+    if (!mirrorRan(engineCode)) {
+      return new Verdict("<b>Error</b> (<i>code " + engineCode + "</i>)", false);
+    }
+    return new Verdict(
+        describe(of(stop, mirrorAborted(engineCode), abortCode, stats), stats), true);
+  }
+
+  private static String describe(final MirrorOutcome outcome, final HTTrackStats stats) {
+    switch (outcome) {
+    case INTERRUPTED:
+      return "<b>Interrupted</b>! (" + stats.errorsCount + " errors)";
+    case STOPPED_AT_LIMIT:
+      return "<b>Stopped</b>! (size or time limit reached, " + stats.errorsCount + " errors)";
+    case ABORTED_FATAL:
+      return "<b>Aborted</b>! (out of disk space, too many links, or another fatal error)";
+    case ABORTED_ROLLBACK:
+      return "<b>Aborted</b>! (nothing was transferred, so the mirror was left as it was)";
+    case ABORTED_OTHER:
+      return "<b>Aborted</b>! (the engine could not continue)";
+    case SUCCESS:
+      return "<b>Success</b>!";
+    case SUCCESS_WITH_ERRORS:
+      return "<b>Success</b>! (" + stats.errorsCount + " errors)";
+    case FAILED:
+      return "<b>Failed</b>! (" + stats.errorsCount + " errors, no files written)";
+    default:
+      // No build-time check catches a new constant; a null message would ship as "null".
+      throw new IllegalStateException(outcome.name());
+    }
+  }
+
   /** Whether the engine ran a mirror at all, rather than refusing the command line. */
   static boolean mirrorRan(final int engineCode) {
     return engineCode == 0 || engineCode == HTTrackLib.EXIT_MIRROR_ABORTED;

--- a/app/src/main/java/com/httrack/android/MirrorOutcome.java
+++ b/app/src/main/java/com/httrack/android/MirrorOutcome.java
@@ -4,7 +4,7 @@ import com.httrack.android.jni.HTTrackLib;
 import com.httrack.android.jni.HTTrackStats;
 
 /**
- * What a finished crawl actually was. Kept free of android.* so the choice can be tested; the
+ * What a finished crawl actually was. Kept apart from the pane so the choice can be tested; the
  * wording that goes with each case belongs to the caller.
  */
 enum MirrorOutcome {

--- a/app/src/main/java/com/httrack/android/jni/HTTrackLib.java
+++ b/app/src/main/java/com/httrack/android/jni/HTTrackLib.java
@@ -108,10 +108,17 @@ public class HTTrackLib {
   }
 
   /**
+   * The engine's HTS_EXIT_MIRROR_ABORTED: a mirror started and it gave up. Must stay a
+   * compile-time constant, so that reading it does not load this class under plain JUnit.
+   */
+  public static final int EXIT_MIRROR_ABORTED = 3;
+
+  /**
    * Start the engine.
    *
    * @param args main() arguments.
-   * @return The exit code upon completion.
+   * @return 0 once the mirror ended, including one the caller stopped, EXIT_MIRROR_ABORTED for
+   * one the engine gave up on, and -1 or 1 for a command line it refused before mirroring
    * @throws IOException upon error
    */
   public native int main(String[] args) throws IOException;
@@ -125,8 +132,8 @@ public class HTTrackLib {
   public native boolean stop(boolean force);
 
   /**
-   * How the engine aborted the last run, if it did. main() returns 0 for nearly every abort, so
-   * its return code alone cannot tell a mirror that died from one that finished.
+   * Why the engine aborted the last run, if it did. main() reports that it aborted but not why,
+   * and a few of its guards give up without setting a cause at all.
    *
    * @return 0 when the mirror was not aborted, -1 on a fatal write such as a full disk, 1 when a
    * callback refused to continue, 2 when nothing arrived and the previous session was restored

--- a/app/src/main/java/com/httrack/android/jni/HTTrackLib.java
+++ b/app/src/main/java/com/httrack/android/jni/HTTrackLib.java
@@ -107,10 +107,7 @@ public class HTTrackLib {
     return buildTopIndex(p, t);
   }
 
-  /**
-   * The engine's HTS_EXIT_MIRROR_ABORTED: a mirror started and it gave up. Must stay a
-   * compile-time constant, so that reading it does not load this class under plain JUnit.
-   */
+  /** The engine's HTS_EXIT_MIRROR_ABORTED: a mirror started, and the engine gave up on it. */
   public static final int EXIT_MIRROR_ABORTED = 3;
 
   /**

--- a/app/src/main/jni/htslibjni.c
+++ b/app/src/main/jni/htslibjni.c
@@ -915,9 +915,8 @@ Java_com_httrack_android_jni_HTTrackLib_wasStopped(JNIEnv* env, jobject object) 
   }
 
   MUTEX_LOCK(context->lock);
-  /* hts_main2() returns 0 for nearly every abort, so ask the engine instead.
-     stop is a cap or a user stop; exit_xh is a fatal disk error, an aborting
-     callback, or a rolled-back session. */
+  /* The exit code misses every stop that still returns 0, so ask the engine: stop
+     is a cap or a user stop, exit_xh a fatal error, a refusing callback, a rollback. */
   if (context->opt != NULL) {
     stopped = context->opt->state.stop != 0
         || hts_is_exiting(context->opt) != 0 ? JNI_TRUE : JNI_FALSE;

--- a/app/src/main/jni/htslibjni.c
+++ b/app/src/main/jni/htslibjni.c
@@ -915,8 +915,7 @@ Java_com_httrack_android_jni_HTTrackLib_wasStopped(JNIEnv* env, jobject object) 
   }
 
   MUTEX_LOCK(context->lock);
-  /* The exit code misses every stop that still returns 0, so ask the engine: stop
-     is a cap or a user stop, exit_xh a fatal error, a refusing callback, a rollback. */
+  /* The exit code misses every stop that still returns 0, so ask the engine instead. */
   if (context->opt != NULL) {
     stopped = context->opt->state.stop != 0
         || hts_is_exiting(context->opt) != 0 ? JNI_TRUE : JNI_FALSE;

--- a/app/src/test/java/com/httrack/android/EngineAbortReportedTest.java
+++ b/app/src/test/java/com/httrack/android/EngineAbortReportedTest.java
@@ -11,6 +11,9 @@ import org.junit.Test;
 
 /** MirrorOutcomeTest covers the choice; what it cannot reach is the wiring that feeds it. */
 public class EngineAbortReportedTest {
+  /** The only mention of the finish message allowed to precede the verdict gate. */
+  private static final String DECLARATION = "String message = null;";
+
   private static String abortCodeBody() throws Exception {
     return TestSources.between(TestSources.jniSource("htslibjni.c"), "HTTrackLib_abortCode", "\n}");
   }
@@ -68,10 +71,10 @@ public class EngineAbortReportedTest {
         "protected void runInternal()", "displayFinishedPanel(");
     final int gate = body.indexOf("if (MirrorOutcome.mirrorRan(code)) {");
     assertTrue("the verdict gate is gone", gate != -1);
-    final Matcher assignment = Pattern.compile("(?m)^\\s*message\\s*\\+?=").matcher(body);
-    assertTrue("no finish message assignment found", assignment.find());
-    assertTrue("the message must not be decided before the mirror's verdict",
-        assignment.start() > gate);
+    // Anywhere, not at a line start: an inserted branch can assign on its own brace's line.
+    final String before = body.substring(0, gate).replace(DECLARATION, "");
+    assertFalse("the message must not be decided before the mirror's verdict",
+        Pattern.compile("\\bmessage\\s*\\+?=").matcher(before).find());
   }
 
   /** Transposing the two branches is invisible to the enum, so each is pinned to its source. */

--- a/app/src/test/java/com/httrack/android/EngineAbortReportedTest.java
+++ b/app/src/test/java/com/httrack/android/EngineAbortReportedTest.java
@@ -30,7 +30,17 @@ public class EngineAbortReportedTest {
         "MirrorOutcome.of");
     assertEquals("the pane must weigh the same stop the resume offer does", "stop",
         call.split(",")[0].trim());
+    assertEquals("the exit code is a channel of its own, and of() reads it second", "code",
+        call.split(",")[1].trim());
     assertTrue("the engine's verdict must reach the choice", call.contains("engine.abortCode()"));
+  }
+
+  /** A gate of code == 0 alone sends every aborted mirror to the bare-code branch. */
+  @Test
+  public void theAbortedExitCodeStillEarnsAVerdict() throws Exception {
+    assertTrue("the branch that classifies must admit the aborted exit code",
+        TestSources.javaSource("HTTrackActivity")
+            .contains("code == MirrorOutcome.EXIT_MIRROR_ABORTED"));
   }
 
   /** Transposing the two branches is invisible to the enum, so each is pinned to its source. */

--- a/app/src/test/java/com/httrack/android/EngineAbortReportedTest.java
+++ b/app/src/test/java/com/httrack/android/EngineAbortReportedTest.java
@@ -33,7 +33,7 @@ public class EngineAbortReportedTest {
         "MirrorOutcome.of");
     assertEquals("the pane must weigh the same stop the resume offer does", "stop",
         call.split(",")[0].trim());
-    assertEquals("the exit code is a channel of its own, and of() reads it second",
+    assertEquals("of() must read the aborted flag second",
         "MirrorOutcome.mirrorAborted(code)", call.split(",")[1].trim());
     assertEquals("the engine's verdict must reach the choice", "engine.abortCode()",
         call.split(",")[2].trim());
@@ -52,12 +52,26 @@ public class EngineAbortReportedTest {
   /** Java hardcodes the value, and a pin bump that renumbered it would fail nothing else. */
   @Test
   public void theExitCodeMatchesThePinnedEngine() throws Exception {
-    final String header = TestSources.read(TestSources.engineFile("src/httrack-library.h"));
+    final String header = TestSources.withoutCommentsAndStrings(
+        TestSources.read(TestSources.engineFile("src/httrack-library.h")));
     final Matcher define = Pattern.compile(
         "#define\\s+HTS_EXIT_MIRROR_ABORTED\\s+(\\d+)").matcher(header);
     assertTrue("the engine no longer defines HTS_EXIT_MIRROR_ABORTED", define.find());
     assertEquals("the engine renumbered its aborted exit code", define.group(1),
         String.valueOf(HTTrackLib.EXIT_MIRROR_ABORTED));
+  }
+
+  /** A branch reached before the gate would answer for an aborted mirror behind its back. */
+  @Test
+  public void nothingDecidesTheMessageBeforeTheVerdictGate() throws Exception {
+    final String body = TestSources.between(TestSources.javaSource("HTTrackActivity"),
+        "protected void runInternal()", "displayFinishedPanel(");
+    final int gate = body.indexOf("if (MirrorOutcome.mirrorRan(code)) {");
+    assertTrue("the verdict gate is gone", gate != -1);
+    final Matcher assignment = Pattern.compile("(?m)^\\s*message\\s*\\+?=").matcher(body);
+    assertTrue("no finish message assignment found", assignment.find());
+    assertTrue("the message must not be decided before the mirror's verdict",
+        assignment.start() > gate);
   }
 
   /** Transposing the two branches is invisible to the enum, so each is pinned to its source. */

--- a/app/src/test/java/com/httrack/android/EngineAbortReportedTest.java
+++ b/app/src/test/java/com/httrack/android/EngineAbortReportedTest.java
@@ -4,6 +4,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import com.httrack.android.jni.HTTrackLib;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.junit.Test;
 
 /** MirrorOutcomeTest covers the choice; what it cannot reach is the wiring that feeds it. */
@@ -30,9 +33,12 @@ public class EngineAbortReportedTest {
         "MirrorOutcome.of");
     assertEquals("the pane must weigh the same stop the resume offer does", "stop",
         call.split(",")[0].trim());
-    assertEquals("the exit code is a channel of its own, and of() reads it second", "code",
-        call.split(",")[1].trim());
-    assertTrue("the engine's verdict must reach the choice", call.contains("engine.abortCode()"));
+    assertEquals("the exit code is a channel of its own, and of() reads it second",
+        "MirrorOutcome.mirrorAborted(code)", call.split(",")[1].trim());
+    assertEquals("the engine's verdict must reach the choice", "engine.abortCode()",
+        call.split(",")[2].trim());
+    assertEquals("the run's own tally must reach the choice", "lastStats",
+        call.split(",")[3].trim());
   }
 
   /** A gate of code == 0 alone sends every aborted mirror to the bare-code branch. */
@@ -40,7 +46,18 @@ public class EngineAbortReportedTest {
   public void theAbortedExitCodeStillEarnsAVerdict() throws Exception {
     assertTrue("the branch that classifies must admit the aborted exit code",
         TestSources.javaSource("HTTrackActivity")
-            .contains("code == MirrorOutcome.EXIT_MIRROR_ABORTED"));
+            .contains("if (MirrorOutcome.mirrorRan(code)) {"));
+  }
+
+  /** Java hardcodes the value, and a pin bump that renumbered it would fail nothing else. */
+  @Test
+  public void theExitCodeMatchesThePinnedEngine() throws Exception {
+    final String header = TestSources.read(TestSources.engineFile("src/httrack-library.h"));
+    final Matcher define = Pattern.compile(
+        "#define\\s+HTS_EXIT_MIRROR_ABORTED\\s+(\\d+)").matcher(header);
+    assertTrue("the engine no longer defines HTS_EXIT_MIRROR_ABORTED", define.find());
+    assertEquals("the engine renumbered its aborted exit code", define.group(1),
+        String.valueOf(HTTrackLib.EXIT_MIRROR_ABORTED));
   }
 
   /** Transposing the two branches is invisible to the enum, so each is pinned to its source. */

--- a/app/src/test/java/com/httrack/android/EngineAbortReportedTest.java
+++ b/app/src/test/java/com/httrack/android/EngineAbortReportedTest.java
@@ -61,6 +61,13 @@ public class EngineAbortReportedTest {
         body.split("mirrorFolder = target", -1).length - 1);
     assertTrue("the folder must hang off the verdict's own answer",
         body.contains("if (verdict.showsFolderLink()) {\n          mirrorFolder = target;"));
+    // A second verdict, or a second assignment, would answer over the one decide() handed back.
+    assertTrue("the verdict must not be replaceable",
+        body.contains("final MirrorOutcome.Verdict verdict = MirrorOutcome.decide("));
+    assertEquals("the pane must say what the verdict says, once", 1,
+        body.split(Pattern.quote("message = verdict.text();"), -1).length - 1);
+    assertEquals("nothing else may set the message", 1,
+        Pattern.compile("(?<!String )\\bmessage\\s*=[^=]").matcher(body).results().count());
   }
 
   /** Transposing the two branches is invisible to the enum, so each is pinned to its source. */

--- a/app/src/test/java/com/httrack/android/EngineAbortReportedTest.java
+++ b/app/src/test/java/com/httrack/android/EngineAbortReportedTest.java
@@ -11,9 +11,6 @@ import org.junit.Test;
 
 /** MirrorOutcomeTest covers the choice; what it cannot reach is the wiring that feeds it. */
 public class EngineAbortReportedTest {
-  /** The only mention of the finish message allowed to precede the verdict gate. */
-  private static final String DECLARATION = "String message = null;";
-
   private static String abortCodeBody() throws Exception {
     return TestSources.between(TestSources.jniSource("htslibjni.c"), "HTTrackLib_abortCode", "\n}");
   }
@@ -33,23 +30,14 @@ public class EngineAbortReportedTest {
   @Test
   public void theFinishedPaneWeighsBothTheStopAndTheEnginesVerdict() throws Exception {
     final String call = TestSources.arguments(TestSources.javaSource("HTTrackActivity"),
-        "MirrorOutcome.of");
+        "MirrorOutcome.decide");
+    assertEquals("the exit code must reach the choice", "code", call.split(",")[0].trim());
     assertEquals("the pane must weigh the same stop the resume offer does", "stop",
-        call.split(",")[0].trim());
-    assertEquals("of() must read the aborted flag second",
-        "MirrorOutcome.mirrorAborted(code)", call.split(",")[1].trim());
+        call.split(",")[1].trim());
     assertEquals("the engine's verdict must reach the choice", "engine.abortCode()",
         call.split(",")[2].trim());
     assertEquals("the run's own tally must reach the choice", "lastStats",
         call.split(",")[3].trim());
-  }
-
-  /** A gate of code == 0 alone sends every aborted mirror to the bare-code branch. */
-  @Test
-  public void theAbortedExitCodeStillEarnsAVerdict() throws Exception {
-    assertTrue("the branch that classifies must admit the aborted exit code",
-        TestSources.javaSource("HTTrackActivity")
-            .contains("if (MirrorOutcome.mirrorRan(code)) {"));
   }
 
   /** Java hardcodes the value, and a pin bump that renumbered it would fail nothing else. */
@@ -64,17 +52,15 @@ public class EngineAbortReportedTest {
         String.valueOf(HTTrackLib.EXIT_MIRROR_ABORTED));
   }
 
-  /** A branch reached before the gate would answer for an aborted mirror behind its back. */
+  /** MirrorOutcomeTest owns the text and the link; only the folder the link points at is here. */
   @Test
-  public void nothingDecidesTheMessageBeforeTheVerdictGate() throws Exception {
+  public void theFolderIsOfferedExactlyWhenTheVerdictSaysSo() throws Exception {
     final String body = TestSources.between(TestSources.javaSource("HTTrackActivity"),
-        "protected void runInternal()", "displayFinishedPanel(");
-    final int gate = body.indexOf("if (MirrorOutcome.mirrorRan(code)) {");
-    assertTrue("the verdict gate is gone", gate != -1);
-    // Anywhere, not at a line start: an inserted branch can assign on its own brace's line.
-    final String before = body.substring(0, gate).replace(DECLARATION, "");
-    assertFalse("the message must not be decided before the mirror's verdict",
-        Pattern.compile("\\bmessage\\s*\\+?=").matcher(before).find());
+        "protected void runInternal()", "// Build top index");
+    assertEquals("the mirror folder must be offered once, and only under the verdict", 1,
+        body.split("mirrorFolder = target", -1).length - 1);
+    assertTrue("the folder must hang off the verdict's own answer",
+        body.contains("if (verdict.showsFolderLink()) {\n          mirrorFolder = target;"));
   }
 
   /** Transposing the two branches is invisible to the enum, so each is pinned to its source. */
@@ -86,17 +72,5 @@ public class EngineAbortReportedTest {
         assigned.matches("(?s).*interrupted\\s*\\?\\s*MirrorOutcome\\.Stop\\.USER.*"));
     assertTrue("the engine stopping itself must be the ENGINE stop",
         assigned.matches("(?s).*wasStopped\\(\\)\\s*\\?\\s*MirrorOutcome\\.Stop\\.ENGINE.*"));
-  }
-
-  /** Swapping two abort messages is invisible to the enum, so each is pinned to its cause. */
-  @Test
-  public void eachAbortCauseKeepsItsOwnWording() throws Exception {
-    final String source = TestSources.javaSource("HTTrackActivity");
-    assertTrue("a fatal abort must name what ran out",
-        TestSources.between(source, "case ABORTED_FATAL:", "break;").contains("disk space"));
-    assertTrue("a rolled-back session must say the mirror was left alone",
-        TestSources.between(source, "case ABORTED_ROLLBACK:", "break;").contains("left as it was"));
-    assertTrue("a capped run must name the cap, not an abort",
-        TestSources.between(source, "case STOPPED_AT_LIMIT:", "break;").contains("limit reached"));
   }
 }

--- a/app/src/test/java/com/httrack/android/MirrorOutcomeTest.java
+++ b/app/src/test/java/com/httrack/android/MirrorOutcomeTest.java
@@ -1,7 +1,10 @@
 package com.httrack.android;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
+import com.httrack.android.jni.HTTrackLib;
 import com.httrack.android.jni.HTTrackStats;
 import org.junit.Test;
 
@@ -9,7 +12,8 @@ import org.junit.Test;
 public class MirrorOutcomeTest {
   private static final int ABORT_CALLBACK = 1;
   private static final int ABORT_UNKNOWN = 3;
-  private static final int EXIT_OK = 0;
+  private static final boolean FINISHED = false;
+  private static final boolean GAVE_UP = true;
 
   private static HTTrackStats stats(final long errorsCount, final long filesWritten) {
     final HTTrackStats stats = new HTTrackStats();
@@ -19,16 +23,11 @@ public class MirrorOutcomeTest {
   }
 
   private static void check(final MirrorOutcome expected, final MirrorOutcome.Stop stop,
-      final int abortCode, final long errorsCount, final long filesWritten) {
-    check(expected, stop, EXIT_OK, abortCode, errorsCount, filesWritten);
-  }
-
-  private static void check(final MirrorOutcome expected, final MirrorOutcome.Stop stop,
-      final int engineCode, final int abortCode, final long errorsCount,
+      final boolean engineAborted, final int abortCode, final long errorsCount,
       final long filesWritten) {
-    assertEquals("stop=" + stop + " engineCode=" + engineCode + " abortCode=" + abortCode
+    assertEquals("stop=" + stop + " engineAborted=" + engineAborted + " abortCode=" + abortCode
         + " errors=" + errorsCount + " written=" + filesWritten, expected,
-        MirrorOutcome.of(stop, engineCode, abortCode, stats(errorsCount, filesWritten)));
+        MirrorOutcome.of(stop, engineAborted, abortCode, stats(errorsCount, filesWritten)));
   }
 
   /**
@@ -38,10 +37,13 @@ public class MirrorOutcomeTest {
    */
   @Test
   public void aStopTheUserAskedForIsNeverAnAbort() {
-    check(MirrorOutcome.INTERRUPTED, MirrorOutcome.Stop.USER, MirrorOutcome.ABORT_ROLLBACK, 0, 0);
-    check(MirrorOutcome.INTERRUPTED, MirrorOutcome.Stop.USER, ABORT_CALLBACK, 2, 40);
-    check(MirrorOutcome.INTERRUPTED, MirrorOutcome.Stop.USER, MirrorOutcome.ABORT_FATAL, 0, 7);
-    check(MirrorOutcome.INTERRUPTED, MirrorOutcome.Stop.USER, MirrorOutcome.ABORT_NONE, 0, 7);
+    check(MirrorOutcome.INTERRUPTED, MirrorOutcome.Stop.USER, FINISHED,
+        MirrorOutcome.ABORT_ROLLBACK, 0, 0);
+    check(MirrorOutcome.INTERRUPTED, MirrorOutcome.Stop.USER, FINISHED, ABORT_CALLBACK, 2, 40);
+    check(MirrorOutcome.INTERRUPTED, MirrorOutcome.Stop.USER, FINISHED, MirrorOutcome.ABORT_FATAL,
+        0, 7);
+    check(MirrorOutcome.INTERRUPTED, MirrorOutcome.Stop.USER, FINISHED, MirrorOutcome.ABORT_NONE, 0,
+        7);
   }
 
   /**
@@ -50,19 +52,25 @@ public class MirrorOutcomeTest {
    */
   @Test
   public void anAbortTheUserDidNotAskForIsNamedByItsCause() {
-    check(MirrorOutcome.ABORTED_FATAL, MirrorOutcome.Stop.ENGINE, MirrorOutcome.ABORT_FATAL, 0, 3);
-    check(MirrorOutcome.ABORTED_FATAL, MirrorOutcome.Stop.NONE, MirrorOutcome.ABORT_FATAL, 0, 3);
-    check(MirrorOutcome.ABORTED_ROLLBACK, MirrorOutcome.Stop.ENGINE, MirrorOutcome.ABORT_ROLLBACK, 0, 0);
-    check(MirrorOutcome.ABORTED_ROLLBACK, MirrorOutcome.Stop.NONE, MirrorOutcome.ABORT_ROLLBACK, 0, 0);
+    check(MirrorOutcome.ABORTED_FATAL, MirrorOutcome.Stop.ENGINE, GAVE_UP,
+        MirrorOutcome.ABORT_FATAL, 0, 3);
+    check(MirrorOutcome.ABORTED_FATAL, MirrorOutcome.Stop.NONE, GAVE_UP,
+        MirrorOutcome.ABORT_FATAL, 0, 3);
+    check(MirrorOutcome.ABORTED_ROLLBACK, MirrorOutcome.Stop.ENGINE, FINISHED,
+        MirrorOutcome.ABORT_ROLLBACK, 0, 0);
+    check(MirrorOutcome.ABORTED_ROLLBACK, MirrorOutcome.Stop.NONE, FINISHED,
+        MirrorOutcome.ABORT_ROLLBACK, 0, 0);
   }
 
   /** An abort code nobody has mapped must still abort, not fall through to success. */
   @Test
   public void anUnrecognisedAbortCodeIsStillAnAbort() {
-    check(MirrorOutcome.ABORTED_OTHER, MirrorOutcome.Stop.ENGINE, ABORT_CALLBACK, 0, 0);
-    check(MirrorOutcome.ABORTED_OTHER, MirrorOutcome.Stop.NONE, ABORT_CALLBACK, 0, 0);
-    check(MirrorOutcome.ABORTED_OTHER, MirrorOutcome.Stop.ENGINE, ABORT_UNKNOWN, 0, 40);
-    check(MirrorOutcome.ABORTED_OTHER, MirrorOutcome.Stop.NONE, ABORT_UNKNOWN, 0, 40);
+    check(MirrorOutcome.ABORTED_OTHER, MirrorOutcome.Stop.ENGINE, FINISHED, ABORT_CALLBACK, 0, 0);
+    check(MirrorOutcome.ABORTED_OTHER, MirrorOutcome.Stop.NONE, FINISHED, ABORT_CALLBACK, 0, 0);
+    check(MirrorOutcome.ABORTED_OTHER, MirrorOutcome.Stop.ENGINE, FINISHED, ABORT_UNKNOWN, 0, 40);
+    check(MirrorOutcome.ABORTED_OTHER, MirrorOutcome.Stop.NONE, FINISHED, ABORT_UNKNOWN, 0, 40);
+    check(MirrorOutcome.ABORTED_OTHER, MirrorOutcome.Stop.NONE, GAVE_UP, ABORT_CALLBACK, 0, 0);
+    check(MirrorOutcome.ABORTED_OTHER, MirrorOutcome.Stop.NONE, GAVE_UP, ABORT_UNKNOWN, 0, 40);
   }
 
   /**
@@ -72,54 +80,58 @@ public class MirrorOutcomeTest {
    */
   @Test
   public void aCapTheEngineHitIsNotASuccess() {
-    check(MirrorOutcome.STOPPED_AT_LIMIT, MirrorOutcome.Stop.ENGINE, MirrorOutcome.ABORT_NONE,
-        0, 400);
-    check(MirrorOutcome.STOPPED_AT_LIMIT, MirrorOutcome.Stop.ENGINE, MirrorOutcome.ABORT_NONE,
-        5, 400);
-    check(MirrorOutcome.STOPPED_AT_LIMIT, MirrorOutcome.Stop.ENGINE, MirrorOutcome.ABORT_NONE,
-        5, 0);
+    check(MirrorOutcome.STOPPED_AT_LIMIT, MirrorOutcome.Stop.ENGINE, FINISHED,
+        MirrorOutcome.ABORT_NONE, 0, 400);
+    check(MirrorOutcome.STOPPED_AT_LIMIT, MirrorOutcome.Stop.ENGINE, FINISHED,
+        MirrorOutcome.ABORT_NONE, 5, 400);
+    check(MirrorOutcome.STOPPED_AT_LIMIT, MirrorOutcome.Stop.ENGINE, FINISHED,
+        MirrorOutcome.ABORT_NONE, 5, 0);
   }
 
   @Test
   public void aCompletedRunIsStillJudgedOnItsErrorCount() {
-    check(MirrorOutcome.SUCCESS, MirrorOutcome.Stop.NONE, MirrorOutcome.ABORT_NONE, 0, 40);
-    check(MirrorOutcome.SUCCESS, MirrorOutcome.Stop.NONE, MirrorOutcome.ABORT_NONE, 0, 0);
-    check(MirrorOutcome.SUCCESS_WITH_ERRORS, MirrorOutcome.Stop.NONE, MirrorOutcome.ABORT_NONE, 5, 40);
-    check(MirrorOutcome.FAILED, MirrorOutcome.Stop.NONE, MirrorOutcome.ABORT_NONE, 5, 0);
+    check(MirrorOutcome.SUCCESS, MirrorOutcome.Stop.NONE, FINISHED, MirrorOutcome.ABORT_NONE, 0,
+        40);
+    check(MirrorOutcome.SUCCESS, MirrorOutcome.Stop.NONE, FINISHED, MirrorOutcome.ABORT_NONE, 0, 0);
+    check(MirrorOutcome.SUCCESS_WITH_ERRORS, MirrorOutcome.Stop.NONE, FINISHED,
+        MirrorOutcome.ABORT_NONE, 5, 40);
+    check(MirrorOutcome.FAILED, MirrorOutcome.Stop.NONE, FINISHED, MirrorOutcome.ABORT_NONE, 5, 0);
   }
 
-  /**
-   * Since 3.50 hts_main2() returns 3 for a mirror it gave up on, where it used to return the same 0
-   * as a finished one. The cause it names still decides the wording.
-   */
+  /** Reading the aborted code before the cause would flatten every named abort to ABORTED_OTHER. */
   @Test
-  public void theAbortedExitCodeKeepsTheCauseTheEngineNamed() {
-    check(MirrorOutcome.ABORTED_FATAL, MirrorOutcome.Stop.ENGINE, MirrorOutcome.EXIT_MIRROR_ABORTED,
+  public void aNamedCauseOutranksTheBareAbortedCode() {
+    check(MirrorOutcome.ABORTED_FATAL, MirrorOutcome.Stop.ENGINE, GAVE_UP,
         MirrorOutcome.ABORT_FATAL, 0, 3);
-    check(MirrorOutcome.ABORTED_ROLLBACK, MirrorOutcome.Stop.ENGINE,
-        MirrorOutcome.EXIT_MIRROR_ABORTED, MirrorOutcome.ABORT_ROLLBACK, 0, 0);
-    check(MirrorOutcome.INTERRUPTED, MirrorOutcome.Stop.USER, MirrorOutcome.EXIT_MIRROR_ABORTED,
+    check(MirrorOutcome.INTERRUPTED, MirrorOutcome.Stop.USER, GAVE_UP,
         MirrorOutcome.ABORT_FATAL, 0, 3);
   }
 
   /**
-   * httpmirror() gives up on some startup failures without ever setting exit_xh, so abortCode()
-   * and the stats both read like a clean run and only the exit code disagrees.
+   * httpmirror() gives up on a few allocation and filter-cap guards without ever setting exit_xh,
+   * so abortCode() and the stats both read like a clean run and only the exit code disagrees.
    */
   @Test
   public void anAbortWithNoCauseIsAnAbortAndNotASuccess() {
-    check(MirrorOutcome.ABORTED_OTHER, MirrorOutcome.Stop.NONE, MirrorOutcome.EXIT_MIRROR_ABORTED,
+    check(MirrorOutcome.ABORTED_OTHER, MirrorOutcome.Stop.NONE, GAVE_UP,
         MirrorOutcome.ABORT_NONE, 0, 0);
-    check(MirrorOutcome.ABORTED_OTHER, MirrorOutcome.Stop.NONE, MirrorOutcome.EXIT_MIRROR_ABORTED,
+    check(MirrorOutcome.ABORTED_OTHER, MirrorOutcome.Stop.NONE, GAVE_UP,
         MirrorOutcome.ABORT_NONE, 0, 40);
-    check(MirrorOutcome.ABORTED_OTHER, MirrorOutcome.Stop.ENGINE, MirrorOutcome.EXIT_MIRROR_ABORTED,
+    check(MirrorOutcome.ABORTED_OTHER, MirrorOutcome.Stop.ENGINE, GAVE_UP,
         MirrorOutcome.ABORT_NONE, 0, 400);
+    check(MirrorOutcome.ABORTED_OTHER, MirrorOutcome.Stop.NONE, GAVE_UP,
+        MirrorOutcome.ABORT_NONE, 5, 40);
   }
 
-  /** The abort channel is the exit code's alone: 3 as an abortCode() still means an unnamed cause. */
+  /** Only these two codes mean a mirror ran; anything else is a command line the engine refused. */
   @Test
-  public void theTwoChannelsAreReadSeparately() {
-    check(MirrorOutcome.ABORTED_OTHER, MirrorOutcome.Stop.NONE, EXIT_OK, ABORT_UNKNOWN, 0, 40);
-    check(MirrorOutcome.SUCCESS, MirrorOutcome.Stop.NONE, EXIT_OK, MirrorOutcome.ABORT_NONE, 0, 40);
+  public void theCodesThatMeanAMirrorRanAreTheOnlyOnes() {
+    assertTrue(MirrorOutcome.mirrorRan(0));
+    assertTrue(MirrorOutcome.mirrorRan(HTTrackLib.EXIT_MIRROR_ABORTED));
+    assertFalse(MirrorOutcome.mirrorRan(-1));
+    assertFalse(MirrorOutcome.mirrorRan(1));
+    assertFalse(MirrorOutcome.mirrorAborted(0));
+    assertTrue(MirrorOutcome.mirrorAborted(HTTrackLib.EXIT_MIRROR_ABORTED));
+    assertFalse(MirrorOutcome.mirrorAborted(-1));
   }
 }

--- a/app/src/test/java/com/httrack/android/MirrorOutcomeTest.java
+++ b/app/src/test/java/com/httrack/android/MirrorOutcomeTest.java
@@ -139,4 +139,50 @@ public class MirrorOutcomeTest {
     assertFalse(MirrorOutcome.mirrorAborted(2));
     assertFalse(MirrorOutcome.mirrorAborted(255));
   }
+
+  private static void verdict(final String expectedText, final boolean expectedLink,
+      final int engineCode, final MirrorOutcome.Stop stop, final int abortCode,
+      final long errorsCount, final long filesWritten) {
+    final MirrorOutcome.Verdict v = MirrorOutcome.decide(engineCode, stop, abortCode,
+        stats(errorsCount, filesWritten));
+    final String where = "code=" + engineCode + " stop=" + stop + " abortCode=" + abortCode;
+    assertEquals(where, expectedText, v.text());
+    assertEquals(where + " folder link", expectedLink, v.showsFolderLink());
+  }
+
+  /** A mirror that ran wrote a folder, so its verdict names the cause and keeps the link. */
+  @Test
+  public void everyRunThatMirroredKeepsItsFolderLink() {
+    verdict("<b>Success</b>!", true, 0, MirrorOutcome.Stop.NONE, MirrorOutcome.ABORT_NONE, 0, 40);
+    verdict("<b>Success</b>! (5 errors)", true, 0, MirrorOutcome.Stop.NONE,
+        MirrorOutcome.ABORT_NONE, 5, 40);
+    verdict("<b>Failed</b>! (5 errors, no files written)", true, 0, MirrorOutcome.Stop.NONE,
+        MirrorOutcome.ABORT_NONE, 5, 0);
+    verdict("<b>Interrupted</b>! (2 errors)", true, 0, MirrorOutcome.Stop.USER,
+        MirrorOutcome.ABORT_NONE, 2, 40);
+    verdict("<b>Stopped</b>! (size or time limit reached, 0 errors)", true, 0,
+        MirrorOutcome.Stop.ENGINE, MirrorOutcome.ABORT_NONE, 0, 400);
+    verdict("<b>Aborted</b>! (nothing was transferred, so the mirror was left as it was)", true,
+        0, MirrorOutcome.Stop.ENGINE, MirrorOutcome.ABORT_ROLLBACK, 0, 0);
+  }
+
+  /** The engine gave up, and the half-written mirror is still on disk. */
+  @Test
+  public void anAbortedMirrorNamesItsCauseAndKeepsItsFolderLink() {
+    verdict("<b>Aborted</b>! (out of disk space, too many links, or another fatal error)", true,
+        HTTrackLib.EXIT_MIRROR_ABORTED, MirrorOutcome.Stop.ENGINE, MirrorOutcome.ABORT_FATAL, 0, 3);
+    verdict("<b>Aborted</b>! (the engine could not continue)", true,
+        HTTrackLib.EXIT_MIRROR_ABORTED, MirrorOutcome.Stop.NONE, MirrorOutcome.ABORT_NONE, 0, 0);
+  }
+
+  /** A refused command line mirrored nothing, so there is no folder to offer. */
+  @Test
+  public void aRefusedCommandLineShowsItsCodeAndNoLink() {
+    verdict("<b>Error</b> (<i>code -1</i>)", false, -1, MirrorOutcome.Stop.NONE,
+        MirrorOutcome.ABORT_NONE, 0, 0);
+    verdict("<b>Error</b> (<i>code 1</i>)", false, 1, MirrorOutcome.Stop.NONE,
+        MirrorOutcome.ABORT_NONE, 0, 0);
+    verdict("<b>Error</b> (<i>code 255</i>)", false, 255, MirrorOutcome.Stop.NONE,
+        MirrorOutcome.ABORT_NONE, 0, 0);
+  }
 }

--- a/app/src/test/java/com/httrack/android/MirrorOutcomeTest.java
+++ b/app/src/test/java/com/httrack/android/MirrorOutcomeTest.java
@@ -130,8 +130,12 @@ public class MirrorOutcomeTest {
     assertTrue(MirrorOutcome.mirrorRan(HTTrackLib.EXIT_MIRROR_ABORTED));
     assertFalse(MirrorOutcome.mirrorRan(-1));
     assertFalse(MirrorOutcome.mirrorRan(1));
+    assertFalse(MirrorOutcome.mirrorRan(2));
+    assertFalse(MirrorOutcome.mirrorRan(255));
     assertFalse(MirrorOutcome.mirrorAborted(0));
     assertTrue(MirrorOutcome.mirrorAborted(HTTrackLib.EXIT_MIRROR_ABORTED));
     assertFalse(MirrorOutcome.mirrorAborted(-1));
+    assertFalse(MirrorOutcome.mirrorAborted(1));
+    assertFalse(MirrorOutcome.mirrorAborted(2));
   }
 }

--- a/app/src/test/java/com/httrack/android/MirrorOutcomeTest.java
+++ b/app/src/test/java/com/httrack/android/MirrorOutcomeTest.java
@@ -175,6 +175,22 @@ public class MirrorOutcomeTest {
         HTTrackLib.EXIT_MIRROR_ABORTED, MirrorOutcome.Stop.NONE, MirrorOutcome.ABORT_NONE, 0, 0);
   }
 
+  /** Whatever cause the engine names, a mirror it gave up on had already written a folder. */
+  @Test
+  public void everyAbortedRunKeepsItsFolderLink() {
+    final int[] causes = { MirrorOutcome.ABORT_NONE, MirrorOutcome.ABORT_FATAL,
+        MirrorOutcome.ABORT_ROLLBACK, ABORT_CALLBACK, ABORT_UNKNOWN };
+    for (final MirrorOutcome.Stop stop : MirrorOutcome.Stop.values()) {
+      for (final int abortCode : causes) {
+        final MirrorOutcome.Verdict v = MirrorOutcome.decide(HTTrackLib.EXIT_MIRROR_ABORTED, stop,
+            abortCode, stats(0, 3));
+        final String where = "stop=" + stop + " abortCode=" + abortCode;
+        assertTrue(where + " lost its folder link", v.showsFolderLink());
+        assertTrue(where + " lost its cause: " + v.text(), v.text().startsWith("<b>"));
+      }
+    }
+  }
+
   /** A refused command line mirrored nothing, so there is no folder to offer. */
   @Test
   public void aRefusedCommandLineShowsItsCodeAndNoLink() {

--- a/app/src/test/java/com/httrack/android/MirrorOutcomeTest.java
+++ b/app/src/test/java/com/httrack/android/MirrorOutcomeTest.java
@@ -9,6 +9,7 @@ import org.junit.Test;
 public class MirrorOutcomeTest {
   private static final int ABORT_CALLBACK = 1;
   private static final int ABORT_UNKNOWN = 3;
+  private static final int EXIT_OK = 0;
 
   private static HTTrackStats stats(final long errorsCount, final long filesWritten) {
     final HTTrackStats stats = new HTTrackStats();
@@ -19,9 +20,15 @@ public class MirrorOutcomeTest {
 
   private static void check(final MirrorOutcome expected, final MirrorOutcome.Stop stop,
       final int abortCode, final long errorsCount, final long filesWritten) {
-    assertEquals("stop=" + stop + " abortCode=" + abortCode + " errors=" + errorsCount
-        + " written=" + filesWritten, expected,
-        MirrorOutcome.of(stop, abortCode, stats(errorsCount, filesWritten)));
+    check(expected, stop, EXIT_OK, abortCode, errorsCount, filesWritten);
+  }
+
+  private static void check(final MirrorOutcome expected, final MirrorOutcome.Stop stop,
+      final int engineCode, final int abortCode, final long errorsCount,
+      final long filesWritten) {
+    assertEquals("stop=" + stop + " engineCode=" + engineCode + " abortCode=" + abortCode
+        + " errors=" + errorsCount + " written=" + filesWritten, expected,
+        MirrorOutcome.of(stop, engineCode, abortCode, stats(errorsCount, filesWritten)));
   }
 
   /**
@@ -79,5 +86,40 @@ public class MirrorOutcomeTest {
     check(MirrorOutcome.SUCCESS, MirrorOutcome.Stop.NONE, MirrorOutcome.ABORT_NONE, 0, 0);
     check(MirrorOutcome.SUCCESS_WITH_ERRORS, MirrorOutcome.Stop.NONE, MirrorOutcome.ABORT_NONE, 5, 40);
     check(MirrorOutcome.FAILED, MirrorOutcome.Stop.NONE, MirrorOutcome.ABORT_NONE, 5, 0);
+  }
+
+  /**
+   * Since 3.50 hts_main2() returns 3 for a mirror it gave up on, where it used to return the same 0
+   * as a finished one. The cause it names still decides the wording.
+   */
+  @Test
+  public void theAbortedExitCodeKeepsTheCauseTheEngineNamed() {
+    check(MirrorOutcome.ABORTED_FATAL, MirrorOutcome.Stop.ENGINE, MirrorOutcome.EXIT_MIRROR_ABORTED,
+        MirrorOutcome.ABORT_FATAL, 0, 3);
+    check(MirrorOutcome.ABORTED_ROLLBACK, MirrorOutcome.Stop.ENGINE,
+        MirrorOutcome.EXIT_MIRROR_ABORTED, MirrorOutcome.ABORT_ROLLBACK, 0, 0);
+    check(MirrorOutcome.INTERRUPTED, MirrorOutcome.Stop.USER, MirrorOutcome.EXIT_MIRROR_ABORTED,
+        MirrorOutcome.ABORT_FATAL, 0, 3);
+  }
+
+  /**
+   * httpmirror() gives up on some startup failures without ever setting exit_xh, so abortCode()
+   * and the stats both read like a clean run and only the exit code disagrees.
+   */
+  @Test
+  public void anAbortWithNoCauseIsAnAbortAndNotASuccess() {
+    check(MirrorOutcome.ABORTED_OTHER, MirrorOutcome.Stop.NONE, MirrorOutcome.EXIT_MIRROR_ABORTED,
+        MirrorOutcome.ABORT_NONE, 0, 0);
+    check(MirrorOutcome.ABORTED_OTHER, MirrorOutcome.Stop.NONE, MirrorOutcome.EXIT_MIRROR_ABORTED,
+        MirrorOutcome.ABORT_NONE, 0, 40);
+    check(MirrorOutcome.ABORTED_OTHER, MirrorOutcome.Stop.ENGINE, MirrorOutcome.EXIT_MIRROR_ABORTED,
+        MirrorOutcome.ABORT_NONE, 0, 400);
+  }
+
+  /** The abort channel is the exit code's alone: 3 as an abortCode() still means an unnamed cause. */
+  @Test
+  public void theTwoChannelsAreReadSeparately() {
+    check(MirrorOutcome.ABORTED_OTHER, MirrorOutcome.Stop.NONE, EXIT_OK, ABORT_UNKNOWN, 0, 40);
+    check(MirrorOutcome.SUCCESS, MirrorOutcome.Stop.NONE, EXIT_OK, MirrorOutcome.ABORT_NONE, 0, 40);
   }
 }

--- a/app/src/test/java/com/httrack/android/MirrorOutcomeTest.java
+++ b/app/src/test/java/com/httrack/android/MirrorOutcomeTest.java
@@ -137,5 +137,6 @@ public class MirrorOutcomeTest {
     assertFalse(MirrorOutcome.mirrorAborted(-1));
     assertFalse(MirrorOutcome.mirrorAborted(1));
     assertFalse(MirrorOutcome.mirrorAborted(2));
+    assertFalse(MirrorOutcome.mirrorAborted(255));
   }
 }


### PR DESCRIPTION
Bumps the vendored engine 26 commits to 24deba93. httrack #1419 changed an exported contract: `hts_main2()` now returns 3 for a mirror it gave up on, where before it returned the same 0 as a finished one. Our finished pane only classified a run when the code was 0, so on the new engine a disk-full or link-cap abort would have shown a bare "Error (code 3)" with no link to the mirror folder, instead of naming what ran out. The exit code is its own channel, not a second spelling of `abortCode()`. `httpmirror()` gives up on a few guards without ever setting `exit_xh`, and there `abortCode()` and the stats both read like a clean run while only the exit code disagrees.

Deciding what the pane says moved out of `runInternal()` into `MirrorOutcome.decide()`, which returns the text and whether a mirror exists to link to. Three source-text guards over the old inline version were each defeated by editing the text they searched, and the folder-link half of the invariant was never visible to a regex at all. The table test that replaced them fails on every edit that beat them. The activity's fifty lines are nine now, and every user-visible string is byte-identical to master.

Nothing else in the engine range needs anything here. The option surface, the compiled source list and the guide anchors behind the Help deep links are all unchanged, and the UTF-8 catalog move was already in the previous pin.