### PR TITLE
No tool here can read the crash and ANR rates Play warns about

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -121,6 +121,7 @@ jobs:
       - run: pip install -r tools/ci/play-requirements.txt
       - run: python3 tools/ci/play_track_admin_test.py
       - run: python3 tools/ci/play_reviews_test.py
+      - run: python3 tools/ci/play_vitals_test.py
       # No job builds an .aab, so the alignment script's bundle branch has no other cover.
       - run: tools/ci/check-so-alignment-test.sh
 

--- a/.github/workflows/play-vitals.yml
+++ b/.github/workflows/play-vitals.yml
@@ -1,0 +1,60 @@
+# Android vitals live in the Play Developer Reporting API, not in androidpublisher, so
+# they need their own scope and their own Console grant. Read-only: nothing here writes
+# to Play.
+name: Play vitals
+
+on:
+  workflow_dispatch:
+    inputs:
+      command:
+        description: 'probe (access check), rates (crash/ANR rates), issues (top clusters + stack traces)'
+        type: choice
+        options: [probe, rates, issues]
+        default: probe
+      days:
+        description: 'days back from the freshest data'
+        default: '28'
+      by:
+        description: 'rates: dimension to split on (versionCode, apiLevel, deviceModel, or blank)'
+        default: versionCode
+      kind:
+        description: 'issues: crash, anr or both'
+        default: both
+      version_code:
+        description: 'issues: restrict to one versionCode (blank = all)'
+        default: ''
+
+permissions:
+  contents: read
+
+jobs:
+  vitals:
+    name: read Android vitals
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: pip install -r tools/ci/play-requirements.txt
+      - name: Read vitals
+        # Inputs go through the environment, never interpolated into the script body.
+        env:
+          SA_JSON: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+          COMMAND: ${{ inputs.command }}
+          DAYS: ${{ inputs.days }}
+          BY: ${{ inputs.by }}
+          KIND: ${{ inputs.kind }}
+          VERSION_CODE: ${{ inputs.version_code }}
+        run: |
+          set -euo pipefail
+          umask 077
+          trap 'rm -f "$RUNNER_TEMP/play-sa.json"' EXIT
+          printf '%s' "$SA_JSON" > "$RUNNER_TEMP/play-sa.json"
+          args=()
+          case "$COMMAND" in
+            rates)  args+=(--days "$DAYS" --by "$BY") ;;
+            issues) args+=(--days "$DAYS" --kind "$KIND")
+                    if [ -n "$VERSION_CODE" ]; then args+=(--version-code "$VERSION_CODE"); fi ;;
+          esac
+          python3 tools/ci/play_vitals.py "$RUNNER_TEMP/play-sa.json" "$COMMAND" "${args[@]}"

--- a/tools/ci/play_vitals.py
+++ b/tools/ci/play_vitals.py
@@ -170,6 +170,9 @@ def cmd_issues(token, args):
         sys.exit("no freshness data; run probe first")
     end = datetime.date(latest["year"], latest["month"], latest["day"])
     start = end - datetime.timedelta(days=args.days)
+    # errorIssues:search rejects a named zone ("Unsupported timezone"), unlike the metric
+    # queries, which need one. UTC is the only id it takes.
+    tz = "UTC"
     for kind in kinds:
         terms = [f"errorIssueType = {kind}"]
         if args.version_code:
