### PR TITLE
The vitals samples do not say which device or Android version they hit

### DIFF
--- a/.github/workflows/play-vitals.yml
+++ b/.github/workflows/play-vitals.yml
@@ -20,11 +20,11 @@ on:
       kind:
         description: 'issues: crash, anr or both'
         default: both
-      samples:
+      reports:
         description: 'issues: reports read per cluster, each labelled with its build, API level and device'
         default: '1'
       traces:
-        description: 'issues: how many of those samples print a stack trace'
+        description: 'issues: how many of those reports print a stack trace'
         default: '1'
       version_code:
         description: 'issues: restrict to one versionCode (blank = all)'
@@ -51,7 +51,7 @@ jobs:
           DAYS: ${{ inputs.days }}
           BY: ${{ inputs.by }}
           KIND: ${{ inputs.kind }}
-          SAMPLES: ${{ inputs.samples }}
+          REPORTS: ${{ inputs.reports }}
           TRACES: ${{ inputs.traces }}
           VERSION_CODE: ${{ inputs.version_code }}
         run: |
@@ -62,7 +62,7 @@ jobs:
           args=()
           case "$COMMAND" in
             rates)  args+=(--days "$DAYS" --by "$BY") ;;
-            issues) args+=(--days "$DAYS" --kind "$KIND" --samples "$SAMPLES" --traces "$TRACES")
+            issues) args+=(--days "$DAYS" --kind "$KIND" --reports "$REPORTS" --traces "$TRACES")
                     if [ -n "$VERSION_CODE" ]; then args+=(--version-code "$VERSION_CODE"); fi ;;
           esac
           python3 tools/ci/play_vitals.py "$RUNNER_TEMP/play-sa.json" "$COMMAND" "${args[@]}"

--- a/.github/workflows/play-vitals.yml
+++ b/.github/workflows/play-vitals.yml
@@ -20,6 +20,12 @@ on:
       kind:
         description: 'issues: crash, anr or both'
         default: both
+      samples:
+        description: 'issues: reports read per cluster, each labelled with its build, API level and device'
+        default: '1'
+      traces:
+        description: 'issues: how many of those samples print a stack trace'
+        default: '1'
       version_code:
         description: 'issues: restrict to one versionCode (blank = all)'
         default: ''
@@ -45,6 +51,8 @@ jobs:
           DAYS: ${{ inputs.days }}
           BY: ${{ inputs.by }}
           KIND: ${{ inputs.kind }}
+          SAMPLES: ${{ inputs.samples }}
+          TRACES: ${{ inputs.traces }}
           VERSION_CODE: ${{ inputs.version_code }}
         run: |
           set -euo pipefail
@@ -54,7 +62,7 @@ jobs:
           args=()
           case "$COMMAND" in
             rates)  args+=(--days "$DAYS" --by "$BY") ;;
-            issues) args+=(--days "$DAYS" --kind "$KIND")
+            issues) args+=(--days "$DAYS" --kind "$KIND" --samples "$SAMPLES" --traces "$TRACES")
                     if [ -n "$VERSION_CODE" ]; then args+=(--version-code "$VERSION_CODE"); fi ;;
           esac
           python3 tools/ci/play_vitals.py "$RUNNER_TEMP/play-sa.json" "$COMMAND" "${args[@]}"

--- a/tools/ci/play_vitals.py
+++ b/tools/ci/play_vitals.py
@@ -9,7 +9,7 @@ Usage:
   play_vitals.py <sa_json> probe
   play_vitals.py <sa_json> rates [--days N] [--by versionCode|apiLevel|deviceModel]
   play_vitals.py <sa_json> issues [--kind crash|anr|both] [--days N] [--limit N]
-                            [--samples N] [--traces N] [--version-code VC]
+                            [--reports N] [--traces N] [--version-code VC]
 
 `probe` only reads the two metric-set descriptors, so it answers "does this
 service account have access at all" without asking for any data.
