### PR TITLE
Show Logs reads the whole crawl log into memory and crashes on a large one

### DIFF
--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -2927,29 +2927,38 @@ public class HTTrackActivity extends FragmentActivity {
    */
   public void onShowLogs(final View view) {
     final File log = getTargetLogFile();
-    if (log != null && log.exists()) {
-      showLogTail(log, Long.MAX_VALUE);
+    if (log == null || !log.exists()) {
+      return;
+    }
+    try {
+      showLogTail(log, LogTail.readNewest(log));
+    } catch (final IOException e) {
+      showNotification(e.getLocalizedMessage());
     }
   }
 
-  /** Show the log window ending at byte offset {@code end}; Long.MAX_VALUE asks for the newest. */
-  private void showLogTail(final File log, final long end) {
+  /** Show one window of the log, with a button for the window before it. */
+  private void showLogTail(final File log, final LogTail.Window window) {
+    final TextView text = new TextView(this);
+    text.setText(window.text());
+    final ScrollView scroll = new ScrollView(this);
+    scroll.addView(text);
+    final AlertDialog.Builder builder = new AlertDialog.Builder(this)
+        .setTitle(R.string.show_logs).setView(scroll)
+        .setPositiveButton(android.R.string.ok, null);
+    if (window.hasEarlier()) {
+      builder.setNeutralButton(R.string.show_logs_earlier,
+          (dialog, which) -> showEarlierLogTail(log, window.start()));
+    }
+    builder.show();
+    // A tail is worth reading from its end.
+    scroll.post(() -> scroll.fullScroll(View.FOCUS_DOWN));
+  }
+
+  /** Show the window that ends where the one on screen begins. */
+  private void showEarlierLogTail(final File log, final long end) {
     try {
-      final LogTail.Window window = LogTail.read(log, end);
-      final TextView text = new TextView(this);
-      text.setText(window.text());
-      final ScrollView scroll = new ScrollView(this);
-      scroll.addView(text);
-      final AlertDialog.Builder builder = new AlertDialog.Builder(this)
-          .setTitle(R.string.show_logs).setView(scroll)
-          .setPositiveButton(android.R.string.ok, null);
-      if (window.hasEarlier()) {
-        builder.setNeutralButton(R.string.show_logs_earlier,
-            (dialog, which) -> showLogTail(log, window.start()));
-      }
-      builder.show();
-      // A tail is worth reading from its end.
-      scroll.post(() -> scroll.fullScroll(View.FOCUS_DOWN));
+      showLogTail(log, LogTail.read(log, end));
     } catch (final IOException e) {
       showNotification(e.getLocalizedMessage());
     }

--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -24,7 +24,6 @@ package com.httrack.android;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.FileReader;
 import java.io.FileWriter;
@@ -97,6 +96,7 @@ import android.widget.EditText;
 import android.widget.LinearLayout;
 import android.widget.ProgressBar;
 import android.widget.RadioGroup;
+import android.widget.ScrollView;
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -2927,17 +2927,31 @@ public class HTTrackActivity extends FragmentActivity {
    */
   public void onShowLogs(final View view) {
     final File log = getTargetLogFile();
-    if (log.exists()) {
-      FileInputStream rd;
-      try {
-        rd = new FileInputStream(log);
-        final byte[] data = new byte[(int) log.length()];
-        rd.read(data);
-        rd.close();
-        final String logs = new String(data, "UTF-8");
-        new AlertDialog.Builder(this).setTitle("Logs").setMessage(logs).show();
-      } catch (final IOException e) {
+    if (log != null && log.exists()) {
+      showLogTail(log, Long.MAX_VALUE);
+    }
+  }
+
+  /** Show the log window ending at byte offset {@code end}; Long.MAX_VALUE asks for the newest. */
+  private void showLogTail(final File log, final long end) {
+    try {
+      final LogTail.Window window = LogTail.read(log, end);
+      final TextView text = new TextView(this);
+      text.setText(window.text());
+      final ScrollView scroll = new ScrollView(this);
+      scroll.addView(text);
+      final AlertDialog.Builder builder = new AlertDialog.Builder(this)
+          .setTitle(R.string.show_logs).setView(scroll)
+          .setPositiveButton(android.R.string.ok, null);
+      if (window.hasEarlier()) {
+        builder.setNeutralButton(R.string.show_logs_earlier,
+            (dialog, which) -> showLogTail(log, window.start()));
       }
+      builder.show();
+      // A tail is worth reading from its end.
+      scroll.post(() -> scroll.fullScroll(View.FOCUS_DOWN));
+    } catch (final IOException e) {
+      showNotification(e.getLocalizedMessage());
     }
   }
 

--- a/app/src/main/java/com/httrack/android/LogTail.java
+++ b/app/src/main/java/com/httrack/android/LogTail.java
@@ -14,7 +14,42 @@ final class LogTail {
   /** Bytes read per window, and so the most text a view is ever given. */
   static final int WINDOW = 128 * 1024;
 
+  /** Continuation bytes a UTF-8 sequence split by the window start can leave behind. */
+  private static final int MAX_SPLIT_TAIL = 3;
+
   private LogTail() {
+  }
+
+  /** The file operations a window needs, so a test can make a read come back short. */
+  interface Source {
+    long length() throws IOException;
+
+    void seek(long position) throws IOException;
+
+    int read(byte[] buf, int offset, int count) throws IOException;
+  }
+
+  private static final class FileSource implements Source {
+    private final RandomAccessFile file;
+
+    FileSource(final RandomAccessFile file) {
+      this.file = file;
+    }
+
+    @Override
+    public long length() throws IOException {
+      return file.length();
+    }
+
+    @Override
+    public void seek(final long position) throws IOException {
+      file.seek(position);
+    }
+
+    @Override
+    public int read(final byte[] buf, final int offset, final int count) throws IOException {
+      return file.read(buf, offset, count);
+    }
   }
 
   /** A window of log text, and where it begins so the caller can ask for the one before it. */
@@ -47,48 +82,58 @@ final class LogTail {
    * U+FFFD, which is what a log the engine is still writing to can give.
    *
    * @param file the log file
-   * @param end  byte offset to read back from, exclusive; any larger value asks for the newest
-   *             window
-   * @return the window, beginning on a whole line unless it begins at the file start
+   * @param end  byte offset to read back from, exclusive
+   * @return the window, beginning on a whole line where one starts inside it
    */
   static Window read(final File file, final long end) throws IOException {
     final RandomAccessFile rd = new RandomAccessFile(file, "r");
     try {
-      final long stop = Math.min(end, rd.length());
-      if (stop <= 0) {
-        return new Window("", 0);
-      }
-      final long begin = Math.max(0, stop - WINDOW);
-      final byte[] buf = new byte[(int) (stop - begin)];
-      rd.seek(begin);
-      int len = 0;
-      while (len < buf.length) {
-        final int count = rd.read(buf, len, buf.length - len);
-        if (count <= 0) {
-          break;
-        }
-        len += count;
-      }
-      final int skip = begin != 0 ? boundary(buf, len) : 0;
-      return new Window(new String(buf, skip, len - skip, StandardCharsets.UTF_8), begin + skip);
+      return read(new FileSource(rd), end);
     } finally {
       rd.close();
     }
   }
 
+  /** Read one window from {@code source}, which the caller opens and closes. */
+  static Window read(final Source source, final long end) throws IOException {
+    final long stop = Math.min(end, source.length());
+    if (stop <= 0) {
+      return new Window("", 0);
+    }
+    final long begin = Math.max(0, stop - WINDOW);
+    final byte[] buf = new byte[(int) (stop - begin)];
+    source.seek(begin);
+    int len = 0;
+    while (len < buf.length) {
+      final int count = source.read(buf, len, buf.length - len);
+      if (count <= 0) {
+        break;
+      }
+      len += count;
+    }
+    final int skip = begin != 0 ? boundary(buf, len) : 0;
+    return new Window(new String(buf, skip, len - skip, StandardCharsets.UTF_8), begin + skip);
+  }
+
+  /** Read the end of the log, which is the window a reader opening it wants. */
+  static Window readNewest(final File file) throws IOException {
+    return read(file, Long.MAX_VALUE);
+  }
+
   /**
-   * Where a window that starts mid-file becomes readable: past its first newline, which drops the
+   * Where a window that starts mid-file becomes readable. Past its first newline, which drops the
    * half line and lands on a character boundary too, because a newline byte never occurs inside a
-   * UTF-8 sequence. With no newline at all, skip the continuation bytes instead.
+   * UTF-8 sequence; with no newline to reach, past the continuation bytes instead. Never past the
+   * whole buffer, or a line longer than the window would give an empty window forever.
    */
   private static int boundary(final byte[] buf, final int len) {
-    for (int i = 0; i < len; i++) {
+    for (int i = 0; i + 1 < len; i++) {
       if (buf[i] == '\n') {
         return i + 1;
       }
     }
     int i = 0;
-    while (i < len && (buf[i] & 0xc0) == 0x80) {
+    while (i + 1 < len && i < MAX_SPLIT_TAIL && (buf[i] & 0xc0) == 0x80) {
       i++;
     }
     return i;

--- a/app/src/main/java/com/httrack/android/LogTail.java
+++ b/app/src/main/java/com/httrack/android/LogTail.java
@@ -1,0 +1,96 @@
+package com.httrack.android;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * One window of the end of a log file. A crawl log reaches tens of MB, so reading it whole exhausts
+ * memory and a view given it all blocks laying it out; WINDOW bounds both. No Android type appears
+ * here, so the windowing can be tested.
+ */
+final class LogTail {
+  /** Bytes read per window, and so the most text a view is ever given. */
+  static final int WINDOW = 128 * 1024;
+
+  private LogTail() {
+  }
+
+  /** A window of log text, and where it begins so the caller can ask for the one before it. */
+  static final class Window {
+    private final String text;
+    private final long start;
+
+    Window(final String text, final long start) {
+      this.text = text;
+      this.start = start;
+    }
+
+    String text() {
+      return text;
+    }
+
+    /** Byte offset of the first character returned; pass it back to read() to walk back. */
+    long start() {
+      return start;
+    }
+
+    /** Is there anything before this window? */
+    boolean hasEarlier() {
+      return start > 0;
+    }
+  }
+
+  /**
+   * Read at most WINDOW bytes ending at {@code end}. A character that {@code end} splits decodes to
+   * U+FFFD, which is what a log the engine is still writing to can give.
+   *
+   * @param file the log file
+   * @param end  byte offset to read back from, exclusive; any larger value asks for the newest
+   *             window
+   * @return the window, beginning on a whole line unless it begins at the file start
+   */
+  static Window read(final File file, final long end) throws IOException {
+    final RandomAccessFile rd = new RandomAccessFile(file, "r");
+    try {
+      final long stop = Math.min(end, rd.length());
+      if (stop <= 0) {
+        return new Window("", 0);
+      }
+      final long begin = Math.max(0, stop - WINDOW);
+      final byte[] buf = new byte[(int) (stop - begin)];
+      rd.seek(begin);
+      int len = 0;
+      while (len < buf.length) {
+        final int count = rd.read(buf, len, buf.length - len);
+        if (count <= 0) {
+          break;
+        }
+        len += count;
+      }
+      final int skip = begin != 0 ? boundary(buf, len) : 0;
+      return new Window(new String(buf, skip, len - skip, StandardCharsets.UTF_8), begin + skip);
+    } finally {
+      rd.close();
+    }
+  }
+
+  /**
+   * Where a window that starts mid-file becomes readable: past its first newline, which drops the
+   * half line and lands on a character boundary too, because a newline byte never occurs inside a
+   * UTF-8 sequence. With no newline at all, skip the continuation bytes instead.
+   */
+  private static int boundary(final byte[] buf, final int len) {
+    for (int i = 0; i < len; i++) {
+      if (buf[i] == '\n') {
+        return i + 1;
+      }
+    }
+    int i = 0;
+    while (i < len && (buf[i] & 0xc0) == 0x80) {
+      i++;
+    }
+    return i;
+  }
+}

--- a/app/src/main/java/com/httrack/android/LogTail.java
+++ b/app/src/main/java/com/httrack/android/LogTail.java
@@ -3,53 +3,26 @@ package com.httrack.android;
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
+import java.nio.channels.SeekableByteChannel;
 import java.nio.charset.StandardCharsets;
 
 /**
  * One window of the end of a log file. A crawl log reaches tens of MB, so reading it whole exhausts
- * memory and a view given it all blocks laying it out; WINDOW bounds both. No Android type appears
+ * memory and a view given it all blocks laying it out. WINDOW bounds both. No Android type appears
  * here, so the windowing can be tested.
  */
 final class LogTail {
   /** Bytes read per window, and so the most text a view is ever given. */
   static final int WINDOW = 128 * 1024;
 
-  /** Continuation bytes a UTF-8 sequence split by the window start can leave behind. */
-  private static final int MAX_SPLIT_TAIL = 3;
+  /**
+   * Continuation bytes a UTF-8 sequence split by the window start can leave behind. Bytes that are
+   * not UTF-8 at all must not cost the window more than that.
+   */
+  static final int MAX_SPLIT_TAIL = 3;
 
   private LogTail() {
-  }
-
-  /** The file operations a window needs, so a test can make a read come back short. */
-  interface Source {
-    long length() throws IOException;
-
-    void seek(long position) throws IOException;
-
-    int read(byte[] buf, int offset, int count) throws IOException;
-  }
-
-  private static final class FileSource implements Source {
-    private final RandomAccessFile file;
-
-    FileSource(final RandomAccessFile file) {
-      this.file = file;
-    }
-
-    @Override
-    public long length() throws IOException {
-      return file.length();
-    }
-
-    @Override
-    public void seek(final long position) throws IOException {
-      file.seek(position);
-    }
-
-    @Override
-    public int read(final byte[] buf, final int offset, final int count) throws IOException {
-      return file.read(buf, offset, count);
-    }
   }
 
   /** A window of log text, and where it begins so the caller can ask for the one before it. */
@@ -86,33 +59,31 @@ final class LogTail {
    * @return the window, beginning on a whole line where one starts inside it
    */
   static Window read(final File file, final long end) throws IOException {
+    // FileChannel.open needs File.toPath, which is API 26; getChannel is the one minSdk 24 has.
     final RandomAccessFile rd = new RandomAccessFile(file, "r");
     try {
-      return read(new FileSource(rd), end);
+      return read(rd.getChannel(), end);
     } finally {
       rd.close();
     }
   }
 
   /** Read one window from {@code source}, which the caller opens and closes. */
-  static Window read(final Source source, final long end) throws IOException {
-    final long stop = Math.min(end, source.length());
+  static Window read(final SeekableByteChannel source, final long end) throws IOException {
+    final long stop = Math.min(end, source.size());
     if (stop <= 0) {
       return new Window("", 0);
     }
     final long begin = Math.max(0, stop - WINDOW);
-    final byte[] buf = new byte[(int) (stop - begin)];
-    source.seek(begin);
-    int len = 0;
-    while (len < buf.length) {
-      final int count = source.read(buf, len, buf.length - len);
-      if (count <= 0) {
-        break;
-      }
-      len += count;
+    final ByteBuffer buf = ByteBuffer.allocate((int) (stop - begin));
+    source.position(begin);
+    while (buf.hasRemaining() && source.read(buf) > 0) {
+      // A read can come back short, so ask again until the window is full or the file ends.
     }
-    final int skip = begin != 0 ? boundary(buf, len) : 0;
-    return new Window(new String(buf, skip, len - skip, StandardCharsets.UTF_8), begin + skip);
+    final int len = buf.position();
+    final int skip = begin != 0 ? boundary(buf.array(), len) : 0;
+    return new Window(
+        new String(buf.array(), skip, len - skip, StandardCharsets.UTF_8), begin + skip);
   }
 
   /** Read the end of the log, which is the window a reader opening it wants. */
@@ -121,10 +92,10 @@ final class LogTail {
   }
 
   /**
-   * Where a window that starts mid-file becomes readable. Past its first newline, which drops the
-   * half line and lands on a character boundary too, because a newline byte never occurs inside a
-   * UTF-8 sequence; with no newline to reach, past the continuation bytes instead. Never past the
-   * whole buffer, or a line longer than the window would give an empty window forever.
+   * Where a mid-file window may start, chosen so it never comes back empty. Skip to the first
+   * newline, but not one on the buffer's last byte. A UTF-8 sequence never contains a newline, so
+   * stopping there also lands on a character boundary. Failing that, skip up to MAX_SPLIT_TAIL
+   * continuation bytes, never the whole buffer.
    */
   private static int boundary(final byte[] buf, final int len) {
     for (int i = 0; i + 1 < len; i++) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,6 +22,7 @@
     <string name="stop">Exit</string>
     <string name="exit">Exit</string>
     <string name="show_logs">View log</string>
+    <string name="show_logs_earlier">Earlier</string>
     <string name="browse_website">Browse Mirrored Website</string>
     <string name="app_description">Website Copier/Offline Browser. Copy remote websites to your computer. Free.</string>
     <string name="browse_all">Browse sites</string>

--- a/app/src/test/java/com/httrack/android/LogTailTest.java
+++ b/app/src/test/java/com/httrack/android/LogTailTest.java
@@ -7,10 +7,11 @@ import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.SeekableByteChannel;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Arrays;
-
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -137,9 +138,23 @@ public class LogTailTest {
     final byte[] bytes = new byte[LogTail.WINDOW + 1];
     Arrays.fill(bytes, (byte) 0x80);
     final File file = writeBytes(bytes);
+    final LogTail.Window window = LogTail.readNewest(file);
 
-    assertFalse(LogTail.readNewest(file).text().isEmpty());
+    // Uncapped, the skip would run to the last byte and leave a window one character long.
+    assertEquals(1 + LogTail.MAX_SPLIT_TAIL, window.start());
+    assertEquals(LogTail.WINDOW - LogTail.MAX_SPLIT_TAIL, window.text().length());
     assertFalse(walkBack(file).isEmpty());
+  }
+
+  /** A log rotated away under the read delivers less than it promised, which must not empty it. */
+  @Test
+  public void aChannelThatDeliversLessThanItPromisedIsNotSkippedWhole() throws IOException {
+    final byte[] delivered = {(byte) 0x80, (byte) 0x80};
+    final LogTail.Window window =
+        LogTail.read(new DribblingChannel(delivered, LogTail.WINDOW + 1), LogTail.WINDOW + 1);
+
+    assertFalse(window.text().isEmpty());
+    assertTrue(window.start() < LogTail.WINDOW + 1);
   }
 
   /**
@@ -184,38 +199,70 @@ public class LogTailTest {
   }
 
   /** One byte per read, which is the case the fill loop exists for. */
-  private static final class DribblingSource implements LogTail.Source {
+  private static final class DribblingChannel implements SeekableByteChannel {
     private final byte[] bytes;
+    private final long size;
     private int position;
 
-    DribblingSource(final byte[] bytes) {
+    DribblingChannel(final byte[] bytes) {
+      this(bytes, bytes.length);
+    }
+
+    /** A size larger than {@code bytes} models a file that shrank after it was measured. */
+    DribblingChannel(final byte[] bytes, final long size) {
       this.bytes = bytes;
+      this.size = size;
     }
 
     @Override
-    public long length() {
-      return bytes.length;
+    public long size() {
+      return size;
     }
 
     @Override
-    public void seek(final long start) {
+    public long position() {
+      return position;
+    }
+
+    @Override
+    public SeekableByteChannel position(final long start) {
       position = (int) start;
+      return this;
     }
 
     @Override
-    public int read(final byte[] buf, final int offset, final int count) {
-      if (count == 0 || position >= bytes.length) {
+    public int read(final ByteBuffer buf) {
+      if (!buf.hasRemaining() || position >= bytes.length) {
         return -1;
       }
-      buf[offset] = bytes[position++];
+      buf.put(bytes[position++]);
       return 1;
+    }
+
+    @Override
+    public int write(final ByteBuffer buf) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SeekableByteChannel truncate(final long size) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isOpen() {
+      return true;
+    }
+
+    @Override
+    public void close() {
     }
   }
 
   @Test
   public void aShortReadStillFillsTheWindow() throws IOException {
     final byte[] bytes = "first line\nsecond line\n".getBytes(StandardCharsets.UTF_8);
-    final LogTail.Window window = LogTail.read(new DribblingSource(bytes), bytes.length);
+    final LogTail.Window window = LogTail.read(new DribblingChannel(bytes), bytes.length);
     assertEquals(new String(bytes, StandardCharsets.UTF_8), window.text());
   }
 

--- a/app/src/test/java/com/httrack/android/LogTailTest.java
+++ b/app/src/test/java/com/httrack/android/LogTailTest.java
@@ -1,0 +1,121 @@
+package com.httrack.android;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/** LogTail windows a real file on disk, so these tests write real files. */
+public class LogTailTest {
+  @Rule
+  public final TemporaryFolder tmp = new TemporaryFolder();
+
+  private File write(final String content) throws IOException {
+    final File file = tmp.newFile();
+    Files.write(file.toPath(), content.getBytes(StandardCharsets.UTF_8));
+    return file;
+  }
+
+  /** Enough lines to overflow the window several times over. */
+  private static String lines(final String filler) {
+    final StringBuilder text = new StringBuilder();
+    for (int i = 0; text.length() < 3 * LogTail.WINDOW; i++) {
+      text.append("line ").append(i).append(' ').append(filler).append('\n');
+    }
+    return text.toString();
+  }
+
+  @Test
+  public void aFileSmallerThanTheWindowComesBackWhole() throws IOException {
+    final String content = "first line\nsecond line\n";
+    final LogTail.Window window = LogTail.read(write(content), Long.MAX_VALUE);
+    assertEquals(content, window.text());
+    assertEquals(0, window.start());
+    assertFalse(window.hasEarlier());
+  }
+
+  @Test
+  public void anEmptyFileComesBackEmpty() throws IOException {
+    final LogTail.Window window = LogTail.read(write(""), Long.MAX_VALUE);
+    assertEquals("", window.text());
+    assertFalse(window.hasEarlier());
+  }
+
+  @Test
+  public void aFileLargerThanTheWindowIsCutAtALineBoundary() throws IOException {
+    final String content = lines("padding");
+    final File file = write(content);
+    final LogTail.Window window = LogTail.read(file, Long.MAX_VALUE);
+
+    assertTrue(window.hasEarlier());
+    assertTrue(window.text().length() < content.length());
+    assertTrue(window.text().getBytes(StandardCharsets.UTF_8).length <= LogTail.WINDOW);
+    assertTrue(content.endsWith(window.text()));
+    assertTrue(window.text().startsWith("line "));
+    assertEquals('\n', Files.readAllBytes(file.toPath())[(int) window.start() - 1]);
+  }
+
+  /** Walking back must neither repeat a line nor drop one, so the windows have to join up. */
+  @Test
+  public void earlierWindowsJoinBackIntoTheWholeFile() throws IOException {
+    final String content = lines("padding");
+    final File file = write(content);
+    String seen = "";
+    long end = Long.MAX_VALUE;
+    LogTail.Window window;
+    do {
+      window = LogTail.read(file, end);
+      seen = window.text() + seen;
+      end = window.start();
+    } while (window.hasEarlier());
+    assertEquals(content, seen);
+  }
+
+  /**
+   * The euro sign is three bytes, so with a window of 131072 the cut always lands one byte into a
+   * character. Reaching the next newline is what gets the decoder back onto a boundary.
+   */
+  @Test
+  public void aCutInsideACharacterStillDecodes() throws IOException {
+    final LogTail.Window window = LogTail.read(write(lines("\u20ac\u20ac\u20ac")), Long.MAX_VALUE);
+    assertTrue(window.hasEarlier());
+    assertTrue(window.text().startsWith("line "));
+    assertEquals(-1, window.text().indexOf('\ufffd'));
+  }
+
+  /** Without a newline to reach, only the continuation bytes of the split character are dropped. */
+  @Test
+  public void aWindowWithoutANewlineDropsTheSplitCharacterOnly() throws IOException {
+    final StringBuilder text = new StringBuilder();
+    while (text.length() < LogTail.WINDOW) {
+      text.append('\u20ac');
+    }
+    final String content = text.toString();
+    final LogTail.Window window = LogTail.read(write(content), Long.MAX_VALUE);
+
+    assertEquals(-1, window.text().indexOf('\ufffd'));
+    assertTrue(content.endsWith(window.text()));
+    assertTrue(window.hasEarlier());
+    assertEquals(0, window.start() % 3);
+    assertEquals(content.length() - window.start() / 3, window.text().length());
+  }
+
+  @Test
+  public void anUnreadableFileIsReported() {
+    try {
+      LogTail.read(new File(tmp.getRoot(), "absent"), Long.MAX_VALUE);
+      fail("a missing log must not read as an empty one");
+    } catch (final IOException e) {
+      // expected
+    }
+  }
+}

--- a/app/src/test/java/com/httrack/android/LogTailTest.java
+++ b/app/src/test/java/com/httrack/android/LogTailTest.java
@@ -9,6 +9,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.Arrays;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -16,13 +17,43 @@ import org.junit.rules.TemporaryFolder;
 
 /** LogTail windows a real file on disk, so these tests write real files. */
 public class LogTailTest {
+  /** Bytes in the UTF-8 euro sign, the character these fixtures let the window cut through. */
+  private static final int EURO_BYTES = 3;
+
   @Rule
   public final TemporaryFolder tmp = new TemporaryFolder();
 
   private File write(final String content) throws IOException {
+    return writeBytes(content.getBytes(StandardCharsets.UTF_8));
+  }
+
+  private File writeBytes(final byte[] content) throws IOException {
     final File file = tmp.newFile();
-    Files.write(file.toPath(), content.getBytes(StandardCharsets.UTF_8));
+    Files.write(file.toPath(), content);
     return file;
+  }
+
+  private static boolean isContinuation(final byte b) {
+    return (b & 0xc0) == 0x80;
+  }
+
+  /** Refuse a fixture whose window does not start inside a character, which would prove nothing. */
+  private static void assertCutsACharacter(final byte[] content) {
+    assertTrue("the window starts on a character boundary",
+        isContinuation(content[content.length - LogTail.WINDOW]));
+  }
+
+  /** Walk back to the file start and return everything seen, refusing a step that does not move. */
+  private static String walkBack(final File file) throws IOException {
+    LogTail.Window window = LogTail.readNewest(file);
+    String seen = window.text();
+    while (window.hasEarlier()) {
+      final long end = window.start();
+      window = LogTail.read(file, end);
+      assertTrue("stuck at offset " + window.start(), window.start() < end);
+      seen = window.text() + seen;
+    }
+    return seen;
   }
 
   /** Enough lines to overflow the window several times over. */
@@ -37,7 +68,7 @@ public class LogTailTest {
   @Test
   public void aFileSmallerThanTheWindowComesBackWhole() throws IOException {
     final String content = "first line\nsecond line\n";
-    final LogTail.Window window = LogTail.read(write(content), Long.MAX_VALUE);
+    final LogTail.Window window = LogTail.readNewest(write(content));
     assertEquals(content, window.text());
     assertEquals(0, window.start());
     assertFalse(window.hasEarlier());
@@ -45,7 +76,7 @@ public class LogTailTest {
 
   @Test
   public void anEmptyFileComesBackEmpty() throws IOException {
-    final LogTail.Window window = LogTail.read(write(""), Long.MAX_VALUE);
+    final LogTail.Window window = LogTail.readNewest(write(""));
     assertEquals("", window.text());
     assertFalse(window.hasEarlier());
   }
@@ -54,7 +85,7 @@ public class LogTailTest {
   public void aFileLargerThanTheWindowIsCutAtALineBoundary() throws IOException {
     final String content = lines("padding");
     final File file = write(content);
-    final LogTail.Window window = LogTail.read(file, Long.MAX_VALUE);
+    final LogTail.Window window = LogTail.readNewest(file);
 
     assertTrue(window.hasEarlier());
     assertTrue(window.text().length() < content.length());
@@ -68,51 +99,130 @@ public class LogTailTest {
   @Test
   public void earlierWindowsJoinBackIntoTheWholeFile() throws IOException {
     final String content = lines("padding");
-    final File file = write(content);
-    String seen = "";
-    long end = Long.MAX_VALUE;
-    LogTail.Window window;
-    do {
-      window = LogTail.read(file, end);
-      seen = window.text() + seen;
-      end = window.start();
-    } while (window.hasEarlier());
-    assertEquals(content, seen);
+    assertEquals(content, walkBack(write(content)));
   }
 
   /**
-   * The euro sign is three bytes, so with a window of 131072 the cut always lands one byte into a
-   * character. Reaching the next newline is what gets the decoder back onto a boundary.
+   * The window then ends on the file's only newline, so dropping the partial line would drop
+   * everything and leave the reader an empty dialog it could never step out of.
+   */
+  @Test
+  public void aFileOneByteOverTheWindowIsNotEmpty() throws IOException {
+    final byte[] bytes = new byte[LogTail.WINDOW + 1];
+    Arrays.fill(bytes, (byte) 'a');
+    bytes[LogTail.WINDOW] = '\n';
+    final File file = writeBytes(bytes);
+
+    assertFalse(LogTail.readNewest(file).text().isEmpty());
+    assertEquals(new String(bytes, StandardCharsets.UTF_8), walkBack(file));
+  }
+
+  /** A line longer than the window offers no newline to stop at, so walking back must not need one. */
+  @Test
+  public void aLineLongerThanTheWindowIsStillWalkedPast() throws IOException {
+    final StringBuilder text = new StringBuilder("start\n");
+    while (text.length() < 2 * LogTail.WINDOW) {
+      text.append('a');
+    }
+    final String content = text.append("\nend\n").toString();
+    final File file = write(content);
+
+    assertEquals("end\n", LogTail.readNewest(file).text());
+    assertEquals(content, walkBack(file));
+  }
+
+  /** Bytes that are not UTF-8 at all must not all read as the tail of one split character. */
+  @Test
+  public void aWindowOfContinuationBytesIsNotSkippedWhole() throws IOException {
+    final byte[] bytes = new byte[LogTail.WINDOW + 1];
+    Arrays.fill(bytes, (byte) 0x80);
+    final File file = writeBytes(bytes);
+
+    assertFalse(LogTail.readNewest(file).text().isEmpty());
+    assertFalse(walkBack(file).isEmpty());
+  }
+
+  /**
+   * A run of euro signs long enough to hold the whole window, framed by one-byte text, so the cut
+   * cannot land anywhere but inside a character. Reaching the next newline is what puts the decoder
+   * back onto a boundary.
    */
   @Test
   public void aCutInsideACharacterStillDecodes() throws IOException {
-    final LogTail.Window window = LogTail.read(write(lines("\u20ac\u20ac\u20ac")), Long.MAX_VALUE);
+    final StringBuilder text = new StringBuilder("head line\n");
+    while (text.length() * EURO_BYTES < 2 * LogTail.WINDOW) {
+      text.append('\u20ac');
+    }
+    final String content = text.append("\nend line\n").toString();
+    final File file = write(content);
+    assertCutsACharacter(Files.readAllBytes(file.toPath()));
+
+    final LogTail.Window window = LogTail.readNewest(file);
     assertTrue(window.hasEarlier());
-    assertTrue(window.text().startsWith("line "));
+    assertEquals("end line\n", window.text());
     assertEquals(-1, window.text().indexOf('\ufffd'));
+    assertEquals(content, walkBack(file));
   }
 
   /** Without a newline to reach, only the continuation bytes of the split character are dropped. */
   @Test
   public void aWindowWithoutANewlineDropsTheSplitCharacterOnly() throws IOException {
     final StringBuilder text = new StringBuilder();
-    while (text.length() < LogTail.WINDOW) {
+    while (text.length() * EURO_BYTES < 2 * LogTail.WINDOW) {
       text.append('\u20ac');
     }
     final String content = text.toString();
-    final LogTail.Window window = LogTail.read(write(content), Long.MAX_VALUE);
+    final File file = write(content);
+    assertCutsACharacter(Files.readAllBytes(file.toPath()));
 
+    final LogTail.Window window = LogTail.readNewest(file);
     assertEquals(-1, window.text().indexOf('\ufffd'));
     assertTrue(content.endsWith(window.text()));
     assertTrue(window.hasEarlier());
-    assertEquals(0, window.start() % 3);
-    assertEquals(content.length() - window.start() / 3, window.text().length());
+    assertEquals(0, window.start() % EURO_BYTES);
+    assertEquals(content.length() - window.start() / EURO_BYTES, window.text().length());
+  }
+
+  /** One byte per read, which is the case the fill loop exists for. */
+  private static final class DribblingSource implements LogTail.Source {
+    private final byte[] bytes;
+    private int position;
+
+    DribblingSource(final byte[] bytes) {
+      this.bytes = bytes;
+    }
+
+    @Override
+    public long length() {
+      return bytes.length;
+    }
+
+    @Override
+    public void seek(final long start) {
+      position = (int) start;
+    }
+
+    @Override
+    public int read(final byte[] buf, final int offset, final int count) {
+      if (count == 0 || position >= bytes.length) {
+        return -1;
+      }
+      buf[offset] = bytes[position++];
+      return 1;
+    }
+  }
+
+  @Test
+  public void aShortReadStillFillsTheWindow() throws IOException {
+    final byte[] bytes = "first line\nsecond line\n".getBytes(StandardCharsets.UTF_8);
+    final LogTail.Window window = LogTail.read(new DribblingSource(bytes), bytes.length);
+    assertEquals(new String(bytes, StandardCharsets.UTF_8), window.text());
   }
 
   @Test
   public void anUnreadableFileIsReported() {
     try {
-      LogTail.read(new File(tmp.getRoot(), "absent"), Long.MAX_VALUE);
+      LogTail.readNewest(new File(tmp.getRoot(), "absent"));
       fail("a missing log must not read as an empty one");
     } catch (final IOException e) {
       // expected


### PR DESCRIPTION
Show Logs read the whole `hts-log.txt` into memory and gave it to a dialog. A real crawl's log reaches tens of MB, so it threw `OutOfMemoryError`, which the `IOException` catch did not stop, and the process died.

`LogTail` now seeks back 128 KB from the end and drops the leading partial line, keeping it when the window holds no whole line. That bounds the read and the text the view lays out. A newline byte never occurs inside a UTF-8 sequence, so the drop lands on a character boundary too. The text sits in a `ScrollView`, and an "Earlier" button walks back one window.

Three faults in the same lines go with it: the null `getTargetLogFile()` return, the ignored `read()` count, and the silent catch.

`LogTailTest` writes real temp files and catches a return to reading everything, the old line-drop bounds, or an ignored `read()` count. The dialog driving is not covered, only the windowing.

Closes #184
