### PR TITLE
onConfigurationChanged never calls super, so every rotation crashes the app

### DIFF
--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -3066,7 +3066,7 @@ public class HTTrackActivity extends FragmentActivity {
   @Override
   public void onConfigurationChanged(final Configuration newConfig) {
     Log.d(getClass().getSimpleName(), "onConfigurationChanged");
-    // TODO: handle orientation change ?
+    super.onConfigurationChanged(newConfig);
   }
 
   @Override

--- a/app/src/test/java/com/httrack/android/LifecycleSuperCallTest.java
+++ b/app/src/test/java/com/httrack/android/LifecycleSuperCallTest.java
@@ -13,14 +13,15 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.junit.Test;
 
-/** A lifecycle override that never chains throws SuperNotCalledException; onConfigurationChanged
- *  did not, and crashed the app on every rotation (#186).
- *  Two things this cannot see: super.onCreate(null), or a chain on another overload, sets the
- *  flag the framework checks while dropping the argument; and the scan reads .java under
- *  src/main/java, so a Kotlin source or another source set would need widening. */
+/** The framework throws SuperNotCalledException when a lifecycle override skips its base
+ *  implementation, as onConfigurationChanged did (#186).
+ *  A chain on another overload, such as super.onCreate(null), sets the flag the framework checks
+ *  and drops the argument, which no text scan can see. This one reads .java under src/main/java
+ *  only. */
 public class LifecycleSuperCallTest {
-  /** Void callbacks whose base implementation the framework requires. The boolean menu callbacks
-   *  are left out, since answering without chaining is how they are meant to be used. */
+  /** These callbacks must call their base implementation. The list covers ones the tree does not
+   *  override yet, because the point is the next one someone adds. The boolean menu callbacks are
+   *  left out, since answering without chaining is how they are used. */
   private static final List<String> CHAINED = Arrays.asList("onCreate", "onStart", "onRestart",
       "onResume", "onPostCreate", "onPostResume", "onPause", "onStop", "onDestroy",
       "onSaveInstanceState", "onRestoreInstanceState", "onActivityResult",
@@ -28,14 +29,14 @@ public class LifecycleSuperCallTest {
       "onLowMemory", "onTrimMemory", "onNewIntent", "onViewCreated", "onDestroyView",
       "onTerminate");
 
-  /** Any declaration of one of them, whatever its modifiers and same-line annotations, so that a
-   *  style the scan cannot read fails the coverage check below instead of vanishing. */
+  /** Matches any declaration of one of them, whatever its modifiers or same-line annotations. A
+   *  style this misses fails the coverage check below. */
   private static final Pattern DECLARATION = Pattern.compile("(?m)^[ \t]*"
       + "((?:@\\w+(?:\\([^)\n]*\\))?[ \t]+)*"
       + "(?:(?:public|protected|private|final|static|synchronized|strictfp)[ \t]+)*)"
       + "void[ \t]+(" + join(CHAINED) + ")[ \t]*\\(");
 
-  /** The name used other than as a call on a receiver, which a declaration is. */
+  /** The name anywhere except after a dot, declarations included and filtered out later. */
   private static final Pattern MENTION = Pattern.compile("(?<![.\\w])(" + join(CHAINED)
       + ")\\s*\\(");
 
@@ -92,7 +93,7 @@ public class LifecycleSuperCallTest {
     for (final File file : TestSources.javaSources()) {
       scan(file.getName(), TestSources.read(file), result);
     }
-    // A scan that read nothing would pass, so name overrides the tree has today.
+    // List overrides the tree already has, to catch a scan that reads nothing.
     assertTrue(result.seen.toString(), result.seen.containsAll(Arrays.asList(
         "HTTrackActivity.java.onCreate", "HTTrackActivity.java.onResume",
         "HTTrackActivity.java.onConfigurationChanged", "HTTrackActivity.java.onSaveInstanceState",
@@ -116,6 +117,20 @@ public class LifecycleSuperCallTest {
     assertEquals(Arrays.asList("x.onConfigurationChanged"),
         scanOf("  public void onConfigurationChanged(final Configuration c) {\n"
             + "    // super.onConfigurationChanged(c);\n  }\n").missing);
+  }
+
+  /** Every name in the list, so no entry can sit there matching nothing. */
+  @Test
+  public void everyNameIsExercised() {
+    for (final String name : CHAINED) {
+      final Scan chains = scanOf("  public void " + name + "() {\n    super." + name
+          + "();\n  }\n");
+      assertEquals(name, Arrays.asList(), chains.missing);
+      assertEquals(name, Arrays.asList(), chains.unread);
+      final Scan silent = scanOf("  public void " + name + "() {\n  }\n");
+      assertEquals(name, Arrays.asList("x." + name), silent.missing);
+      assertEquals(name, Arrays.asList(), silent.unread);
+    }
   }
 
   @Test

--- a/app/src/test/java/com/httrack/android/LifecycleSuperCallTest.java
+++ b/app/src/test/java/com/httrack/android/LifecycleSuperCallTest.java
@@ -1,0 +1,84 @@
+package com.httrack.android;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.junit.Test;
+
+/** A lifecycle override that never chains throws SuperNotCalledException; onConfigurationChanged
+ *  did not, and crashed the app on every rotation (#186). */
+public class LifecycleSuperCallTest {
+  /** Void callbacks whose base implementation the framework requires. The boolean menu callbacks
+   *  are left out, since answering without chaining is how they are meant to be used. */
+  private static final List<String> CHAINED = Arrays.asList("onCreate", "onStart", "onRestart",
+      "onResume", "onPostCreate", "onPostResume", "onPause", "onStop", "onDestroy",
+      "onSaveInstanceState", "onRestoreInstanceState", "onActivityResult",
+      "onRequestPermissionsResult", "onAttach", "onDetach", "onConfigurationChanged",
+      "onLowMemory", "onTrimMemory", "onNewIntent", "onViewCreated", "onDestroyView",
+      "onTerminate");
+
+  private static final Pattern OVERRIDE = Pattern.compile("(?m)^[ \t]*(?:public|protected)\\s+"
+      + "(?:final\\s+)?void\\s+(" + join(CHAINED) + ")\\s*\\(");
+
+  private static String join(final List<String> names) {
+    final StringBuilder joined = new StringBuilder();
+    for (final String name : names) {
+      joined.append(joined.length() == 0 ? "" : "|").append(name);
+    }
+    return joined.toString();
+  }
+
+  /** Overrides of SOURCE that never chain, named LABEL.method; every override found is added to
+   *  SEEN. Comments are blanked first, so a commented-out call cannot pass for one. */
+  private static List<String> missingSuper(final String label, final String source,
+      final List<String> seen) {
+    final String code = TestSources.withoutCommentsAndStrings(source);
+    final List<String> missing = new ArrayList<String>();
+    final Matcher matcher = OVERRIDE.matcher(code);
+    while (matcher.find()) {
+      final String name = matcher.group(1);
+      seen.add(label + "." + name);
+      if (!TestSources.balancedBlock(code, matcher.end()).contains("super." + name + "(")) {
+        missing.add(label + "." + name);
+      }
+    }
+    return missing;
+  }
+
+  @Test
+  public void everyLifecycleOverrideChains() throws IOException {
+    final List<String> seen = new ArrayList<String>();
+    final List<String> missing = new ArrayList<String>();
+    for (final File file : TestSources.javaSources()) {
+      missing.addAll(missingSuper(file.getName(), TestSources.read(file), seen));
+    }
+    // A scan that read nothing would pass, so name overrides the tree has today.
+    assertTrue(seen.toString(), seen.containsAll(Arrays.asList(
+        "HTTrackActivity.java.onCreate", "HTTrackActivity.java.onResume",
+        "HTTrackActivity.java.onConfigurationChanged", "HTTrackActivity.java.onSaveInstanceState",
+        "HTTrackActivity.java.onRequestPermissionsResult", "OptionsActivity.java.onCreate",
+        "CleanupActivity.java.onCreate", "FileChooserActivity.java.onCreate",
+        "HTTrackApplication.java.onCreate")));
+    assertEquals(new TreeSet<String>(), new TreeSet<String>(missing));
+  }
+
+  /** The scan itself, against an override that chains and one that does not. */
+  @Test
+  public void scanTellsThemApart() {
+    final String chains = "  public void onResume() {\n    super.onResume();\n  }\n";
+    final String silent = "  public void onConfigurationChanged(final Configuration c) {\n"
+        + "    // super.onConfigurationChanged(c);\n  }\n";
+    final List<String> seen = new ArrayList<String>();
+    assertEquals(Arrays.asList(), missingSuper("x", chains, seen));
+    assertEquals(Arrays.asList("x.onConfigurationChanged"), missingSuper("x", silent, seen));
+    assertEquals(Arrays.asList("x.onResume", "x.onConfigurationChanged"), seen);
+  }
+}

--- a/app/src/test/java/com/httrack/android/LifecycleSuperCallTest.java
+++ b/app/src/test/java/com/httrack/android/LifecycleSuperCallTest.java
@@ -14,7 +14,10 @@ import java.util.regex.Pattern;
 import org.junit.Test;
 
 /** A lifecycle override that never chains throws SuperNotCalledException; onConfigurationChanged
- *  did not, and crashed the app on every rotation (#186). */
+ *  did not, and crashed the app on every rotation (#186).
+ *  Two things this cannot see: super.onCreate(null), or a chain on another overload, sets the
+ *  flag the framework checks while dropping the argument; and the scan reads .java under
+ *  src/main/java, so a Kotlin source or another source set would need widening. */
 public class LifecycleSuperCallTest {
   /** Void callbacks whose base implementation the framework requires. The boolean menu callbacks
    *  are left out, since answering without chaining is how they are meant to be used. */
@@ -25,8 +28,16 @@ public class LifecycleSuperCallTest {
       "onLowMemory", "onTrimMemory", "onNewIntent", "onViewCreated", "onDestroyView",
       "onTerminate");
 
-  private static final Pattern OVERRIDE = Pattern.compile("(?m)^[ \t]*(?:public|protected)\\s+"
-      + "(?:final\\s+)?void\\s+(" + join(CHAINED) + ")\\s*\\(");
+  /** Any declaration of one of them, whatever its modifiers and same-line annotations, so that a
+   *  style the scan cannot read fails the coverage check below instead of vanishing. */
+  private static final Pattern DECLARATION = Pattern.compile("(?m)^[ \t]*"
+      + "((?:@\\w+(?:\\([^)\n]*\\))?[ \t]+)*"
+      + "(?:(?:public|protected|private|final|static|synchronized|strictfp)[ \t]+)*)"
+      + "void[ \t]+(" + join(CHAINED) + ")[ \t]*\\(");
+
+  /** The name used other than as a call on a receiver, which a declaration is. */
+  private static final Pattern MENTION = Pattern.compile("(?<![.\\w])(" + join(CHAINED)
+      + ")\\s*\\(");
 
   private static String join(final List<String> names) {
     final StringBuilder joined = new StringBuilder();
@@ -36,49 +47,96 @@ public class LifecycleSuperCallTest {
     return joined.toString();
   }
 
-  /** Overrides of SOURCE that never chain, named LABEL.method; every override found is added to
-   *  SEEN. Comments are blanked first, so a commented-out call cannot pass for one. */
-  private static List<String> missingSuper(final String label, final String source,
-      final List<String> seen) {
-    final String code = TestSources.withoutCommentsAndStrings(source);
+  /** What one source yields: the overrides read, those of them that never chain, and the
+   *  declarations no pattern here could read. */
+  private static final class Scan {
+    final List<String> seen = new ArrayList<String>();
     final List<String> missing = new ArrayList<String>();
-    final Matcher matcher = OVERRIDE.matcher(code);
-    while (matcher.find()) {
-      final String name = matcher.group(1);
-      seen.add(label + "." + name);
-      if (!TestSources.balancedBlock(code, matcher.end()).contains("super." + name + "(")) {
-        missing.add(label + "." + name);
+    final List<String> unread = new ArrayList<String>();
+  }
+
+  /** Reads SOURCE into RESULT, naming everything LABEL.method. Comments and strings are blanked
+   *  first, so a commented-out call cannot pass for one. */
+  private static void scan(final String label, final String source, final Scan result) {
+    final String code = TestSources.withoutCommentsAndStrings(source);
+    final List<int[]> declarations = new ArrayList<int[]>();
+    final Matcher declaration = DECLARATION.matcher(code);
+    while (declaration.find()) {
+      declarations.add(new int[] { declaration.start(), declaration.end() });
+      final String name = declaration.group(2);
+      // A private helper of the same name is not a framework callback.
+      if (!declaration.group(1).contains("public")
+          && !declaration.group(1).contains("protected")) {
+        continue;
+      }
+      result.seen.add(label + "." + name);
+      if (!TestSources.balancedBlock(code, declaration.end()).contains("super." + name + "(")) {
+        result.missing.add(label + "." + name);
       }
     }
-    return missing;
+    final Matcher mention = MENTION.matcher(code);
+    while (mention.find()) {
+      boolean declared = false;
+      for (final int[] span : declarations) {
+        declared |= span[0] <= mention.start() && mention.start() < span[1];
+      }
+      if (!declared) {
+        result.unread.add(label + "." + mention.group(1));
+      }
+    }
   }
 
   @Test
   public void everyLifecycleOverrideChains() throws IOException {
-    final List<String> seen = new ArrayList<String>();
-    final List<String> missing = new ArrayList<String>();
+    final Scan result = new Scan();
     for (final File file : TestSources.javaSources()) {
-      missing.addAll(missingSuper(file.getName(), TestSources.read(file), seen));
+      scan(file.getName(), TestSources.read(file), result);
     }
     // A scan that read nothing would pass, so name overrides the tree has today.
-    assertTrue(seen.toString(), seen.containsAll(Arrays.asList(
+    assertTrue(result.seen.toString(), result.seen.containsAll(Arrays.asList(
         "HTTrackActivity.java.onCreate", "HTTrackActivity.java.onResume",
         "HTTrackActivity.java.onConfigurationChanged", "HTTrackActivity.java.onSaveInstanceState",
         "HTTrackActivity.java.onRequestPermissionsResult", "OptionsActivity.java.onCreate",
         "CleanupActivity.java.onCreate", "FileChooserActivity.java.onCreate",
         "HTTrackApplication.java.onCreate")));
-    assertEquals(new TreeSet<String>(), new TreeSet<String>(missing));
+    assertEquals(new TreeSet<String>(), new TreeSet<String>(result.unread));
+    assertEquals(new TreeSet<String>(), new TreeSet<String>(result.missing));
   }
 
-  /** The scan itself, against an override that chains and one that does not. */
+  private static Scan scanOf(final String source) {
+    final Scan result = new Scan();
+    scan("x", source, result);
+    return result;
+  }
+
   @Test
-  public void scanTellsThemApart() {
-    final String chains = "  public void onResume() {\n    super.onResume();\n  }\n";
-    final String silent = "  public void onConfigurationChanged(final Configuration c) {\n"
-        + "    // super.onConfigurationChanged(c);\n  }\n";
-    final List<String> seen = new ArrayList<String>();
-    assertEquals(Arrays.asList(), missingSuper("x", chains, seen));
-    assertEquals(Arrays.asList("x.onConfigurationChanged"), missingSuper("x", silent, seen));
-    assertEquals(Arrays.asList("x.onResume", "x.onConfigurationChanged"), seen);
+  public void chainingIsToldFromSilence() {
+    assertEquals(Arrays.asList(),
+        scanOf("  public void onResume() {\n    super.onResume();\n  }\n").missing);
+    assertEquals(Arrays.asList("x.onConfigurationChanged"),
+        scanOf("  public void onConfigurationChanged(final Configuration c) {\n"
+            + "    // super.onConfigurationChanged(c);\n  }\n").missing);
+  }
+
+  @Test
+  public void unusualDeclarationStylesAreRead() {
+    for (final String head : Arrays.asList("  public synchronized void onDestroy()",
+        "  @Override public void onDestroy()", "  @SuppressWarnings(\"x\") protected void"
+            + " onDestroy()", "  public final void onDestroy()")) {
+      final Scan result = scanOf(head + " {\n  }\n");
+      assertEquals(head, Arrays.asList("x.onDestroy"), result.missing);
+      assertEquals(head, Arrays.asList(), result.unread);
+    }
+  }
+
+  /** A declaration no pattern reads must fail the run, not drop out of it. */
+  @Test
+  public void anUnreadableDeclarationIsLoud() {
+    assertEquals(Arrays.asList("x.onStop"),
+        scanOf("  public void\n  onStop() {\n  }\n").unread);
+    // A private helper of that name is neither a callback nor a miss.
+    final Scan helper = scanOf("  private void onStop() {\n  }\n");
+    assertEquals(Arrays.asList(), helper.missing);
+    assertEquals(Arrays.asList(), helper.unread);
   }
 }

--- a/app/src/test/java/com/httrack/android/TestSources.java
+++ b/app/src/test/java/com/httrack/android/TestSources.java
@@ -63,6 +63,23 @@ final class TestSources {
         + ".java"));
   }
 
+  /** Every checked-in Java source of the app, inner packages included. */
+  static List<File> javaSources() {
+    final List<File> files = new ArrayList<File>();
+    collectJava(dir("src/main/java"), files);
+    return files;
+  }
+
+  private static void collectJava(final File dir, final List<File> files) {
+    for (final File file : dir.listFiles()) {
+      if (file.isDirectory()) {
+        collectJava(file, files);
+      } else if (file.getName().endsWith(".java")) {
+        files.add(file);
+      }
+    }
+  }
+
   /** Source of the JNI glue file NAME, such as "htslibjni.c". */
   static String jniSource(final String name) throws IOException {
     return read(new File(dir("src/main/jni"), name));


### PR DESCRIPTION
`HTTrackActivity.onConfigurationChanged` only logged. Android runs it, checks that `Activity`'s own implementation ran, and throws `SuperNotCalledException` when it did not. Play reports 4 users and 6 crashes at this frame.

No activity declares `android:configChanges`, so most configuration changes relaunch the activity instead of reaching this method. Which ones do reach it is not something the manifest tells us, and production shows some do. The override has to chain either way, and the `// TODO: handle orientation change ?` comment goes with the fix.

Every other lifecycle override in the tree already chains. A new source-text guard reads each Java source under `src/main/java` and fails on any void lifecycle override that never calls its super.

Closes #186