@@ -32,6 +32,7 @@ BASE = f"https://playdeveloperreporting.googleapis.com/v1beta1/apps/{PKG}"
 DEFAULT_TZ = "America/Los_Angeles"
 
 MetricSet = collections.namedtuple("MetricSet", "name weighted metrics threshold")
+ReportFields = collections.namedtuple("ReportFields", "version_code api_level build marketing_name")
 
 # The rate Play compares against its threshold is the user-perceived one, weighted over 28
 # days by distinct users. The plain rate rides along because a per-version split of the
@@ -218,7 +219,7 @@ def cmd_issues(token, args):
                 "filter": " AND ".join(terms),
                 "orderBy": "distinctUsers desc",
                 "pageSize": args.limit,
-                "sampleErrorReportLimit": args.samples,
+                "sampleErrorReportLimit": args.reports,
             }
         )
         res = call(token, f"{BASE}/errorIssues:search", params=params)
@@ -233,11 +234,11 @@ def cmd_issues(token, args):
             print(f"    {issue.get('type')} in {issue.get('location')}")
             print(f"    {issue.get('cause')}")
             print(f"    id {issue.get('name')}")
-            reports = search_reports(token, issue.get("name", ""), start, end, tz, args.samples)
-            for rank, report in enumerate(reports):
-                print(f"    [{report_identity(report)}]")
-                if rank < args.traces:
-                    print(indent(report.get("reportText", "")))
+            reports = search_reports(
+                token, issue.get("name", ""), start, end, tz, limit=args.reports
+            )
+            for line in report_lines(reports, args.traces):
+                print(line)
 
 
 def subobject(d, key):
@@ -246,21 +247,32 @@ def subobject(d, key):
     return value if isinstance(value, dict) else {}
 
 
-def report_identity(report):
-    """Returns one report's build, API level and device as a single line.
-
-    Every field here is optional, so an absent one prints as "?" rather than dropping
-    out and shifting what is left onto the wrong label.
-    """
+def report_fields(report):
+    """Returns one report's versions and device, each None when the field is absent."""
     model = subobject(report, "deviceModel")
     device = subobject(model, "deviceId")
-    build = "/".join(p for p in (device.get("buildBrand"), device.get("buildDevice")) if p)
-    name = model.get("marketingName")
-    return (
-        f"vc {subobject(report, 'appVersion').get('versionCode', '?')}, "
-        f"api {subobject(report, 'osVersion').get('apiLevel', '?')}, "
-        f"{build or '?'}" + (f" ({name})" if name else "")
+    build = "/".join(str(p) for p in (device.get("buildBrand"), device.get("buildDevice")) if p)
+    return ReportFields(
+        subobject(report, "appVersion").get("versionCode"),
+        subobject(report, "osVersion").get("apiLevel"),
+        build or None,
+        model.get("marketingName"),
     )
+
+
+def report_lines(reports, traces):
+    """Returns one label per report, plus a stack trace for the first `traces` of them."""
+    lines = []
+    for rank, report in enumerate(reports):
+        fields = report_fields(report)
+        named = f" ({fields.marketing_name})" if fields.marketing_name else ""
+        lines.append(
+            f"    [vc {fields.version_code or '?'}, "
+            f"api {fields.api_level or '?'}, {fields.build or '?'}{named}]"
+        )
+        if rank < traces:
+            lines.append(indent(report.get("reportText", "")))
+    return lines
 
 
 def search_reports(token, issue_name, start, end, tz, limit):
@@ -286,7 +298,7 @@ def indent(text):
     return "\n".join("      " + line for line in text.splitlines())
 
 
-def main():
+def build_parser():
     p = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )
@@ -303,10 +315,14 @@ def main():
     i.add_argument("--kind", default="both", choices=["crash", "anr", "both"])
     i.add_argument("--days", type=int, default=28)
     i.add_argument("--limit", type=int, default=15)