@@ -178,8 +181,8 @@ def cmd_issues(token, args):
             "",
             {
                 "interval": {
-                    "startTime": datetime_at(start, args.timezone),
-                    "endTime": datetime_at(end, args.timezone),
+                    "startTime": datetime_at(start, tz),
+                    "endTime": datetime_at(end, tz),
                 },
                 "filter": " AND ".join(terms),
                 "orderBy": "distinctUsers desc",
@@ -200,14 +203,29 @@ def cmd_issues(token, args):
             print(f"    {issue.get('type')} in {issue.get('location')}")
             print(f"    {issue.get('cause')}")
             print(f"    id {issue.get('name')}")
-            for report in issue.get("sampleErrorReports", []) or []:
-                print(indent(fetch_report(token, report)))
+            for text in search_reports(token, issue.get("name", ""), start, end, tz, args.samples):
+                print(indent(text))
 
 
-def fetch_report(token, name):
-    """The stack trace behind one sample, which the issue itself does not carry."""
-    res = call(token, f"https://playdeveloperreporting.googleapis.com/v1beta1/{name}")
-    return res.get("reportText", json.dumps(res, indent=2))
+def search_reports(token, issue_name, start, end, tz, limit):
+    """The stack traces behind one cluster.
+
+    The issue carries sample report names, but only the names, and they are not a
+    resource path any GET accepts. errorReports:search filtered on the issue id is the
+    route that works.
+    """
+    issue_id = issue_name.rsplit("/", 1)[-1]
+    params = flatten(
+        "",
+        {
+            "interval": {"startTime": datetime_at(start, tz), "endTime": datetime_at(end, tz)},
+            "filter": f"errorIssueId = {issue_id}",
+            "pageSize": limit,
+        },
+        {},
+    )
+    res = call(token, f"{BASE}/errorReports:search", params=params)
+    return [r.get("reportText", "") for r in res.get("errorReports", [])]
 
 
 def indent(text):

--- a/tools/ci/play_vitals.py
+++ b/tools/ci/play_vitals.py
@@ -16,6 +16,7 @@ service account have access at all" without asking for any data.
 """
 
 import argparse
+import collections
 import json
 import sys
 
@@ -30,25 +31,36 @@ BASE = f"https://playdeveloperreporting.googleapis.com/v1beta1/apps/{PKG}"
 # that timezone or the buckets do not line up with what the Console shows.
 DEFAULT_TZ = "America/Los_Angeles"
 
-# The rates Play compares against its thresholds: user-perceived, weighted over 28 days
-# by distinct users. The plain rate is kept because a per-version split of the weighted
-# one is meaningless on its own.
-CRASH_METRICS = ["userPerceivedCrashRate28dUserWeighted", "userPerceivedCrashRate", "distinctUsers"]
-ANR_METRICS = ["userPerceivedAnrRate28dUserWeighted", "userPerceivedAnrRate", "distinctUsers"]
+MetricSet = collections.namedtuple("MetricSet", "name weighted metrics threshold")
 
-# The bad-behaviour thresholds Play warns on, so the output can say which rows are over.
-CRASH_THRESHOLD = 0.0109
-ANR_THRESHOLD = 0.0047
+# The rate Play compares against its threshold is the user-perceived one, weighted over 28
+# days by distinct users. The plain rate rides along because a per-version split of the
+# weighted one is meaningless on its own.
+METRIC_SETS = (
+    MetricSet(
+        "crashRateMetricSet",
+        "userPerceivedCrashRate28dUserWeighted",
+        ["userPerceivedCrashRate28dUserWeighted", "userPerceivedCrashRate", "distinctUsers"],
+        0.0109,
+    ),
+    MetricSet(
+        "anrRateMetricSet",
+        "userPerceivedAnrRate28dUserWeighted",
+        ["userPerceivedAnrRate28dUserWeighted", "userPerceivedAnrRate", "distinctUsers"],
+        0.0047,
+    ),
+)
 
 
-def flatten(prefix, value, out):
+def flatten(value, out=None, prefix=""):
     """Encode a nested body as the dotted query parameters the search methods take."""
+    out = {} if out is None else out
     if isinstance(value, dict):
         for k, v in value.items():
-            flatten(f"{prefix}.{k}" if prefix else k, v, out)
+            flatten(v, out, f"{prefix}.{k}" if prefix else k)
     elif isinstance(value, list):
         for v in value:
-            flatten(prefix, v, out)
+            flatten(v, out, prefix)
     else:
         out.setdefault(prefix, []).append(str(value))
     return out
@@ -84,8 +96,13 @@ def call(token, url, method="GET", body=None, params=None):
             f"{r.text}"
         )
     if not r.ok:
-        sys.exit(f"{r.status_code} {r.request.method} {r.url}\n{r.text}")
-    return r.json()
+        sys.exit(f"{r.status_code} {method} {url}\n{r.text}")
+    if not r.content:
+        return {}
+    try:
+        return r.json()
+    except ValueError:
+        sys.exit(f"{r.status_code} {method} {url} answered non-JSON:\n{r.text[:500]}")
 
 
 def day_str(day):
@@ -101,31 +118,57 @@ def freshness(metric_set):
 
 
 def cmd_probe(token, _args):
-    for name in ("crashRateMetricSet", "anrRateMetricSet"):
-        latest = freshness(call(token, f"{BASE}/{name}"))
+    for metric_set in METRIC_SETS:
+        latest = freshness(call(token, f"{BASE}/{metric_set.name}"))
         when = day_str(latest) if latest else "no DAILY freshness reported"
-        print(f"{name}: readable, data through {when}")
+        print(f"{metric_set.name}: readable, data through {when}")
+
+
+def dimension_value(d):
+    """A dimension arrives as one of two typed fields, and "" and 0 are both real values."""
+    for key in ("stringValue", "int64Value"):
+        if key in d:
+            return d[key]
+    return None
 
 
 def rates_row(row, metrics):
+    """One row as (dimension name -> value, the metrics in the order asked for)."""
     values = {m["metric"]: m.get("decimalValue", {}).get("value") for m in row.get("metrics", [])}
-    dims = {
-        d["dimension"]: d.get("stringValue") or d.get("int64Value")
-        for d in row.get("dimensions", [])
-    }
-    return dims, [values.get(m) for m in metrics]
+    dims = {d["dimension"]: dimension_value(d) for d in row.get("dimensions", [])}
+    return dims, {m: values.get(m) for m in metrics}
+
+
+def print_rates(res, metric_set, by, span):
+    """Print one metric set's timeline, marking the rows Play would call bad behaviour."""
+    print(f"=== {metric_set.name} {span} by {by or 'nothing'} ===")
+    print("  " + "\t".join(["day"] + ([by] if by else []) + metric_set.metrics))
+    over = 0
+    for row in res.get("rows", []):
+        dims, values = rates_row(row, metric_set.metrics)
+        weighted = values[metric_set.weighted]
+        flag = ""
+        if weighted is not None and float(weighted) > metric_set.threshold:
+            flag, over = "  OVER", over + 1
+        cells = [day_str(row.get("startTime", {}))]
+        cells += [str(v) for v in dims.values()] + [str(v) for v in values.values()]
+        print("  " + "\t".join(cells) + flag)
+    print(f"  ({over} row(s) above the {metric_set.threshold:.2%} threshold)")
+    if not res.get("rows"):
+        print(
+            "  no rows: Play withholds dimensioned data below its privacy "
+            "aggregation threshold, so try again without --by"
+        )
+    return over
 
 
 def cmd_rates(token, args):
     import datetime
 
-    for name, metrics, threshold in (
-        ("crashRateMetricSet", CRASH_METRICS, CRASH_THRESHOLD),
-        ("anrRateMetricSet", ANR_METRICS, ANR_THRESHOLD),
-    ):
-        latest = freshness(call(token, f"{BASE}/{name}"))
+    for metric_set in METRIC_SETS:
+        latest = freshness(call(token, f"{BASE}/{metric_set.name}"))
         if not latest:
-            print(f"=== {name}: no data ===")
+            print(f"=== {metric_set.name}: no data ===")
             continue
         end = datetime.date(latest["year"], latest["month"], latest["day"])
         start = end - datetime.timedelta(days=args.days)
@@ -136,29 +179,11 @@ def cmd_rates(token, args):
                 "endTime": datetime_at(end, args.timezone),
             },
             "dimensions": [args.by] if args.by else [],
