### PR TITLE
Back on the progress pane crashes when the launcher refuses the home intent

### DIFF
--- a/app/src/main/java/com/httrack/android/BackgroundPolicy.java
+++ b/app/src/main/java/com/httrack/android/BackgroundPolicy.java
@@ -1,16 +1,16 @@
 package com.httrack.android;
 
 /**
- * Where a back press goes while a crawl runs. Finishing the activity would take the retained
- * fragment, and the crawl it holds, down with it, so back only moves the task out of the way.
- * No Android type appears here, so each decision can be checked against its truth table.
+ * These decide where a back press goes while a crawl runs. Finishing the activity would take the
+ * retained fragment, and the crawl it holds, down with it, so back only moves the task out of
+ * the way. No Android type appears here, so each decision can be checked against its truth table.
  */
 final class BackgroundPolicy {
   private BackgroundPolicy() {
   }
 
   /**
-   * Ask the launcher for the home screen, the only way out left once the task refuses to move.
+   * Should the launcher be asked, the only way out once the task refuses to move?
    *
    * @param movedToBack whether the task went to the background
    * @return true when the home intent must be fired
@@ -20,7 +20,7 @@ final class BackgroundPolicy {
   }
 
   /**
-   * Report a back press that changed nothing, which neither way out says on its own.
+   * Did the app stay on screen because both ways out failed, not just one?
    *
    * @param movedToBack whether the task went to the background
    * @param wentHome    whether the launcher took the home intent

--- a/app/src/main/java/com/httrack/android/BackgroundPolicy.java
+++ b/app/src/main/java/com/httrack/android/BackgroundPolicy.java
@@ -1,0 +1,32 @@
+package com.httrack.android;
+
+/**
+ * Where a back press goes while a crawl runs. Finishing the activity would take the retained
+ * fragment, and the crawl it holds, down with it, so back only moves the task out of the way.
+ * No Android type appears here, so each decision can be checked against its truth table.
+ */
+final class BackgroundPolicy {
+  private BackgroundPolicy() {
+  }
+
+  /**
+   * Ask the launcher for the home screen, the only way out left once the task refuses to move.
+   *
+   * @param movedToBack whether the task went to the background
+   * @return true when the home intent must be fired
+   */
+  static boolean askTheLauncher(final boolean movedToBack) {
+    return !movedToBack;
+  }
+
+  /**
+   * Report a back press that changed nothing, which neither way out says on its own.
+   *
+   * @param movedToBack whether the task went to the background
+   * @param wentHome    whether the launcher took the home intent
+   * @return true when the app is still in front of the user
+   */
+  static boolean stillOnScreen(final boolean movedToBack, final boolean wentHome) {
+    return !movedToBack && !wentHome;
+  }
+}

--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -3413,11 +3413,26 @@ public class HTTrackActivity extends FragmentActivity {
     }
   }
 
