### PR TITLE
A project name holding a slash crashes the app when you tap Next

### DIFF
--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -2927,7 +2927,7 @@ public class HTTrackActivity extends FragmentActivity {
    */
   public void onShowLogs(final View view) {
     final File log = getTargetLogFile();
-    if (log.exists()) {
+    if (log != null && log.exists()) {
       FileInputStream rd;
       try {
         rd = new FileInputStream(log);

--- a/app/src/main/java/com/httrack/android/OptionsMapper.java
+++ b/app/src/main/java/com/httrack/android/OptionsMapper.java
@@ -614,6 +614,41 @@ public class OptionsMapper {
     }
 
     /**
+     * The key/value pairs a profile file states, values still encoded.
+     *
+     * @param profile
+     *          The profile file (winprofile.ini), null when the project name
+     *          was refused as a path
+     * @return the pairs, in file order
+     * @throws IOException
+     *           When there is no profile to read, or upon I/O error.
+     */
+    static Map<String, String> rawFields(final File profile)
+        throws IOException {
+      if (profile == null || !profile.exists()) {
+        throw new IOException("no such profile");
+      }
+      final Map<String, String> raw = new LinkedHashMap<String, String>();
+      final BufferedReader reader = new BufferedReader(new FileReader(profile));
+      try {
+        String rawline;
+        while ((rawline = reader.readLine()) != null) {
+          final String line = rawline.trim();
+          if (line.length() == 0 || line.charAt(0) == ';') {
+            continue;
+          }
+          final int sep = line.indexOf('=');
+          if (sep != -1) {
+            raw.put(line.substring(0, sep), line.substring(sep + 1));
+          }
+        }
+      } finally {
+        reader.close();
+      }
+      return raw;
+    }
+
+    /**
      * The keys a profile file already states, under their current spelling.
      *
      * @param profile
@@ -2016,45 +2051,26 @@ public class OptionsMapper {
    * Unserialize a specific profile from disk.
    * 
    * @param profile
-   *          The profile file (winprofile.ini)
+   *          The profile file (winprofile.ini), may be null
    * @param map
    *          The map to be filled
    * 
    * @throws IOException
-   *           Upon I/O error.
+   *           When there is no profile to read, or upon I/O error.
    */
   public static void unserialize(final File profile,
       final SparseArray<String> map) throws IOException {
-    // Write settings
-    if (!profile.exists()) {
-      throw new IOException("no such profile");
+    final Map<String, String> raw = new LinkedHashMap<String, String>();
+    for (final Map.Entry<String, String> line : ProfileFormat.rawFields(profile)
+        .entrySet()) {
+      raw.put(line.getKey(), OptionsMapper.profileDecode(line.getValue()));
     }
-    final FileReader reader = new FileReader(profile);
-    final BufferedReader lreader = new BufferedReader(reader);
-    try {
-      final Map<String, String> raw = new LinkedHashMap<String, String>();
-      String rawline;
-      while ((rawline = lreader.readLine()) != null) {
-        final String line = rawline.trim();
-        if (line.length() == 0 || line.charAt(0) == ';') {
-          continue;
-        }
-        final int sep = line.indexOf('=');
-        if (sep != -1) {
-          raw.put(line.substring(0, sep),
-              OptionsMapper.profileDecode(line.substring(sep + 1)));
-        }
+    for (final Map.Entry<String, String> field : ProfileFormat.resolve(raw)
+        .entrySet()) {
+      final Integer id = OptionsMapper.fieldsNameToId.get(field.getKey());
+      if (id != null) {
+        map.put(id, field.getValue());
       }
-      for (final Map.Entry<String, String> field : ProfileFormat.resolve(raw)
-          .entrySet()) {
-        final Integer id = OptionsMapper.fieldsNameToId.get(field.getKey());
-        if (id != null) {
-          map.put(id, field.getValue());
-        }
-      }
-      lreader.close();
-    } finally {
-      reader.close();
     }
   }
 

--- a/app/src/main/java/com/httrack/android/OptionsMapper.java
+++ b/app/src/main/java/com/httrack/android/OptionsMapper.java
@@ -614,7 +614,7 @@ public class OptionsMapper {
     }
 
     /**
-     * The key/value pairs a profile file states, values still encoded.
+     * Reads a profile's stated pairs, values still encoded.
      *
      * @param profile
      *          The profile file (winprofile.ini), null when the project name

--- a/app/src/main/java/com/httrack/android/OptionsMapper.java
+++ b/app/src/main/java/com/httrack/android/OptionsMapper.java
@@ -2060,12 +2060,12 @@ public class OptionsMapper {
    */
   public static void unserialize(final File profile,
       final SparseArray<String> map) throws IOException {
-    final Map<String, String> raw = new LinkedHashMap<String, String>();
+    final Map<String, String> decoded = new LinkedHashMap<String, String>();
     for (final Map.Entry<String, String> line : ProfileFormat.rawFields(profile)
         .entrySet()) {
-      raw.put(line.getKey(), OptionsMapper.profileDecode(line.getValue()));
+      decoded.put(line.getKey(), OptionsMapper.profileDecode(line.getValue()));
     }
-    for (final Map.Entry<String, String> field : ProfileFormat.resolve(raw)
+    for (final Map.Entry<String, String> field : ProfileFormat.resolve(decoded)
         .entrySet()) {
       final Integer id = OptionsMapper.fieldsNameToId.get(field.getKey());
       if (id != null) {

--- a/app/src/test/java/com/httrack/android/ProfileReadTest.java
+++ b/app/src/test/java/com/httrack/android/ProfileReadTest.java
@@ -15,7 +15,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-/** Reading a winprofile.ini, the null one a refused project name yields included. */
+/** Reads winprofile.ini, including the null file a refused project name yields. */
 public class ProfileReadTest {
   @Rule
   public final TemporaryFolder tmp = new TemporaryFolder();
@@ -85,7 +85,7 @@ public class ProfileReadTest {
 
     assertTrue("unserialize must hand the profile to rawFields",
         body.contains("ProfileFormat.rawFields(profile)"));
-    // A second mention is unserialize opening or stat'ing the file itself, which is the crash.
+    // A second mention is unserialize opening or testing the file itself, which is the crash.
     assertEquals("rawFields must be the only use of the profile file", 1,
         occurrences(body, "profile"));
     // Without it the %% escapes reach the UI verbatim.

--- a/app/src/test/java/com/httrack/android/ProfileReadTest.java
+++ b/app/src/test/java/com/httrack/android/ProfileReadTest.java
@@ -9,6 +9,8 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -17,6 +19,15 @@ import org.junit.rules.TemporaryFolder;
 public class ProfileReadTest {
   @Rule
   public final TemporaryFolder tmp = new TemporaryFolder();
+
+  private static int occurrences(final String text, final String word) {
+    final Matcher at = Pattern.compile("\\b" + word + "\\b").matcher(text);
+    int count = 0;
+    while (at.find()) {
+      count++;
+    }
+    return count;
+  }
 
   /** A name holding a slash is refused as a path, so getProfileFile() hands down null. */
   @Test
@@ -52,15 +63,33 @@ public class ProfileReadTest {
     assertEquals("http://example.com/?a=b", raw.get("CurrentUrl"));
   }
 
+  /** rawFields is one side of the decode boundary, so it must hand the escapes back untouched. */
+  @Test
+  public void leavesTheValuesEncoded() throws Exception {
+    final File profile = tmp.newFile("winprofile.ini");
+    Files.write(profile.toPath(), "Category=100%% done%09here\n".getBytes("UTF-8"));
+
+    assertEquals("100%% done%09here",
+        ProfileFormat.rawFields(profile).get("Category"));
+  }
+
   /** The crash was in unserialize, so the guard is only worth anything if it reads through it. */
   @Test
   public void unserializeReachesTheFileOnlyThroughRawFields() throws Exception {
-    final String source = TestSources.javaSource("OptionsMapper");
-    final String body = TestSources.balancedBlock(source,
-        source.indexOf("public static void unserialize(final File profile,"));
+    final String source = TestSources.withoutCommentsAndStrings(
+        TestSources.javaSource("OptionsMapper"));
+    final int at =
+        source.indexOf("public static void unserialize(final File profile,");
+    assertTrue("unserialize's declaration changed; re-anchor this guard", at != -1);
+    final String body = TestSources.balancedBlock(source, at);
+
     assertTrue("unserialize must hand the profile to rawFields",
         body.contains("ProfileFormat.rawFields(profile)"));
-    assertEquals("unserialize must not touch the file itself", -1,
-        body.indexOf("profile."));
+    // A second mention is unserialize opening or stat'ing the file itself, which is the crash.
+    assertEquals("rawFields must be the only use of the profile file", 1,
+        occurrences(body, "profile"));
+    // Without it the %% escapes reach the UI verbatim.
+    assertTrue("unserialize must decode what rawFields returns",
+        body.contains("profileDecode(line.getValue())"));
   }
 }

--- a/app/src/test/java/com/httrack/android/ProfileReadTest.java
+++ b/app/src/test/java/com/httrack/android/ProfileReadTest.java
@@ -1,0 +1,66 @@
+package com.httrack.android;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import com.httrack.android.OptionsMapper.ProfileFormat;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Map;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/** Reading a winprofile.ini, the null one a refused project name yields included. */
+public class ProfileReadTest {
+  @Rule
+  public final TemporaryFolder tmp = new TemporaryFolder();
+
+  /** A name holding a slash is refused as a path, so getProfileFile() hands down null. */
+  @Test
+  public void aProfileThatIsNullReadsAsAnAbsentOne() throws Exception {
+    try {
+      ProfileFormat.rawFields(null);
+      fail("a null profile must not read as an empty one");
+    } catch (final IOException e) {
+      assertEquals("no such profile", e.getMessage());
+    }
+  }
+
+  @Test
+  public void anAbsentProfileStillThrows() throws Exception {
+    try {
+      ProfileFormat.rawFields(new File(tmp.getRoot(), "winprofile.ini"));
+      fail("expected IOException");
+    } catch (final IOException e) {
+      assertEquals("no such profile", e.getMessage());
+    }
+  }
+
+  @Test
+  public void keepsTheStatedPairsAndDropsCommentsAndBlanks() throws Exception {
+    final File profile = tmp.newFile("winprofile.ini");
+    Files.write(profile.toPath(),
+        ("; a comment\n\nProjectName=demo\nCurrentUrl=http://example.com/?a=b\nnoise\n")
+            .getBytes("UTF-8"));
+
+    final Map<String, String> raw = ProfileFormat.rawFields(profile);
+    assertEquals(2, raw.size());
+    assertEquals("demo", raw.get("ProjectName"));
+    assertEquals("http://example.com/?a=b", raw.get("CurrentUrl"));
+  }
+
+  /** The crash was in unserialize, so the guard is only worth anything if it reads through it. */
+  @Test
+  public void unserializeReachesTheFileOnlyThroughRawFields() throws Exception {
+    final String source = TestSources.javaSource("OptionsMapper");
+    final String body = TestSources.balancedBlock(source,
+        source.indexOf("public static void unserialize(final File profile,"));
+    assertTrue("unserialize must hand the profile to rawFields",
+        body.contains("ProfileFormat.rawFields(profile)"));
+    assertEquals("unserialize must not touch the file itself", -1,
+        body.indexOf("profile."));
+  }
+}


### PR DESCRIPTION
Closes #185

Type a project name holding a slash, such as a pasted site address, then tap Next, and the app crashes. `StoragePaths.isValidProjectName` refuses the name, so `getProfileFile()` returns null, and `OptionsMapper.unserialize` calls `exists()` on it. Play counts 21 users and 32 reports.

The read half of `unserialize` moves to `ProfileFormat.rawFields`, which refuses a null file with the same `IOException("no such profile")` an absent file already got. `validatePane` already catches that, and it still rejects the name a few lines later, so the path-traversal defence is unchanged.

The move is what makes the guard testable: `OptionsMapper`'s static initializer builds `android.util.Pair` values, which the stub `android.jar` refuses. `ProfileReadTest` throws a NullPointerException without the fix.