-    i.add_argument("--samples", type=int, default=1, help="reports read per cluster")
+    i.add_argument("--reports", type=int, default=1, help="reports read per cluster")
     i.add_argument("--traces", type=int, default=1, help="of those, how many print a stack trace")
     i.add_argument("--version-code", type=int)
-    args = p.parse_args()
+    return p
+
+
+def main():
+    args = build_parser().parse_args()
 
     with open(args.sa_json, encoding="utf-8") as f:
         sa = json.load(f)

--- a/tools/ci/play_vitals.py
+++ b/tools/ci/play_vitals.py
@@ -237,7 +237,7 @@ def cmd_issues(token, args):
             reports = search_reports(
                 token, issue.get("name", ""), start, end, tz, limit=args.reports
             )
-            for line in report_lines(reports, args.traces):
+            for line in report_lines(reports, traces=args.traces):
                 print(line)
 
 
@@ -251,6 +251,7 @@ def report_fields(report):
     """Returns one report's versions and device, each None when the field is absent."""
     model = subobject(report, "deviceModel")
     device = subobject(model, "deviceId")
+    # Play types both build fields as strings, so str() only guards a stray number here.
     build = "/".join(str(p) for p in (device.get("buildBrand"), device.get("buildDevice")) if p)
     return ReportFields(
         subobject(report, "appVersion").get("versionCode"),
@@ -314,7 +315,7 @@ def build_parser():
     i = sub.add_parser("issues")
     i.add_argument("--kind", default="both", choices=["crash", "anr", "both"])
     i.add_argument("--days", type=int, default=28)
-    i.add_argument("--limit", type=int, default=15)
+    i.add_argument("--limit", type=int, default=15, help="clusters listed per kind")
     i.add_argument("--reports", type=int, default=1, help="reports read per cluster")
     i.add_argument("--traces", type=int, default=1, help="of those, how many print a stack trace")
     i.add_argument("--version-code", type=int)

--- a/tools/ci/play_vitals.py
+++ b/tools/ci/play_vitals.py
@@ -9,7 +9,7 @@ Usage:
   play_vitals.py <sa_json> probe
   play_vitals.py <sa_json> rates [--days N] [--by versionCode|apiLevel|deviceModel]
   play_vitals.py <sa_json> issues [--kind crash|anr|both] [--days N] [--limit N]
-                            [--samples N] [--version-code VC]
+                            [--samples N] [--traces N] [--version-code VC]
 
 `probe` only reads the two metric-set descriptors, so it answers "does this
 service account have access at all" without asking for any data.
@@ -233,12 +233,38 @@ def cmd_issues(token, args):
             print(f"    {issue.get('type')} in {issue.get('location')}")
             print(f"    {issue.get('cause')}")
             print(f"    id {issue.get('name')}")
-            for text in search_reports(token, issue.get("name", ""), start, end, tz, args.samples):
-                print(indent(text))
+            reports = search_reports(token, issue.get("name", ""), start, end, tz, args.samples)
+            for rank, report in enumerate(reports):
+                print(f"    [{report_identity(report)}]")
+                if rank < args.traces:
+                    print(indent(report.get("reportText", "")))
+
+
+def subobject(d, key):
+    """Returns a nested object, or an empty one when the field is absent or null."""
+    value = d.get(key)
+    return value if isinstance(value, dict) else {}
+
+
+def report_identity(report):
+    """Returns one report's build, API level and device as a single line.
+
+    Every field here is optional, so an absent one prints as "?" rather than dropping
+    out and shifting what is left onto the wrong label.
+    """
+    model = subobject(report, "deviceModel")
+    device = subobject(model, "deviceId")
+    build = "/".join(p for p in (device.get("buildBrand"), device.get("buildDevice")) if p)
+    name = model.get("marketingName")
+    return (
+        f"vc {subobject(report, 'appVersion').get('versionCode', '?')}, "
+        f"api {subobject(report, 'osVersion').get('apiLevel', '?')}, "
+        f"{build or '?'}" + (f" ({name})" if name else "")
+    )
 
 
 def search_reports(token, issue_name, start, end, tz, limit):
-    """Returns the stack traces behind one cluster.
+    """Returns the reports behind one cluster, each with its device and versions.
 
     The issue carries sample report names, but only the names, and they are not a
     resource path any GET accepts. errorReports:search filtered on the issue id is the
@@ -253,7 +279,7 @@ def search_reports(token, issue_name, start, end, tz, limit):
         }
     )
     res = call(token, f"{BASE}/errorReports:search", params=params)