-  /** Navigate back to home, without killing us. **/
+  /** Leave the foreground, without killing us. **/
   private void goToHome() {
-    final Intent intent = new Intent(Intent.ACTION_MAIN);
-    intent.addCategory(Intent.CATEGORY_HOME);
-    startActivity(intent);
+    final boolean moved = moveTaskToBack(true);
+    final boolean home = BackgroundPolicy.askTheLauncher(moved) && startHomeIntent();
+    if (BackgroundPolicy.stillOnScreen(moved, home)) {
+      Log.w(getClass().getSimpleName(), "back pressed, but the task would not move");
+    }
+  }
+
+  /** Ask the launcher for the home screen, and return false when it refuses with an exception. */
+  private boolean startHomeIntent() {
+    try {
+      final Intent intent = new Intent(Intent.ACTION_MAIN);
+      intent.addCategory(Intent.CATEGORY_HOME);
+      startActivity(intent);
+      return true;
+    } catch (final Exception e) {
+      Log.w(getClass().getSimpleName(), "no home screen to go to", e);
+      return false;
+    }
   }
 
   /*

--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -53,7 +53,6 @@ import android.app.AlertDialog;
 import android.app.Notification;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
-import android.content.ActivityNotFoundException;
 import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.ContentResolver;
@@ -2666,8 +2665,8 @@ public class HTTrackActivity extends FragmentActivity {
     try {
       showNotification(getString(R.string.import_mirrors_prompt));
       startActivityForResult(intent, ACTIVITY_IMPORT_TREE);
-    } catch (final ActivityNotFoundException e) {
-      Log.w(getClass().getSimpleName(), "no document-tree picker", e);
+    } catch (final Exception e) {
+      Log.w(getClass().getSimpleName(), "could not open the document-tree picker", e);
       showNotification(getString(R.string.import_mirrors_none));
     }
   }
@@ -3415,6 +3414,7 @@ public class HTTrackActivity extends FragmentActivity {
 
   /** Leave the foreground, without killing us. **/
   private void goToHome() {
+    // Throws only when system_server has died, which takes this process with it anyway.
     final boolean moved = moveTaskToBack(true);
     final boolean home = BackgroundPolicy.askTheLauncher(moved) && startHomeIntent();
     if (BackgroundPolicy.stillOnScreen(moved, home)) {

--- a/app/src/test/java/com/httrack/android/BackgroundPolicyTest.java
+++ b/app/src/test/java/com/httrack/android/BackgroundPolicyTest.java
@@ -1,0 +1,61 @@
+package com.httrack.android;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import org.junit.Test;
+
+/** Truth tables for where back goes while a crawl runs, plus the source-text checks that prove
+ *  the activity delegates here. */
+public class BackgroundPolicyTest {
+  @Test
+  public void aTaskThatMovedNeedsNothingElse() {
+    assertFalse(BackgroundPolicy.askTheLauncher(true));
+    assertFalse(BackgroundPolicy.stillOnScreen(true, false));
+    assertFalse(BackgroundPolicy.stillOnScreen(true, true));
+  }
+
+  @Test
+  public void aTaskThatWouldNotMoveFallsBackToTheLauncher() {
+    assertTrue(BackgroundPolicy.askTheLauncher(false));
+    assertFalse(BackgroundPolicy.stillOnScreen(false, true));
+  }
+
+  @Test
+  public void bothWaysOutFailingLeavesTheAppInFront() {
+    assertTrue(BackgroundPolicy.stillOnScreen(false, false));
+  }
+
+  @Test
+  public void backSendsTheTaskAwayRatherThanFiringAnIntent() throws IOException {
+    final String home = TestSources.between(TestSources.javaSource("HTTrackActivity"),
+        "private void goToHome()", "\n  }");
+    assertTrue("the task move is what keeps the crawl alive",
+        home.contains("moveTaskToBack(true)"));
+    assertTrue("a refused move must not be ignored",
+        home.contains("BackgroundPolicy.askTheLauncher(")
+            && home.contains("BackgroundPolicy.stillOnScreen("));
+  }
+
+  @Test
+  public void theHomeIntentIsGuarded() throws IOException {
+    final String source = TestSources.withoutCommentsAndStrings(
+        TestSources.javaSource("HTTrackActivity"));
+    final String intent = TestSources.between(source, "private boolean startHomeIntent()",
+        "\n  }");
+    assertTrue("startActivity throws the launcher's refusal back at us",
+        intent.indexOf("startActivity(") < intent.indexOf("catch ("));
+  }
+
+  @Test
+  public void leavingWhileMirroringNeverFinishesTheActivity() throws IOException {
+    final String source = TestSources.withoutCommentsAndStrings(
+        TestSources.javaSource("HTTrackActivity"));
+    for (final String method : new String[] { "private void goToHome()",
+        "private boolean startHomeIntent()", "public void handleOnBackPressed()" }) {
+      assertFalse(method + " would take the retained fragment down",
+          TestSources.between(source, method, "\n  }").contains("finish()"));
+    }
+  }
+}


### PR DESCRIPTION
Back on the progress pane must not finish the activity, because the crawl runs in a retained fragment the activity owns. It left the app by firing a home intent at the launcher. Play reports that `startActivity` coming back as an `IllegalStateException`, which kills the crawl the handler exists to protect.

`moveTaskToBack(true)` backgrounds the task without naming another app. The home intent stays as the fallback for its false return, now inside a try/catch. When both fail the app stays on screen, which is the only outcome that keeps the crawl. The legacy-mirror picker caught only `ActivityNotFoundException`, so it is widened here too.

`BackgroundPolicy` holds the two decisions so they can be truth-tabled, after `NativeFaultPolicy`. Source-text tests pin the delegation, and each was checked against a mutation that reverts the fix.

Closes #188
