### PR TITLE
Progress updates flood the UI handler, which is the top ANR

### DIFF
--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -226,6 +226,19 @@ public class HTTrackActivity extends FragmentActivity {
   // Handler to execute code in UI thread
   private final Handler handlerUI = new Handler();
 
+  // The engine refreshes faster than the main thread can draw, so only the newest frame is queued
+  private final ProgressCoalescer<String[]> progressLines = new ProgressCoalescer<String[]>();
+
+  private final Runnable progressLinesTask = new Runnable() {
+    @Override
+    public void run() {
+      final String[] lines = progressLines.take();
+      if (lines != null) {
+        setProgressLinesInternal(lines);
+      }
+    }
+  };
+
   // Interrupt was requested
   protected boolean interruptRequested;
 
@@ -2380,12 +2393,10 @@ public class HTTrackActivity extends FragmentActivity {
    * Set the "progress" layout lines. To be run in any thread.
    */
   protected void setProgressLines(final String[] lines) {
-    handlerUI.post(new Runnable() {
-      @Override
-      public void run() {
-        setProgressLinesInternal(lines);
-      }
-    });
+    if (progressLines.offer(lines) && !handlerUI.post(progressLinesTask)) {
+      // The looper is gone, so nothing would ever disarm the coalescer.
+      progressLines.take();
+    }
   }
 
   /*

--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -2395,7 +2395,7 @@ public class HTTrackActivity extends FragmentActivity {
   protected void setProgressLines(final String[] lines) {
     if (progressLines.offer(lines) && !handlerUI.post(progressLinesTask)) {
       // The looper is gone, so nothing would ever disarm the coalescer.
-      progressLines.take();
+      progressLines.disarm();
     }
   }
 

--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -233,6 +233,7 @@ public class HTTrackActivity extends FragmentActivity {
     @Override
     public void run() {
       final String[] lines = progressLines.take();
+      // Defensive: only a disarm after the post could empty the coalescer, and nothing live does.
       if (lines != null) {
         setProgressLinesInternal(lines);
       }
@@ -2393,8 +2394,8 @@ public class HTTrackActivity extends FragmentActivity {
    * Set the "progress" layout lines. To be run in any thread.
    */
   protected void setProgressLines(final String[] lines) {
-    if (progressLines.offer(lines) && !handlerUI.post(progressLinesTask)) {
-      // The looper is gone, so nothing would ever disarm the coalescer.
+    if (progressLines.offerNeedsPost(lines) && !handlerUI.post(progressLinesTask)) {
+      // Unreachable short of process death, since post() only refuses once the Looper quits.
       progressLines.disarm();
     }
   }

--- a/app/src/main/java/com/httrack/android/ProgressCoalescer.java
+++ b/app/src/main/java/com/httrack/android/ProgressCoalescer.java
@@ -6,29 +6,27 @@ package com.httrack.android;
  * in between cost nothing, because each one replaces the whole progress pane anyway.
  */
 final class ProgressCoalescer<T> {
+  /** The frame to draw next, and null exactly when no task has been posted to draw one. */
   private T pending;
-  private boolean armed;
 
   /**
-   * Keep this payload as the one to draw next.
+   * Keep this payload as the one to draw next, and say whether a task must now be posted.
    *
-   * @param payload the newest progress, never null
-   * @return true when the caller must schedule the drawing task
+   * @param payload the newest progress, never null, since a null would read as nothing pending
+   * @return true when the caller must schedule the drawing task, false when a pending one will
+   *         carry this payload instead
    */
-  synchronized boolean offer(final T payload) {
+  synchronized boolean offerNeedsPost(final T payload) {
     if (payload == null) {
       throw new NullPointerException("payload");
     }
+    final boolean needsPost = pending == null;
     pending = payload;
-    if (armed) {
-      return false;
-    }
-    armed = true;
-    return true;
+    return needsPost;
   }
 
   /**
-   * Take the payload to draw, and let the next offer schedule again. Disarming here rather than
+   * Take the payload to draw, and let the next offer schedule again. Clearing here rather than
    * after the drawing gives a refresh that lands mid-draw a task of its own.
    *
    * @return the newest payload, or null when nothing is pending
@@ -42,6 +40,5 @@ final class ProgressCoalescer<T> {
   /** Drop whatever is pending and let the next offer schedule again. */
   synchronized void disarm() {
     pending = null;
-    armed = false;
   }
 }

--- a/app/src/main/java/com/httrack/android/ProgressCoalescer.java
+++ b/app/src/main/java/com/httrack/android/ProgressCoalescer.java
@@ -35,8 +35,13 @@ final class ProgressCoalescer<T> {
    */
   synchronized T take() {
     final T payload = pending;
+    disarm();
+    return payload;
+  }
+
+  /** Drop whatever is pending and let the next offer schedule again. */
+  synchronized void disarm() {
     pending = null;
     armed = false;
-    return payload;
   }
 }

--- a/app/src/main/java/com/httrack/android/ProgressCoalescer.java
+++ b/app/src/main/java/com/httrack/android/ProgressCoalescer.java
@@ -1,12 +1,12 @@
 package com.httrack.android;
 
 /**
- * At most one pending UI update, always carrying the newest payload. One posted task per engine
- * refresh grows the main thread's queue until the app stops answering input, and the frames dropped
- * in between cost nothing, because each one replaces the whole progress pane anyway.
+ * Holds at most one pending update, always the newest. One posted task per engine refresh grows
+ * the main thread's queue until the app stops answering input. The frames dropped in between cost
+ * nothing, because each one replaces the whole progress pane.
  */
 final class ProgressCoalescer<T> {
-  /** The frame to draw next, and null exactly when no task has been posted to draw one. */
+  /** Holds the frame to draw next, and is null exactly when no task has been posted. */
   private T pending;
 
   /**
@@ -26,8 +26,8 @@ final class ProgressCoalescer<T> {
   }
 
   /**
-   * Take the payload to draw, and let the next offer schedule again. Clearing here rather than
-   * after the drawing gives a refresh that lands mid-draw a task of its own.
+   * Take the payload to draw, and let the next offer schedule again. Clear before the drawing, not
+   * after, so a refresh landing mid-draw gets a task of its own.
    *
    * @return the newest payload, or null when nothing is pending
    */

--- a/app/src/main/java/com/httrack/android/ProgressCoalescer.java
+++ b/app/src/main/java/com/httrack/android/ProgressCoalescer.java
@@ -1,0 +1,42 @@
+package com.httrack.android;
+
+/**
+ * At most one pending UI update, always carrying the newest payload. One posted task per engine
+ * refresh grows the main thread's queue until the app stops answering input, and the frames dropped
+ * in between cost nothing, because each one replaces the whole progress pane anyway.
+ */
+final class ProgressCoalescer<T> {
+  private T pending;
+  private boolean armed;
+
+  /**
+   * Keep this payload as the one to draw next.
+   *
+   * @param payload the newest progress, never null
+   * @return true when the caller must schedule the drawing task
+   */
+  synchronized boolean offer(final T payload) {
+    if (payload == null) {
+      throw new NullPointerException("payload");
+    }
+    pending = payload;
+    if (armed) {
+      return false;
+    }
+    armed = true;
+    return true;
+  }
+
+  /**
+   * Take the payload to draw, and let the next offer schedule again. Disarming here rather than
+   * after the drawing gives a refresh that lands mid-draw a task of its own.
+   *
+   * @return the newest payload, or null when nothing is pending
+   */
+  synchronized T take() {
+    final T payload = pending;
+    pending = null;
+    armed = false;
+    return payload;
+  }
+}

--- a/app/src/test/java/com/httrack/android/ProgressCoalescerTest.java
+++ b/app/src/test/java/com/httrack/android/ProgressCoalescerTest.java
@@ -15,21 +15,37 @@ import org.junit.Test;
  * the looper no unit test can run.
  */
 public class ProgressCoalescerTest {
+  /** Every drain pattern over the first six frames of a run. */
+  private static final int SCHEDULES = 64;
+  private static final int FRAMES_PER_SCHEDULE = 20;
+  private static final int CONCURRENT_FRAMES = 5000;
+
+  private static String frame(final int index) {
+    return "frame " + index;
+  }
+
   /** Posting, and drawing split in two, so a refresh can be timed to land mid-draw. */
   private static final class FakeUiThread {
     final ProgressCoalescer<String> coalescer = new ProgressCoalescer<String>();
+
+    /** What the drawing task has put on screen, oldest first. */
     final List<String> drawn = new ArrayList<String>();
-    int queued;
+
+    /** Tasks posted and not yet run, counted atomically because the crawl thread offers too. */
+    private final AtomicInteger postedTasks = new AtomicInteger();
 
     void refresh(final String payload) {
       if (coalescer.offer(payload)) {
-        queued++;
+        postedTasks.incrementAndGet();
       }
     }
 
+    int postedTasks() {
+      return postedTasks.get();
+    }
+
     String startDraw() {
-      assertTrue("no task was posted", queued > 0);
-      queued--;
+      postedTasks.decrementAndGet();
       return coalescer.take();
     }
 
@@ -44,21 +60,25 @@ public class ProgressCoalescerTest {
     }
 
     void drain() {
-      while (queued > 0) {
+      while (postedTasks() > 0) {
         runOneTask();
       }
+    }
+
+    String lastDrawn() {
+      return drawn.get(drawn.size() - 1);
     }
   }
 
   @Test
   public void aBurstOfRefreshesPostsOneTaskCarryingTheLastOne() {
     final FakeUiThread ui = new FakeUiThread();
-    for (final String frame : new String[] { "1", "2", "3", "4", "5" }) {
-      ui.refresh(frame);
+    for (int i = 0; i < 5; i++) {
+      ui.refresh(frame(i));
     }
-    assertEquals(1, ui.queued);
+    assertEquals(1, ui.postedTasks());
     ui.drain();
-    assertEquals(Arrays.asList("5"), ui.drawn);
+    assertEquals(Arrays.asList(frame(4)), ui.drawn);
   }
 
   @Test
@@ -66,11 +86,10 @@ public class ProgressCoalescerTest {
     final FakeUiThread ui = new FakeUiThread();
     final List<String> expected = new ArrayList<String>();
     for (int i = 0; i < 100; i++) {
-      final String frame = "frame " + i;
-      ui.refresh(frame);
-      assertEquals(1, ui.queued);
+      ui.refresh(frame(i));
+      assertEquals(1, ui.postedTasks());
       ui.drain();
-      expected.add(frame);
+      expected.add(frame(i));
     }
     assertEquals(expected, ui.drawn);
   }
@@ -81,6 +100,7 @@ public class ProgressCoalescerTest {
     ui.refresh("first");
     final String drawing = ui.startDraw();
     ui.refresh("last");
+    assertEquals(1, ui.postedTasks());
     ui.endDraw(drawing);
     ui.drain();
     assertEquals(Arrays.asList("first", "last"), ui.drawn);
@@ -89,18 +109,18 @@ public class ProgressCoalescerTest {
   /** Whatever the engine and the looper do, the frame nothing follows must reach the screen. */
   @Test
   public void theLastFrameIsDrawnWhateverTheInterleaving() {
-    for (int seed = 0; seed < 64; seed++) {
+    for (int schedule = 0; schedule < SCHEDULES; schedule++) {
       final FakeUiThread ui = new FakeUiThread();
-      int schedule = seed;
-      for (int frame = 0; frame < 20; frame++) {
-        ui.refresh("frame " + frame);
-        if (schedule % 2 == 0 && ui.queued > 0) {
+      int drainAfter = schedule;
+      for (int i = 0; i < FRAMES_PER_SCHEDULE; i++) {
+        ui.refresh(frame(i));
+        if (drainAfter % 2 == 0) {
           ui.runOneTask();
         }
-        schedule /= 2;
+        drainAfter /= 2;
       }
       ui.drain();
-      assertEquals("seed " + seed, "frame 19", ui.drawn.get(ui.drawn.size() - 1));
+      assertEquals("schedule " + schedule, frame(FRAMES_PER_SCHEDULE - 1), ui.lastDrawn());
     }
   }
 
@@ -124,34 +144,29 @@ public class ProgressCoalescerTest {
     assertEquals("next", coalescer.take());
   }
 
+  /** The drawing task tells an empty coalescer apart by the null, so no frame may be one. */
+  @Test(expected = NullPointerException.class)
+  public void aNullFrameIsRefused() {
+    new ProgressCoalescer<String>().offer(null);
+  }
+
   @Test
   public void theCrawlThreadAndTheUiThreadAgreeOnTheLastFrame() throws InterruptedException {
-    final int frames = 5000;
-    final ProgressCoalescer<Integer> coalescer = new ProgressCoalescer<Integer>();
-    final AtomicInteger queued = new AtomicInteger();
+    final FakeUiThread ui = new FakeUiThread();
     final Thread crawl = new Thread(new Runnable() {
       @Override
       public void run() {
-        for (int frame = 1; frame <= frames; frame++) {
-          if (coalescer.offer(Integer.valueOf(frame))) {
-            queued.incrementAndGet();
-          }
+        for (int i = 0; i < CONCURRENT_FRAMES; i++) {
+          ui.refresh(frame(i));
         }
       }
     });
     crawl.start();
-
-    Integer last = null;
-    while (crawl.isAlive() || queued.get() > 0) {
-      while (queued.get() > 0) {
-        queued.decrementAndGet();
-        final Integer payload = coalescer.take();
-        if (payload != null) {
-          last = payload;
-        }
-      }
+    while (crawl.isAlive()) {
+      ui.drain();
     }
     crawl.join();
-    assertEquals(Integer.valueOf(frames), last);
+    ui.drain();
+    assertEquals(frame(CONCURRENT_FRAMES - 1), ui.lastDrawn());
   }
 }

--- a/app/src/test/java/com/httrack/android/ProgressCoalescerTest.java
+++ b/app/src/test/java/com/httrack/android/ProgressCoalescerTest.java
@@ -11,8 +11,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Test;
 
 /**
- * The queue discipline HTTrackActivity.setProgressLines follows, with a counter standing in for
- * the looper no unit test can run.
+ * Verifies the queue discipline setProgressLines follows, with a counter standing in for the
+ * untestable looper.
  */
 public class ProgressCoalescerTest {
   /** Every drain pattern over the first six frames of a run. */

--- a/app/src/test/java/com/httrack/android/ProgressCoalescerTest.java
+++ b/app/src/test/java/com/httrack/android/ProgressCoalescerTest.java
@@ -35,7 +35,7 @@ public class ProgressCoalescerTest {
     private final AtomicInteger postedTasks = new AtomicInteger();
 
     void refresh(final String payload) {
-      if (coalescer.offer(payload)) {
+      if (coalescer.offerNeedsPost(payload)) {
         postedTasks.incrementAndGet();
       }
     }
@@ -128,7 +128,7 @@ public class ProgressCoalescerTest {
   public void aTaskWhoseFrameWasAlreadyDrawnDrawsNothing() {
     final ProgressCoalescer<String> coalescer = new ProgressCoalescer<String>();
     assertNull(coalescer.take());
-    coalescer.offer("frame");
+    coalescer.offerNeedsPost("frame");
     assertEquals("frame", coalescer.take());
     assertNull(coalescer.take());
   }
@@ -137,17 +137,17 @@ public class ProgressCoalescerTest {
   @Test
   public void disarmingDropsThePendingFrameAndLetsTheNextOnePost() {
     final ProgressCoalescer<String> coalescer = new ProgressCoalescer<String>();
-    assertTrue(coalescer.offer("stranded"));
+    assertTrue(coalescer.offerNeedsPost("stranded"));
     coalescer.disarm();
     assertNull(coalescer.take());
-    assertTrue(coalescer.offer("next"));
+    assertTrue(coalescer.offerNeedsPost("next"));
     assertEquals("next", coalescer.take());
   }
 
-  /** The drawing task tells an empty coalescer apart by the null, so no frame may be one. */
+  /** A null frame would read as no task pending, and post a second one over the first. */
   @Test(expected = NullPointerException.class)
   public void aNullFrameIsRefused() {
-    new ProgressCoalescer<String>().offer(null);
+    new ProgressCoalescer<String>().offerNeedsPost(null);
   }
 
   @Test

--- a/app/src/test/java/com/httrack/android/ProgressCoalescerTest.java
+++ b/app/src/test/java/com/httrack/android/ProgressCoalescerTest.java
@@ -1,0 +1,146 @@
+package com.httrack.android;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Test;
+
+/**
+ * The queue discipline HTTrackActivity.setProgressLines follows, with a counter standing in for
+ * the looper no unit test can run.
+ */
+public class ProgressCoalescerTest {
+  /** Posting, and drawing split in two, so a refresh can be timed to land mid-draw. */
+  private static final class FakeUiThread {
+    final ProgressCoalescer<String> coalescer = new ProgressCoalescer<String>();
+    final List<String> drawn = new ArrayList<String>();
+    int queued;
+
+    void refresh(final String payload) {
+      if (coalescer.offer(payload)) {
+        queued++;
+      }
+    }
+
+    String startDraw() {
+      assertTrue("no task was posted", queued > 0);
+      queued--;
+      return coalescer.take();
+    }
+
+    void endDraw(final String payload) {
+      if (payload != null) {
+        drawn.add(payload);
+      }
+    }
+
+    void runOneTask() {
+      endDraw(startDraw());
+    }
+
+    void drain() {
+      while (queued > 0) {
+        runOneTask();
+      }
+    }
+  }
+
+  @Test
+  public void aBurstOfRefreshesPostsOneTaskCarryingTheLastOne() {
+    final FakeUiThread ui = new FakeUiThread();
+    for (final String frame : new String[] { "1", "2", "3", "4", "5" }) {
+      ui.refresh(frame);
+    }
+    assertEquals(1, ui.queued);
+    ui.drain();
+    assertEquals(Arrays.asList("5"), ui.drawn);
+  }
+
+  @Test
+  public void aTaskThatHasRunLetsTheNextRefreshPostAgain() {
+    final FakeUiThread ui = new FakeUiThread();
+    final List<String> expected = new ArrayList<String>();
+    for (int i = 0; i < 100; i++) {
+      final String frame = "frame " + i;
+      ui.refresh(frame);
+      assertEquals(1, ui.queued);
+      ui.drain();
+      expected.add(frame);
+    }
+    assertEquals(expected, ui.drawn);
+  }
+
+  @Test
+  public void aRefreshArrivingMidDrawGetsATaskOfItsOwn() {
+    final FakeUiThread ui = new FakeUiThread();
+    ui.refresh("first");
+    final String drawing = ui.startDraw();
+    ui.refresh("last");
+    ui.endDraw(drawing);
+    ui.drain();
+    assertEquals(Arrays.asList("first", "last"), ui.drawn);
+  }
+
+  /** Whatever the engine and the looper do, the frame nothing follows must reach the screen. */
+  @Test
+  public void theLastFrameIsDrawnWhateverTheInterleaving() {
+    for (int seed = 0; seed < 64; seed++) {
+      final FakeUiThread ui = new FakeUiThread();
+      int schedule = seed;
+      for (int frame = 0; frame < 20; frame++) {
+        ui.refresh("frame " + frame);
+        if (schedule % 2 == 0 && ui.queued > 0) {
+          ui.runOneTask();
+        }
+        schedule /= 2;
+      }
+      ui.drain();
+      assertEquals("seed " + seed, "frame 19", ui.drawn.get(ui.drawn.size() - 1));
+    }
+  }
+
+  @Test
+  public void aTaskWhoseFrameWasAlreadyDrawnDrawsNothing() {
+    final ProgressCoalescer<String> coalescer = new ProgressCoalescer<String>();
+    assertNull(coalescer.take());
+    coalescer.offer("frame");
+    assertEquals("frame", coalescer.take());
+    assertNull(coalescer.take());
+  }
+
+  @Test
+  public void theCrawlThreadAndTheUiThreadAgreeOnTheLastFrame() throws InterruptedException {
+    final int frames = 5000;
+    final ProgressCoalescer<Integer> coalescer = new ProgressCoalescer<Integer>();
+    final AtomicInteger queued = new AtomicInteger();
+    final Thread crawl = new Thread(new Runnable() {
+      @Override
+      public void run() {
+        for (int frame = 1; frame <= frames; frame++) {
+          if (coalescer.offer(Integer.valueOf(frame))) {
+            queued.incrementAndGet();
+          }
+        }
+      }
+    });
+    crawl.start();
+
+    Integer last = null;
+    while (crawl.isAlive() || queued.get() > 0) {
+      while (queued.get() > 0) {
+        queued.decrementAndGet();
+        final Integer payload = coalescer.take();
+        if (payload != null) {
+          last = payload;
+        }
+      }
+    }
+    crawl.join();
+    assertEquals(Integer.valueOf(frames), last);
+  }
+}

--- a/app/src/test/java/com/httrack/android/ProgressCoalescerTest.java
+++ b/app/src/test/java/com/httrack/android/ProgressCoalescerTest.java
@@ -113,6 +113,17 @@ public class ProgressCoalescerTest {
     assertNull(coalescer.take());
   }
 
+  /** What the failed-post branch of setProgressLines rests on. */
+  @Test
+  public void disarmingDropsThePendingFrameAndLetsTheNextOnePost() {
+    final ProgressCoalescer<String> coalescer = new ProgressCoalescer<String>();
+    assertTrue(coalescer.offer("stranded"));
+    coalescer.disarm();
+    assertNull(coalescer.take());
+    assertTrue(coalescer.offer("next"));
+    assertEquals("next", coalescer.take());
+  }
+
   @Test
   public void theCrawlThreadAndTheUiThreadAgreeOnTheLastFrame() throws InterruptedException {
     final int frames = 5000;


### PR DESCRIPTION
`setProgressLines` posted one Runnable per engine refresh, and each one walks the layout, measures every line and parses it with `Html.fromHtml`. The engine produces frames faster than the main thread draws them, so the queue grew without limit.

The newest lines now sit in a `ProgressCoalescer` behind one reusable task, and a refresh arriving while a task is pending replaces the payload. Nothing is lost, because each frame replaces the whole progress pane.

The task takes the payload and disarms in one synchronized step before drawing. A refresh landing mid-draw then posts a task of its own, so the final frame still reaches the screen. Three mutants of the coalescer each fail the new tests.

Moving `Html.fromHtml` off the main thread is a separate change.

Closes #187