-    return [r.get("reportText", "") for r in res.get("errorReports", [])]
+    return res.get("errorReports", [])
 
 
 def indent(text):
@@ -277,7 +303,8 @@ def main():
     i.add_argument("--kind", default="both", choices=["crash", "anr", "both"])
     i.add_argument("--days", type=int, default=28)
     i.add_argument("--limit", type=int, default=15)
-    i.add_argument("--samples", type=int, default=1)
+    i.add_argument("--samples", type=int, default=1, help="reports read per cluster")
+    i.add_argument("--traces", type=int, default=1, help="of those, how many print a stack trace")
     i.add_argument("--version-code", type=int)
     args = p.parse_args()
 

--- a/tools/ci/play_vitals_test.py
+++ b/tools/ci/play_vitals_test.py
@@ -5,6 +5,7 @@ import argparse
 import datetime
 import io
 import os
+import re
 import sys
 import unittest
 from unittest import mock
@@ -12,6 +13,9 @@ from unittest import mock
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 import play_vitals as pv  # noqa: E402
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+WORKFLOW = os.path.join(ROOT, ".github", "workflows", "play-vitals.yml")
 
 
 class Flatten(unittest.TestCase):
@@ -322,16 +326,43 @@ class Parser(unittest.TestCase):
         args = self.parse()
         self.assertEqual((args.reports, args.traces), (1, 1))
 
-    def test_the_workflow_argv_parses(self):
-        args = self.parse("--days", "28", "--kind", "both", "--reports", "20", "--traces", "2")
-        self.assertEqual((args.reports, args.traces), (20, 2))
+    def workflow_flags(self, command):
+        """Returns the flags the dispatch really passes, read out of its case arm."""
+        with open(WORKFLOW, encoding="utf-8") as f:
+            arm = f.read().split(f"{command})", 1)[1].split(";;", 1)[0]
+        return sorted(set(re.findall(r"--[a-z-]+", arm)))
+
+    def value_for(self, flag):
+        return {"--kind": "both", "--by": ""}.get(flag, "1")
+
+    def test_every_flag_the_workflow_sends_to_issues_is_accepted(self):
+        flags = self.workflow_flags("issues")
+        self.assertIn("--reports", flags)
+        for flag in flags:
+            self.parse(flag, self.value_for(flag))
+
+    def test_every_flag_the_workflow_sends_to_rates_is_accepted(self):
+        flags = self.workflow_flags("rates")
+        self.assertIn("--by", flags)
+        for flag in flags:
+            pv.build_parser().parse_args(["sa.json", "rates", flag, self.value_for(flag)])
+
+    def test_the_workflow_restricts_issues_to_one_version(self):
+        self.assertEqual(self.parse("--version-code", "63").version_code, 63)
+
+    def test_rates_takes_the_blank_dimension_the_workflow_can_send(self):
+        args = pv.build_parser().parse_args(["sa.json", "rates", "--by", ""])
+        self.assertEqual(args.by, "")
+
+    def test_probe_takes_no_options(self):
+        self.assertEqual(pv.build_parser().parse_args(["sa.json", "probe"]).cmd, "probe")
 
 
 class Issues(unittest.TestCase):
     """cmd_issues must ask the API for as many reports as it was told to read."""
 