-            "metrics": metrics,
+            "metrics": metric_set.metrics,
             "pageSize": 1000,
         }
-        res = call(token, f"{BASE}/{name}:query", method="POST", body=body)
-        print(f"=== {name} {start}..{end} by {args.by or 'nothing'} ===")
-        print("  " + "\t".join(["day"] + ([args.by] if args.by else []) + metrics))
-        over = 0
-        for row in res.get("rows", []):
-            dims, values = rates_row(row, metrics)
-            day = row.get("startTime", {})
-            stamp = day_str(day)
-            weighted = values[0]
-            flag = ""
-            if weighted is not None and float(weighted) > threshold:
-                flag, over = "  OVER", over + 1
-            cells = [stamp] + [str(v) for v in dims.values()] + [str(v) for v in values]
-            print("  " + "\t".join(cells) + flag)
-        print(f"  ({over} row(s) above the {threshold:.2%} threshold)")
-        if not res.get("rows"):
-            print(
-                "  no rows: Play withholds dimensioned data below its privacy "
-                "aggregation threshold, so try again without --by"
-            )
+        res = call(token, f"{BASE}/{metric_set.name}:query", method="POST", body=body)
+        print_rates(res, metric_set, args.by, f"{start}..{end}")
 
 
 def cmd_issues(token, args):

--- a/tools/ci/play_vitals.py
+++ b/tools/ci/play_vitals.py
@@ -169,6 +169,7 @@ def print_rates(res, metric_set, by, span):
 def cmd_rates(token, args):
     import datetime
 
+    over = {}
     for metric_set in METRIC_SETS:
         latest = freshness(call(token, f"{BASE}/{metric_set.name}"))
         if not latest:
@@ -187,7 +188,9 @@ def cmd_rates(token, args):
             "pageSize": 1000,
         }
         res = call(token, f"{BASE}/{metric_set.name}:query", method="POST", body=body)
-        print_rates(res, metric_set, args.by, f"{start}..{end}")
+        over[metric_set.name] = print_rates(res, metric_set, args.by, f"{start}..{end}")
+    bad = [name for name, count in over.items() if count]
+    print(f"\nover threshold: {', '.join(bad) if bad else 'nothing'}")
 
 
 def cmd_issues(token, args):

--- a/tools/ci/play_vitals.py
+++ b/tools/ci/play_vitals.py
@@ -71,7 +71,7 @@ def _flatten(value, out, prefix):
 
 
 def datetime_at(day, tz):
