### PR TITLE
The workflow action pins only move when someone notices

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+# gradle and gitsubmodule stay out: bumping the engine pin or a runtime dep
+# needs a device run, and no CI leg does one.
+updates:
+  # Keep the workflow action pins current (they only rot manually otherwise).
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    ignore:
+      # play-publish.yml never runs on a PR, so no check validates this bump.
+      - dependency-name: r0adkll/upload-google-play

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -23,6 +23,8 @@ env:
   NDK_VERSION: r27d
   OPENSSL_VERSION: "3.0.15"
 
+# native and assemble are the two required checks. Never give either a job-level `if:`,
+# because a skipped check run counts as success and auto-merge would land on a build that never ran.
 jobs:
   # Native-only: proves recursive submodules (incl. nested coucal), libiconv
   # vendoring, OpenSSL 3.x, and the 64-bit ndk-build. x86_64 needs the coffeecatch

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -7,7 +7,9 @@ name: Dependabot auto-merge
 on: pull_request_target
 
 concurrency:
-  group: dependabot-automerge-${{ github.ref }}
+  # On pull_request_target github.ref is the base branch, so keying on it puts every PR in one
+  # group. Any later PR event, human ones included, then cancels an in-flight arming run.
+  group: dependabot-automerge-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 permissions:
@@ -19,7 +21,12 @@ permissions:
 jobs:
   automerge:
     name: Arm auto-merge
-    if: github.repository == 'xroche/httrack-android' && github.actor == 'dependabot[bot]'
+    # github.actor is the pusher, not the author, so a dependabot push onto a fork PR can
+    # satisfy it. The head-repo clause is the one that cannot be forged.
+    if: >-
+      github.repository == 'xroche/httrack-android'
+      && github.event.pull_request.user.login == 'dependabot[bot]'
+      && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-24.04
     steps:
       # Dependabot's body is a release-notes dump, so give the squash commit a body of its own.

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,5 +1,5 @@
 # Auto-merge saves the manual click, but only the two required jobs gate it. A pin those jobs
-# never run, such as the release and docker workflows' actions, merges unexercised.
+# never run, such as actions/download-artifact, merges unexercised.
 name: Dependabot auto-merge
 
 # pull_request_target, because a dependabot pull_request gets a read-only token.

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,4 +1,5 @@
-# CI already validates every pin dependabot bumps here, so auto-merge only saves the manual click.
+# Auto-merge saves the manual click, but only the two required jobs gate it. A pin those jobs
+# never run, such as the release and docker workflows' actions, merges unexercised.
 name: Dependabot auto-merge
 
 # pull_request_target, because a dependabot pull_request gets a read-only token.

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,31 @@
+# CI already validates every pin dependabot bumps here, so auto-merge only saves the manual click.
+name: Dependabot auto-merge
+
+# pull_request_target, because a dependabot pull_request gets a read-only token.
+# Nothing from the PR is checked out or run, so the writable token stays safe.
+on: pull_request_target
+
+concurrency:
+  group: dependabot-automerge-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  # Both writes are what enabling auto-merge costs: the API call needs the pull
+  # request scope, and the merge it queues needs the contents one.
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    name: Arm auto-merge
+    if: github.repository == 'xroche/httrack-android' && github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-24.04
+    steps:
+      # Dependabot's body is a release-notes dump, so give the squash commit a body of its own.
+      - name: Enable auto-merge
+        run: gh pr merge --auto --squash --subject "$PR_TITLE (#$PR_NUMBER)" --body "" "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Nothing bumps the action pins across the seven workflows here, so they move only when someone notices. Dependabot now opens a weekly PR per pin, and `dependabot-automerge.yml` arms auto-merge on it. The required "assemble (AGP 8)" and "native (ndk-build)" checks still gate that merge.

The workflow is xroche/httrack's file of the same name, with the `github.repository ==` guard repointed and its header comment rewritten. That comment claimed CI validates every pin dependabot bumps, which is not true here. `docker/login-action`, `docker/build-push-action` and `actions/download-artifact` run in no PR-triggered workflow at all.

Only github-actions is enabled. A Gradle bump moves what ships in the APK. MirrorServerTest drives nanohttpd over a real socket under the required checks. No androidTest source set exists, so nothing exercises Custom Tabs or the app on a device. A submodule bump moves the engine, which needs the `versionName` realignment and the `Android.mk` source-list check of a release round. `r0adkll/upload-google-play` is ignored for the same reason: no PR runs `play-publish.yml`, so nothing validates that bump before it reaches the Play upload path. Dependabot security updates are disabled on this repo, so no advisory-driven PR opens today.

The guard tests `github.event.pull_request.user.login` and the head repo, not `github.actor`. `github.actor` is the pusher, so a dependabot push onto a fork PR can satisfy it. The concurrency key is the PR number. `pull_request_target` reports the base branch as `github.ref`, so one shared group lets any later PR cancel an in-flight arming run.

`android.yml` now warns off a job-level `if:` on the two required jobs. A skipped check run counts as success, so an `if:` there would let auto-merge land on a build that never ran.