-    def run_issues(self, wanted, traces, available=5):
-        pool = [dict(FULL_REPORT, reportText=f"trace-{i}") for i in range(available)]
+    def run_issues(self, wanted, traces):
+        pool = [dict(FULL_REPORT, reportText=f"trace-{i}") for i in range(wanted + 2)]
         asked = {}
 
         def fake_call(_token, url, method="GET", body=None, params=None):
@@ -360,6 +391,15 @@ class Issues(unittest.TestCase):
     def test_every_report_the_api_returns_is_labelled_once(self):
         printed, _ = self.run_issues(wanted=3, traces=1)
         self.assertEqual(printed.count(FULL_LABEL), 3)
+
+    def test_the_trace_limit_reaches_the_printing(self):
+        printed, _ = self.run_issues(wanted=3, traces=1)
+        self.assertIn("trace-0", printed)
+        self.assertNotIn("trace-1", printed)
+
+    def test_raising_the_trace_limit_reaches_the_printing_too(self):
+        printed, _ = self.run_issues(wanted=3, traces=3)
+        self.assertIn("trace-2", printed)
 
 
 if __name__ == "__main__":

--- a/tools/ci/play_vitals_test.py
+++ b/tools/ci/play_vitals_test.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Tests for play_vitals.py, stubbing what the Reporting API really returns."""
 
+import argparse
 import datetime
 import io
 import os
@@ -223,6 +224,87 @@ class SearchParams(unittest.TestCase):
             )
         )
         self.assertEqual(seen["params"]["filter"], ["errorIssueId = deadbeef"])
+
+
+class ReportIdentity(unittest.TestCase):
+    """Every field of an ErrorReport is optional, so absence is the normal case."""
+
+    FULL = {
+        "appVersion": {"versionCode": "63"},
+        "osVersion": {"apiLevel": "24"},
+        "deviceModel": {
+            "marketingName": "Galaxy A51",
+            "deviceId": {"buildBrand": "samsung", "buildDevice": "a51"},
+        },
+    }
+
+    def test_a_complete_report_names_the_build_the_api_level_and_the_device(self):
+        self.assertEqual(pv.report_identity(self.FULL), "vc 63, api 24, samsung/a51 (Galaxy A51)")
+
+    def test_an_empty_report_still_labels_all_three_fields(self):
+        self.assertEqual(pv.report_identity({}), "vc ?, api ?, ?")
+
+    def test_a_null_subobject_reads_as_absent_rather_than_raising(self):
+        report = {"appVersion": None, "osVersion": None, "deviceModel": None}
+        self.assertEqual(pv.report_identity(report), "vc ?, api ?, ?")
+
+    def test_a_device_with_no_marketing_name_keeps_its_build_identity(self):
+        report = dict(self.FULL, deviceModel={"deviceId": {"buildBrand": "samsung"}})
+        self.assertEqual(pv.report_identity(report), "vc 63, api 24, samsung")
+
+    def test_a_missing_api_level_does_not_shift_the_version_code_onto_it(self):
+        report = {"appVersion": {"versionCode": "63"}, "osVersion": {}}
+        self.assertIn("vc 63, api ?", pv.report_identity(report))
+
+
+class Issues(unittest.TestCase):
+    """The device spread needs every sample labelled, not only the ones printed in full."""
+
+    def run_issues(self, samples, traces):
+        issue = {"name": "apps/com.httrack.android/abc", "type": "CRASH", "location": "here"}
+        reports = [
+            dict(ReportIdentity.FULL, reportText=f"trace-{i}", osVersion={"apiLevel": str(20 + i)})
+            for i in range(samples)
+        ]
+
+        def fake_call(_token, url, **_kw):
+            if url.endswith("/crashRateMetricSet"):
+                return {
+                    "freshnessInfo": {
+                        "freshnesses": [
+                            {
+                                "aggregationPeriod": "DAILY",
+                                "latestEndTime": {"year": 2026, "month": 9, "day": 7},
+                            }
+                        ]
+                    }
+                }
+            if url.endswith("/errorIssues:search"):
+                return {"errorIssues": [issue]}
+            return {"errorReports": reports}
+
+        args = argparse.Namespace(
+            kind="crash", days=28, limit=15, samples=samples, traces=traces, version_code=None
+        )
+        out = io.StringIO()
+        with mock.patch("play_vitals.call", side_effect=fake_call):
+            with mock.patch("sys.stdout", new=out):
+                pv.cmd_issues("t", args)
+        return out.getvalue()
+
+    def test_every_sample_is_labelled_even_when_only_one_trace_prints(self):
+        printed = self.run_issues(samples=3, traces=1)
+        for level in ("api 20", "api 21", "api 22"):
+            self.assertIn(level, printed)
+
+    def test_traces_beyond_the_limit_are_not_printed(self):
+        printed = self.run_issues(samples=3, traces=1)
+        self.assertIn("trace-0", printed)
+        self.assertNotIn("trace-1", printed)
+
+    def test_raising_the_trace_limit_prints_more_of_them(self):
+        printed = self.run_issues(samples=3, traces=3)
+        self.assertIn("trace-2", printed)
 
 
 if __name__ == "__main__":

--- a/tools/ci/play_vitals_test.py
+++ b/tools/ci/play_vitals_test.py
@@ -226,85 +226,140 @@ class SearchParams(unittest.TestCase):
         self.assertEqual(seen["params"]["filter"], ["errorIssueId = deadbeef"])
 
 
-class ReportIdentity(unittest.TestCase):
+FULL_REPORT = {
+    "appVersion": {"versionCode": "63"},
+    "osVersion": {"apiLevel": "24"},
+    "deviceModel": {
+        "marketingName": "Galaxy A51",
+        "deviceId": {"buildBrand": "samsung", "buildDevice": "a51"},
+    },
+}
+FULL_LABEL = "    [vc 63, api 24, samsung/a51 (Galaxy A51)]"
+FRESHNESS = {
+    "freshnessInfo": {
+        "freshnesses": [
+            {"aggregationPeriod": "DAILY", "latestEndTime": {"year": 2026, "month": 9, "day": 7}}
+        ]
+    }
+}
+
+
+class Fields(unittest.TestCase):
     """Every field of an ErrorReport is optional, so absence is the normal case."""
 
-    FULL = {
-        "appVersion": {"versionCode": "63"},
-        "osVersion": {"apiLevel": "24"},
-        "deviceModel": {
-            "marketingName": "Galaxy A51",
-            "deviceId": {"buildBrand": "samsung", "buildDevice": "a51"},
-        },
-    }
+    def test_a_complete_report_yields_all_four_fields(self):
+        self.assertEqual(pv.report_fields(FULL_REPORT), ("63", "24", "samsung/a51", "Galaxy A51"))
 
-    def test_a_complete_report_names_the_build_the_api_level_and_the_device(self):
-        self.assertEqual(pv.report_identity(self.FULL), "vc 63, api 24, samsung/a51 (Galaxy A51)")
-
-    def test_an_empty_report_still_labels_all_three_fields(self):
-        self.assertEqual(pv.report_identity({}), "vc ?, api ?, ?")
+    def test_an_empty_report_yields_four_absent_fields(self):
+        self.assertEqual(pv.report_fields({}), (None, None, None, None))
 
     def test_a_null_subobject_reads_as_absent_rather_than_raising(self):
         report = {"appVersion": None, "osVersion": None, "deviceModel": None}
-        self.assertEqual(pv.report_identity(report), "vc ?, api ?, ?")
+        self.assertEqual(pv.report_fields(report), (None, None, None, None))
 
-    def test_a_device_with_no_marketing_name_keeps_its_build_identity(self):
-        report = dict(self.FULL, deviceModel={"deviceId": {"buildBrand": "samsung"}})
-        self.assertEqual(pv.report_identity(report), "vc 63, api 24, samsung")
+    def test_a_scalar_where_an_object_belongs_reads_as_absent(self):
+        report = {"osVersion": "24", "deviceModel": "Galaxy A51"}
+        self.assertEqual(pv.report_fields(report), (None, None, None, None))
 
-    def test_a_missing_api_level_does_not_shift_the_version_code_onto_it(self):
-        report = {"appVersion": {"versionCode": "63"}, "osVersion": {}}
-        self.assertIn("vc 63, api ?", pv.report_identity(report))
+    def test_a_null_device_id_reads_as_absent_rather_than_raising(self):
+        report = {"deviceModel": {"marketingName": "Galaxy A51", "deviceId": None}}
+        self.assertEqual(pv.report_fields(report).build, None)
+
+    def test_a_device_named_by_brand_alone_keeps_that_brand(self):
+        report = {"deviceModel": {"deviceId": {"buildBrand": "samsung"}}}
+        self.assertEqual(pv.report_fields(report).build, "samsung")
+
+    def test_a_non_string_build_field_does_not_raise(self):
+        report = {"deviceModel": {"deviceId": {"buildBrand": 1, "buildDevice": "a51"}}}
+        self.assertEqual(pv.report_fields(report).build, "1/a51")
+
+
+class Lines(unittest.TestCase):
+    """The device spread needs every sample labelled, not only the ones printed in full."""
+
+    def reports(self, count):
+        return [
+            dict(FULL_REPORT, reportText=f"trace-{i}", osVersion={"apiLevel": str(20 + i)})
+            for i in range(count)
+        ]
+
+    def test_an_absent_field_prints_a_question_mark_under_its_own_label(self):
+        self.assertEqual(pv.report_lines([{}], 0), ["    [vc ?, api ?, ?]"])
+
+    def test_a_field_present_but_null_also_prints_a_question_mark(self):
+        report = {"osVersion": {"apiLevel": None}, "appVersion": {"versionCode": None}}
+        self.assertEqual(pv.report_lines([report], 0), ["    [vc ?, api ?, ?]"])
+
+    def test_a_complete_report_names_the_build_the_api_level_and_the_device(self):
+        self.assertEqual(pv.report_lines([FULL_REPORT], 0), [FULL_LABEL])
+
+    def test_every_sample_is_labelled_and_only_the_first_carries_a_trace(self):
+        self.assertEqual(
+            pv.report_lines(self.reports(3), 1),
+            [
+                "    [vc 63, api 20, samsung/a51 (Galaxy A51)]",
+                "      trace-0",
+                "    [vc 63, api 21, samsung/a51 (Galaxy A51)]",
+                "    [vc 63, api 22, samsung/a51 (Galaxy A51)]",
+            ],
+        )
+
+    def test_raising_the_trace_limit_prints_more_of_them(self):
+        printed = "\n".join(pv.report_lines(self.reports(3), 3))
+        self.assertIn("trace-2", printed)
+
+    def test_a_report_with_no_text_still_prints_its_label(self):
+        self.assertEqual(pv.report_lines([FULL_REPORT], 1)[0], FULL_LABEL)
+
+
+class Parser(unittest.TestCase):
+    """The workflow is the only caller, so a flag it passes must exist here."""
+
+    def parse(self, *argv):
+        return pv.build_parser().parse_args(["sa.json", "issues", *argv])
+
+    def test_both_report_counts_default_to_one(self):
+        args = self.parse()
+        self.assertEqual((args.reports, args.traces), (1, 1))
+
+    def test_the_workflow_argv_parses(self):
+        args = self.parse("--days", "28", "--kind", "both", "--reports", "20", "--traces", "2")
+        self.assertEqual((args.reports, args.traces), (20, 2))
 
 
 class Issues(unittest.TestCase):
-    """The device spread needs every sample labelled, not only the ones printed in full."""
+    """cmd_issues must ask the API for as many reports as it was told to read."""
 
-    def run_issues(self, samples, traces):
-        issue = {"name": "apps/com.httrack.android/abc", "type": "CRASH", "location": "here"}
-        reports = [
-            dict(ReportIdentity.FULL, reportText=f"trace-{i}", osVersion={"apiLevel": str(20 + i)})
-            for i in range(samples)
-        ]
+    def run_issues(self, wanted, traces, available=5):
+        pool = [dict(FULL_REPORT, reportText=f"trace-{i}") for i in range(available)]
+        asked = {}
 
-        def fake_call(_token, url, **_kw):
+        def fake_call(_token, url, method="GET", body=None, params=None):
             if url.endswith("/crashRateMetricSet"):
-                return {
-                    "freshnessInfo": {
-                        "freshnesses": [
-                            {
-                                "aggregationPeriod": "DAILY",
-                                "latestEndTime": {"year": 2026, "month": 9, "day": 7},
-                            }
-                        ]
-                    }
-                }
+                return FRESHNESS
             if url.endswith("/errorIssues:search"):
-                return {"errorIssues": [issue]}
-            return {"errorReports": reports}
+                asked["issues"] = params
+                return {"errorIssues": [{"name": "apps/com.httrack.android/abc"}]}
+            asked["reports"] = params
+            return {"errorReports": pool[: int(params["pageSize"][0])]}
 
         args = argparse.Namespace(
-            kind="crash", days=28, limit=15, samples=samples, traces=traces, version_code=None
+            kind="crash", days=28, limit=15, reports=wanted, traces=traces, version_code=None
         )
         out = io.StringIO()
         with mock.patch("play_vitals.call", side_effect=fake_call):
             with mock.patch("sys.stdout", new=out):
                 pv.cmd_issues("t", args)
-        return out.getvalue()
+        return out.getvalue(), asked
 
-    def test_every_sample_is_labelled_even_when_only_one_trace_prints(self):
-        printed = self.run_issues(samples=3, traces=1)
-        for level in ("api 20", "api 21", "api 22"):
-            self.assertIn(level, printed)
+    def test_both_searches_ask_for_the_number_of_reports_requested(self):
+        _, asked = self.run_issues(wanted=3, traces=1)
+        self.assertEqual(asked["reports"]["pageSize"], ["3"])
+        self.assertEqual(asked["issues"]["sampleErrorReportLimit"], ["3"])
 
-    def test_traces_beyond_the_limit_are_not_printed(self):
-        printed = self.run_issues(samples=3, traces=1)
-        self.assertIn("trace-0", printed)
-        self.assertNotIn("trace-1", printed)
-
-    def test_raising_the_trace_limit_prints_more_of_them(self):
-        printed = self.run_issues(samples=3, traces=3)
-        self.assertIn("trace-2", printed)
+    def test_every_report_the_api_returns_is_labelled_once(self):
+        printed, _ = self.run_issues(wanted=3, traces=1)
+        self.assertEqual(printed.count(FULL_LABEL), 3)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`issues` printed one stack trace per cluster and nothing else. The Reporting API sends `deviceModel`, `osVersion` and `appVersion` on every error report, and `search_reports()` kept `reportText` and dropped the rest.

Every sample now prints its build, API level and device. `--traces` says how many of them also print the trace, so a wider `--reports` reads as a device spread rather than a wall of traces.

This is for the `UnsatisfiedLinkError` cluster on the 2017 build. We need to know whether those eleven users sit behind the 32-bit wall or the Android 7 one before costing a 32-bit build leg.

Every mutation of the new code fails a test, except one that only differs when Play sends an empty string.