### PR TITLE
The Android build asks the engine for its deliberate-crash option

### DIFF
--- a/app/src/main/jni/Android.mk
+++ b/app/src/main/jni/Android.mk
@@ -105,7 +105,6 @@ LOCAL_CFLAGS += -O3 -g3 -funwind-tables -fPIC -rdynamic 					\
 	-Wno-nested-externs														\
 	-D_REENTRANT -DPIC -DANDROID -D_ANDROID -DHAVE_CONFIG_H -DINET6			\
 	-DLIBHTTRACK_EXPORTS -DZLIB_CONST -DHTS_INTHASH_USES_MD5 -DLIBICONV_PLUG\
-	-DHTS_CRASH_TEST														\
 	-Wl,-O1
 LOCAL_CPPFLAGS += -pthread
 include $(BUILD_SHARED_LIBRARY)


### PR DESCRIPTION
Nothing in the tree reads `HTS_CRASH_TEST`, so this deletion changes no behaviour today. It matters for what comes next.

The engine is gaining an `#ifdef HTS_CRASH_TEST` guard around `-#c`. Once we bump the pin, this define would be the one thing keeping the deliberate crash enabled for Android. Dropping it now means it is already gone when the pin moves.

Closes #196
