### PR TITLE
The auto-merge guard comment implies its author clause is forgeable

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -22,7 +22,7 @@ jobs:
   automerge:
     name: Arm auto-merge
     # github.actor is the pusher, not the author, so a dependabot push onto a fork PR can
-    # satisfy it. The head-repo clause is the one that cannot be forged.
+    # satisfy it. Dependabot never opens a PR from a fork.
     if: >-
       github.repository == 'xroche/httrack-android'
       && github.event.pull_request.user.login == 'dependabot[bot]'

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -21,8 +21,8 @@ permissions:
 jobs:
   automerge:
     name: Arm auto-merge
-    # github.actor is the pusher, not the author, so a dependabot push onto a fork PR can
-    # satisfy it. The head-repo clause still holds if the author check is ever loosened.
+    # github.actor names whoever triggered the event, so the author check reads user.login.
+    # The head-repo clause makes dependabot's same-repo branches a precondition, not an assumption.
     if: >-
       github.repository == 'xroche/httrack-android'
       && github.event.pull_request.user.login == 'dependabot[bot]'

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -22,7 +22,7 @@ jobs:
   automerge:
     name: Arm auto-merge
     # github.actor is the pusher, not the author, so a dependabot push onto a fork PR can
-    # satisfy it. Dependabot never opens a PR from a fork.
+    # satisfy it. The head-repo clause still holds if the author check is ever loosened.
     if: >-
       github.repository == 'xroche/httrack-android'
       && github.event.pull_request.user.login == 'dependabot[bot]'


### PR DESCRIPTION
The comment on the auto-merge guard ranked its two clauses, calling the head-repo one the only clause that cannot be forged. Neither can be forged. GitHub logins hold only letters, digits and hyphens, so `dependabot[bot]` is unregisterable.

It also said `github.actor` is the pusher rather than the author. `github.actor` names whoever triggered the event, and on `opened` that is the author, so the old wording was false for the default event set.

The replacement gives each clause its own present-tense reason. The author check reads `user.login` because `github.actor` names a triggerer. The head-repo clause turns dependabot's same-repo branches from an assumption into a precondition the run enforces.