-    """A day boundary as the API's DateTime, which needs an explicit zone."""
+    """Returns a day boundary as the API's DateTime, which needs an explicit zone."""
     return {
         "year": day.year,
         "month": day.month,
@@ -114,7 +114,7 @@ def day_str(day):
 
 
 def freshness(metric_set):
-    """The last day the set has data for; a query past it comes back empty."""
+    """Returns the last day the set has data for. A query past it comes back empty."""
     for f in metric_set.get("freshnessInfo", {}).get("freshnesses", []):
         if f.get("aggregationPeriod") == "DAILY":
             return f.get("latestEndTime", {})
@@ -129,7 +129,7 @@ def cmd_probe(token, _args):
 
 
 def dimension_value(d):
-    """A dimension arrives as one of two typed fields, and "" and 0 are both real values."""
+    """Returns a dimension's value. It has two typed fields, and "" and 0 are both real."""
     for key in ("stringValue", "int64Value"):
         if key in d:
             return d[key]
@@ -137,7 +137,7 @@ def dimension_value(d):
 
 
 def rates_row(row, metrics):
-    """One row as (dimension name -> value, the metrics in the order asked for)."""
+    """Returns one row as (dimension name -> value, the metrics in the order asked for)."""
     values = {m["metric"]: m.get("decimalValue", {}).get("value") for m in row.get("metrics", [])}
     dims = {d["dimension"]: dimension_value(d) for d in row.get("dimensions", [])}
     return dims, {m: values.get(m) for m in metrics}
@@ -235,7 +235,7 @@ def cmd_issues(token, args):
 
 
 def search_reports(token, issue_name, start, end, tz, limit):
-    """The stack traces behind one cluster.
+    """Returns the stack traces behind one cluster.
 
     The issue carries sample report names, but only the names, and they are not a
     resource path any GET accepts. errorReports:search filtered on the issue id is the

--- a/tools/ci/play_vitals.py
+++ b/tools/ci/play_vitals.py
@@ -52,18 +52,22 @@ METRIC_SETS = (
 )
 
 
-def flatten(value, out=None, prefix=""):
+def flatten(body):
     """Encode a nested body as the dotted query parameters the search methods take."""
-    out = {} if out is None else out
+    out = {}
+    _flatten(body, out, "")
+    return out
+
+
+def _flatten(value, out, prefix):
     if isinstance(value, dict):
         for k, v in value.items():
-            flatten(v, out, f"{prefix}.{k}" if prefix else k)
+            _flatten(v, out, f"{prefix}.{k}" if prefix else k)
     elif isinstance(value, list):
         for v in value:
-            flatten(v, out, prefix)
+            _flatten(v, out, prefix)
     else:
         out.setdefault(prefix, []).append(str(value))
-    return out
 
 
 def datetime_at(day, tz):
@@ -203,7 +207,6 @@ def cmd_issues(token, args):
         if args.version_code:
             terms.append(f"versionCode = {args.version_code}")
         params = flatten(
-            "",
             {
                 "interval": {
                     "startTime": datetime_at(start, tz),
@@ -213,8 +216,7 @@ def cmd_issues(token, args):
                 "orderBy": "distinctUsers desc",
                 "pageSize": args.limit,
                 "sampleErrorReportLimit": args.samples,
-            },
-            {},
+            }
         )
         res = call(token, f"{BASE}/errorIssues:search", params=params)
         issues = res.get("errorIssues", [])
@@ -241,13 +243,11 @@ def search_reports(token, issue_name, start, end, tz, limit):
     """
     issue_id = issue_name.rsplit("/", 1)[-1]
     params = flatten(
-        "",
         {
             "interval": {"startTime": datetime_at(start, tz), "endTime": datetime_at(end, tz)},
             "filter": f"errorIssueId = {issue_id}",
             "pageSize": limit,
-        },
-        {},
+        }
     )
     res = call(token, f"{BASE}/errorReports:search", params=params)
     return [r.get("reportText", "") for r in res.get("errorReports", [])]

--- a/tools/ci/play_vitals.py
+++ b/tools/ci/play_vitals.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Read Android vitals: crash and ANR rates, and the error clusters behind them.
+
+androidpublisher, which the other scripts here speak, carries no quality data at
+all. The rates Play warns about live in the Play Developer Reporting API, a
+separate service with its own scope and its own permission grant.
+
+Usage:
+  play_vitals.py <sa_json> probe
+  play_vitals.py <sa_json> rates [--days N] [--by versionCode|apiLevel|deviceModel]
+  play_vitals.py <sa_json> issues [--kind crash|anr|both] [--days N] [--limit N]
+                            [--samples N] [--version-code VC]
+
+`probe` only reads the two metric-set descriptors, so it answers "does this
+service account have access at all" without asking for any data.
+"""
+
+import argparse
+import json
+import sys
+
+import requests
+
+from play_track_admin import PKG, TIMEOUT, access_token
+
+REPORTING_SCOPE = "https://www.googleapis.com/auth/playdeveloperreporting"
+BASE = f"https://playdeveloperreporting.googleapis.com/v1beta1/apps/{PKG}"
+
+# Play attributes a day to the app's reporting timezone, and a DAILY query must ask in
+# that timezone or the buckets do not line up with what the Console shows.
+DEFAULT_TZ = "America/Los_Angeles"
+
+# The rates Play compares against its thresholds: user-perceived, weighted over 28 days
+# by distinct users. The plain rate is kept because a per-version split of the weighted
+# one is meaningless on its own.
+CRASH_METRICS = ["userPerceivedCrashRate28dUserWeighted", "userPerceivedCrashRate", "distinctUsers"]
+ANR_METRICS = ["userPerceivedAnrRate28dUserWeighted", "userPerceivedAnrRate", "distinctUsers"]
+
+# The bad-behaviour thresholds Play warns on, so the output can say which rows are over.
+CRASH_THRESHOLD = 0.0109
+ANR_THRESHOLD = 0.0047
+
+
+def flatten(prefix, value, out):
+    """Encode a nested body as the dotted query parameters the search methods take."""
+    if isinstance(value, dict):
+        for k, v in value.items():
+            flatten(f"{prefix}.{k}" if prefix else k, v, out)
+    elif isinstance(value, list):
+        for v in value:
+            flatten(prefix, v, out)
+    else:
+        out.setdefault(prefix, []).append(str(value))
+    return out
+
+
+def datetime_at(day, tz):
+    """A day boundary as the API's DateTime, which needs an explicit zone."""
+    return {
+        "year": day.year,
+        "month": day.month,
+        "day": day.day,
+        "hours": 0,
+        "timeZone": {"id": tz},
+    }
+
+
+def call(token, url, method="GET", body=None, params=None):
+    r = requests.request(
+        method,
+        url,
+        headers={"Authorization": f"Bearer {token}"},
+        json=body,
+        params=params,
+        timeout=TIMEOUT,
+    )
+    if r.status_code == 403:
+        sys.exit(
+            "403 from the Reporting API. Two different causes, and the message says which:\n"
+            '  "has not been used in project N" -> enable Play Developer Reporting API on\n'
+            "     that Cloud project, the one owning the service account key.\n"
+            '  "caller does not have permission" -> in Play Console, Users and permissions,\n'
+            "     grant this service account 'View app quality information (read-only)'.\n\n"
+            f"{r.text}"
+        )
+    if not r.ok:
+        sys.exit(f"{r.status_code} {r.request.method} {r.url}\n{r.text}")
+    return r.json()
+
+
+def day_str(day):
+    return f"{day.get('year')}-{day.get('month'):02d}-{day.get('day'):02d}"
+
+
+def freshness(metric_set):
+    """The last day the set has data for; a query past it comes back empty."""
+    for f in metric_set.get("freshnessInfo", {}).get("freshnesses", []):
+        if f.get("aggregationPeriod") == "DAILY":
+            return f.get("latestEndTime", {})
+    return {}
+
+
+def cmd_probe(token, _args):
+    for name in ("crashRateMetricSet", "anrRateMetricSet"):
+        latest = freshness(call(token, f"{BASE}/{name}"))
+        when = day_str(latest) if latest else "no DAILY freshness reported"
+        print(f"{name}: readable, data through {when}")
+
+
+def rates_row(row, metrics):
+    values = {m["metric"]: m.get("decimalValue", {}).get("value") for m in row.get("metrics", [])}
+    dims = {
+        d["dimension"]: d.get("stringValue") or d.get("int64Value")
+        for d in row.get("dimensions", [])
+    }
+    return dims, [values.get(m) for m in metrics]
+
+
+def cmd_rates(token, args):
+    import datetime
+
+    for name, metrics, threshold in (
+        ("crashRateMetricSet", CRASH_METRICS, CRASH_THRESHOLD),
+        ("anrRateMetricSet", ANR_METRICS, ANR_THRESHOLD),
+    ):
+        latest = freshness(call(token, f"{BASE}/{name}"))
+        if not latest:
+            print(f"=== {name}: no data ===")
+            continue
+        end = datetime.date(latest["year"], latest["month"], latest["day"])
+        start = end - datetime.timedelta(days=args.days)
+        body = {
+            "timelineSpec": {
+                "aggregationPeriod": "DAILY",
+                "startTime": datetime_at(start, args.timezone),
+                "endTime": datetime_at(end, args.timezone),
+            },
+            "dimensions": [args.by] if args.by else [],
+            "metrics": metrics,
+            "pageSize": 1000,
+        }
+        res = call(token, f"{BASE}/{name}:query", method="POST", body=body)
+        print(f"=== {name} {start}..{end} by {args.by or 'nothing'} ===")
+        print("  " + "\t".join(["day"] + ([args.by] if args.by else []) + metrics))
+        over = 0
+        for row in res.get("rows", []):
+            dims, values = rates_row(row, metrics)
+            day = row.get("startTime", {})
+            stamp = day_str(day)
+            weighted = values[0]
+            flag = ""
+            if weighted is not None and float(weighted) > threshold:
+                flag, over = "  OVER", over + 1
+            cells = [stamp] + [str(v) for v in dims.values()] + [str(v) for v in values]
+            print("  " + "\t".join(cells) + flag)
+        print(f"  ({over} row(s) above the {threshold:.2%} threshold)")
+        if not res.get("rows"):
+            print(
+                "  no rows: Play withholds dimensioned data below its privacy "
+                "aggregation threshold, so try again without --by"
+            )
+
+
+def cmd_issues(token, args):
+    import datetime
+
+    kinds = ["CRASH", "ANR"] if args.kind == "both" else [args.kind.upper()]
+    latest = freshness(call(token, f"{BASE}/crashRateMetricSet"))
+    if not latest:
+        sys.exit("no freshness data; run probe first")
+    end = datetime.date(latest["year"], latest["month"], latest["day"])
+    start = end - datetime.timedelta(days=args.days)
+    for kind in kinds:
+        terms = [f"errorIssueType = {kind}"]
+        if args.version_code:
+            terms.append(f"versionCode = {args.version_code}")
+        params = flatten(
+            "",
+            {
+                "interval": {
+                    "startTime": datetime_at(start, args.timezone),
+                    "endTime": datetime_at(end, args.timezone),
+                },
+                "filter": " AND ".join(terms),
+                "orderBy": "distinctUsers desc",
+                "pageSize": args.limit,
+                "sampleErrorReportLimit": args.samples,
+            },
+            {},
+        )
+        res = call(token, f"{BASE}/errorIssues:search", params=params)
+        issues = res.get("errorIssues", [])
+        print(f"=== top {kind} clusters {start}..{end} ({len(issues)}) ===")
+        for issue in issues:
+            print(
+                f"\n--- {issue.get('distinctUsers')} users, "
+                f"{issue.get('errorReportCount')} reports, "
+                f"last seen {issue.get('lastErrorReportTime')}"
+            )
+            print(f"    {issue.get('type')} in {issue.get('location')}")
+            print(f"    {issue.get('cause')}")
+            print(f"    id {issue.get('name')}")
+            for report in issue.get("sampleErrorReports", []) or []:
+                print(indent(fetch_report(token, report)))
+
+
+def fetch_report(token, name):
+    """The stack trace behind one sample, which the issue itself does not carry."""
+    res = call(token, f"https://playdeveloperreporting.googleapis.com/v1beta1/{name}")
+    return res.get("reportText", json.dumps(res, indent=2))
+
+
+def indent(text):
+    return "\n".join("      " + line for line in text.splitlines())
+
+
+def main():
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    p.add_argument("sa_json")
+    p.add_argument("--timezone", default=DEFAULT_TZ)
+    sub = p.add_subparsers(dest="cmd", required=True)
+    sub.add_parser("probe")
+    r = sub.add_parser("rates")
+    r.add_argument("--days", type=int, default=28)
+    r.add_argument(
+        "--by", default="versionCode", choices=["versionCode", "apiLevel", "deviceModel", ""]
+    )
+    i = sub.add_parser("issues")
+    i.add_argument("--kind", default="both", choices=["crash", "anr", "both"])
+    i.add_argument("--days", type=int, default=28)
+    i.add_argument("--limit", type=int, default=15)
+    i.add_argument("--samples", type=int, default=1)
+    i.add_argument("--version-code", type=int)
+    args = p.parse_args()
+
+    with open(args.sa_json, encoding="utf-8") as f:
+        sa = json.load(f)
+    token = access_token(sa, scope=REPORTING_SCOPE)
+    {"probe": cmd_probe, "rates": cmd_rates, "issues": cmd_issues}[args.cmd](token, args)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/ci/play_vitals_test.py
+++ b/tools/ci/play_vitals_test.py
@@ -176,5 +176,54 @@ class Probe(unittest.TestCase):
         self.assertEqual(printed.count("2026-09-07"), len(pv.METRIC_SETS))
 
 
+class SearchParams(unittest.TestCase):
+    """The command paths build their own query, and nothing used to exercise them.
+
+    A refactor of flatten() left both call sites passing the old argument order. Every
+    unit test still passed, because they all called flatten() directly.
+    """
+
+    def captured_params(self, fn):
+        seen = {}
+
+        def fake_call(_token, url, method="GET", body=None, params=None):
+            seen["url"], seen["params"] = url, params
+            return {}
+
+        with mock.patch("play_vitals.call", side_effect=fake_call):
+            fn()
+        return seen
+
+    def test_search_reports_sends_a_dotted_interval_and_filter(self):
+        seen = self.captured_params(
+            lambda: pv.search_reports(
+                "t",
+                "apps/com.httrack.android/abc123",
+                datetime.date(2026, 8, 10),
+                datetime.date(2026, 9, 7),
+                "UTC",
+                1,
+            )
+        )
+        self.assertTrue(seen["url"].endswith("/errorReports:search"))
+        self.assertEqual(seen["params"]["interval.startTime.year"], ["2026"])
+        self.assertEqual(seen["params"]["interval.endTime.day"], ["7"])
+        self.assertEqual(seen["params"]["filter"], ["errorIssueId = abc123"])
+        self.assertEqual(seen["params"]["pageSize"], ["1"])
+
+    def test_the_issue_id_is_taken_from_the_last_path_segment(self):
+        seen = self.captured_params(
+            lambda: pv.search_reports(
+                "t",
+                "apps/com.httrack.android/deadbeef",
+                datetime.date(2026, 9, 1),
+                datetime.date(2026, 9, 7),
+                "UTC",
+                2,
+            )
+        )
+        self.assertEqual(seen["params"]["filter"], ["errorIssueId = deadbeef"])
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tools/ci/play_vitals_test.py
+++ b/tools/ci/play_vitals_test.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Tests for play_vitals.py, stubbing what the Reporting API really returns."""
+
+import datetime
+import io
+import os
+import sys
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import play_vitals as pv  # noqa: E402
+
+
+class Flatten(unittest.TestCase):
+    """The search methods take the nested body as dotted query parameters."""
+
+    def test_nested_interval_becomes_dotted_keys(self):
+        got = pv.flatten("", {"interval": {"startTime": {"year": 2026, "hours": 0}}}, {})
+        self.assertEqual(got["interval.startTime.year"], ["2026"])
+        self.assertEqual(got["interval.startTime.hours"], ["0"])
+
+    def test_a_zone_survives_the_flattening(self):
+        got = pv.flatten("", {"i": pv.datetime_at(datetime.date(2026, 9, 1), "UTC")}, {})
+        self.assertEqual(got["i.timeZone.id"], ["UTC"])
+        self.assertEqual(got["i.day"], ["1"])
+
+    def test_a_repeated_key_keeps_every_value(self):
+        got = pv.flatten("", {"metrics": ["a", "b"]}, {})
+        self.assertEqual(got["metrics"], ["a", "b"])
+
+
+class Freshness(unittest.TestCase):
+    """A query past the freshest day comes back empty, so the day drives the window."""
+
+    def test_the_daily_period_is_picked_out_of_several(self):
+        got = pv.freshness(
+            {
+                "freshnessInfo": {
+                    "freshnesses": [
+                        {"aggregationPeriod": "HOURLY", "latestEndTime": {"day": 8}},
+                        {
+                            "aggregationPeriod": "DAILY",
+                            "latestEndTime": {"year": 2026, "month": 9, "day": 7},
+                        },
+                    ]
+                }
+            }
+        )
+        self.assertEqual(pv.day_str(got), "2026-09-07")
+
+    def test_no_freshness_is_empty_not_an_exception(self):
+        self.assertEqual(pv.freshness({}), {})
+
+
+class Rows(unittest.TestCase):
+    def test_a_missing_metric_reads_as_none_rather_than_zero(self):
+        dims, values = pv.rates_row(
+            {
+                "dimensions": [{"dimension": "versionCode", "int64Value": "63"}],
+                "metrics": [{"metric": "distinctUsers", "decimalValue": {"value": "12"}}],
+            },
+            ["userPerceivedCrashRate28dUserWeighted", "distinctUsers"],
+        )
+        self.assertEqual(dims, {"versionCode": "63"})
+        self.assertEqual(values, [None, "12"])
+
+
+class Errors(unittest.TestCase):
+    """A 403 has two causes and the wrong one sends you to the wrong console."""
+
+    def test_403_names_both_the_api_enablement_and_the_console_grant(self):
+        resp = mock.Mock(status_code=403, text="PERMISSION_DENIED")
+        with mock.patch("play_vitals.requests.request", return_value=resp):
+            with mock.patch("sys.stdout", new=io.StringIO()):
+                with self.assertRaises(SystemExit) as cm:
+                    pv.call("t", "https://example/x")
+        self.assertIn("has not been used in project", str(cm.exception))
+        self.assertIn("View app quality information", str(cm.exception))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tools/ci/play_vitals_test.py
+++ b/tools/ci/play_vitals_test.py
@@ -17,17 +17,17 @@ class Flatten(unittest.TestCase):
     """The search methods take the nested body as dotted query parameters."""
 
     def test_nested_interval_becomes_dotted_keys(self):
-        got = pv.flatten("", {"interval": {"startTime": {"year": 2026, "hours": 0}}}, {})
+        got = pv.flatten({"interval": {"startTime": {"year": 2026, "hours": 0}}})
         self.assertEqual(got["interval.startTime.year"], ["2026"])
         self.assertEqual(got["interval.startTime.hours"], ["0"])
 
     def test_a_zone_survives_the_flattening(self):
-        got = pv.flatten("", {"i": pv.datetime_at(datetime.date(2026, 9, 1), "UTC")}, {})
+        got = pv.flatten({"i": pv.datetime_at(datetime.date(2026, 9, 1), "UTC")})
         self.assertEqual(got["i.timeZone.id"], ["UTC"])
         self.assertEqual(got["i.day"], ["1"])
 
     def test_a_repeated_key_keeps_every_value(self):
-        got = pv.flatten("", {"metrics": ["a", "b"]}, {})
+        got = pv.flatten({"metrics": ["a", "b"]})
         self.assertEqual(got["metrics"], ["a", "b"])
 
 
@@ -64,7 +64,13 @@ class Rows(unittest.TestCase):
             ["userPerceivedCrashRate28dUserWeighted", "distinctUsers"],
         )
         self.assertEqual(dims, {"versionCode": "63"})
-        self.assertEqual(values, [None, "12"])
+        self.assertIsNone(values["userPerceivedCrashRate28dUserWeighted"])
+        self.assertEqual(values["distinctUsers"], "12")
+
+    def test_an_empty_dimension_value_is_kept_rather_than_read_as_absent(self):
+        self.assertEqual(pv.dimension_value({"stringValue": ""}), "")
+        self.assertEqual(pv.dimension_value({"int64Value": "0"}), "0")
+        self.assertIsNone(pv.dimension_value({}))
 
 
 class Errors(unittest.TestCase):
@@ -78,6 +84,96 @@ class Errors(unittest.TestCase):
                     pv.call("t", "https://example/x")
         self.assertIn("has not been used in project", str(cm.exception))
         self.assertIn("View app quality information", str(cm.exception))
+
+
+class Body(unittest.TestCase):
+    """Play answers some calls 200 with no body at all, which json() cannot parse."""
+
+    def response(self, status=200, content=b"", payload=None):
+        r = mock.Mock(status_code=status, ok=status < 400, content=content, text=content.decode())
+        r.json.side_effect = (lambda: payload) if payload is not None else ValueError("no json")
+        return r
+
+    def test_an_empty_200_reads_as_an_empty_result_rather_than_raising(self):
+        with mock.patch("play_vitals.requests.request", return_value=self.response()):
+            self.assertEqual(pv.call("t", "https://example/x"), {})
+
+    def test_a_200_carrying_junk_exits_naming_the_url(self):
+        junk = self.response(content=b"<html>nope</html>")
+        with mock.patch("play_vitals.requests.request", return_value=junk):
+            with self.assertRaises(SystemExit) as cm:
+                pv.call("t", "https://example/x")
+        self.assertIn("non-JSON", str(cm.exception))
+        self.assertIn("https://example/x", str(cm.exception))
+
+    def test_a_500_exits_naming_the_method_and_the_url(self):
+        with mock.patch("play_vitals.requests.request", return_value=self.response(503)):
+            with self.assertRaises(SystemExit) as cm:
+                pv.call("t", "https://example/x", method="POST")
+        self.assertIn("503", str(cm.exception))
+        self.assertIn("POST", str(cm.exception))
+
+
+class Rates(unittest.TestCase):
+    """The threshold comparison is the whole point of the rates output."""
+
+    CRASH = pv.METRIC_SETS[0]
+
+    def row(self, weighted, day=7):
+        return {
+            "startTime": {"year": 2026, "month": 9, "day": day},
+            "metrics": [{"metric": self.CRASH.weighted, "decimalValue": {"value": weighted}}],
+        }
+
+    def count_over(self, *weighted):
+        rows = {"rows": [self.row(w, day=i + 1) for i, w in enumerate(weighted)]}
+        with mock.patch("sys.stdout", new=io.StringIO()):
+            return pv.print_rates(rows, self.CRASH, "", "2026-09-01..2026-09-07")
+
+    def test_a_rate_over_the_threshold_counts(self):
+        self.assertEqual(self.count_over("0.1455"), 1)
+
+    def test_a_rate_under_the_threshold_does_not(self):
+        self.assertEqual(self.count_over("0.0001"), 0)
+
+    def test_a_rate_exactly_on_the_threshold_is_not_over(self):
+        self.assertEqual(self.count_over(str(self.CRASH.threshold)), 0)
+
+    def test_each_row_is_judged_rather_than_only_the_first(self):
+        self.assertEqual(self.count_over("0.0001", "0.5", "0.9"), 2)
+
+    def test_the_crash_and_anr_thresholds_are_not_interchangeable(self):
+        crash, anr = pv.METRIC_SETS
+        self.assertGreater(crash.threshold, anr.threshold)
+        self.assertIn("Crash", crash.weighted)
+        self.assertIn("Anr", anr.weighted)
+
+    def test_a_row_missing_the_weighted_metric_is_not_counted(self):
+        rows = {"rows": [{"startTime": {"year": 2026, "month": 9, "day": 7}, "metrics": []}]}
+        with mock.patch("sys.stdout", new=io.StringIO()):
+            self.assertEqual(pv.print_rates(rows, self.CRASH, "", "span"), 0)
+
+
+class Probe(unittest.TestCase):
+    def test_probe_reads_every_metric_set_and_reports_its_freshest_day(self):
+        payload = {
+            "freshnessInfo": {
+                "freshnesses": [
+                    {
+                        "aggregationPeriod": "DAILY",
+                        "latestEndTime": {"year": 2026, "month": 9, "day": 7},
+                    }
+                ]
+            }
+        }
+        out = io.StringIO()
+        with mock.patch("play_vitals.call", return_value=payload):
+            with mock.patch("sys.stdout", new=out):
+                pv.cmd_probe("t", None)
+        printed = out.getvalue()
+        for metric_set in pv.METRIC_SETS:
+            self.assertIn(metric_set.name, printed)
+        self.assertEqual(printed.count("2026-09-07"), len(pv.METRIC_SETS))
 
 
 if __name__ == "__main__":

--- a/tools/ci/play_vitals_test.py
+++ b/tools/ci/play_vitals_test.py
@@ -115,7 +115,7 @@ class Body(unittest.TestCase):
 
 
 class Rates(unittest.TestCase):
-    """The threshold comparison is the whole point of the rates output."""
+    """Tests that rates marks the rows over Play's threshold."""
 
     CRASH = pv.METRIC_SETS[0]
 


### PR DESCRIPTION
Play warns the app is over both bad-behaviour thresholds, and nothing here could say which build or which stack trace was responsible. Android vitals are not in `androidpublisher` at all.

`play_vitals.py` reads the Play Developer Reporting API, a separate service with its own scope and its own Console grant. `probe` proves access without asking for data. `rates` prints the user-perceived crash and ANR rates and marks the rows over Play's threshold. `issues` prints the top error clusters with their stack traces.

Two things cost a round trip each against the live API. `errorIssues:search` refuses a named timezone, where the metric queries require one. An issue's sample report names are not a path any GET accepts, so the traces come from `errorReports:search` instead.

Run against the real account. The probe passes, and the output named the top production crash, now #185.

Closes #189
