### PR TITLE
The cluster search rejects a sample limit above 1, so the dispatch 400s

### DIFF
--- a/tools/ci/play_vitals.py
+++ b/tools/ci/play_vitals.py
@@ -219,7 +219,9 @@ def cmd_issues(token, args):
                 "filter": " AND ".join(terms),
                 "orderBy": "distinctUsers desc",
                 "pageSize": args.limit,
-                "sampleErrorReportLimit": args.reports,
+                # errorIssues:search answers 400 above 1 ("'sample_error_reports' field only
+                # supports the values 0 and 1"). The samples we print come from the search below.
+                "sampleErrorReportLimit": 1,
             }
         )
         res = call(token, f"{BASE}/errorIssues:search", params=params)

--- a/tools/ci/play_vitals_test.py
+++ b/tools/ci/play_vitals_test.py
@@ -383,10 +383,14 @@ class Issues(unittest.TestCase):
                 pv.cmd_issues("t", args)
         return out.getvalue(), asked
 
-    def test_both_searches_ask_for_the_number_of_reports_requested(self):
+    def test_the_report_search_asks_for_the_number_of_reports_requested(self):
         _, asked = self.run_issues(wanted=3, traces=1)
         self.assertEqual(asked["reports"]["pageSize"], ["3"])
-        self.assertEqual(asked["issues"]["sampleErrorReportLimit"], ["3"])
+
+    def test_the_cluster_search_never_asks_for_more_than_one_sample(self):
+        for wanted in (1, 3, 25):
+            _, asked = self.run_issues(wanted=wanted, traces=1)
+            self.assertEqual(asked["issues"]["sampleErrorReportLimit"], ["1"])
 
     def test_every_report_the_api_returns_is_labelled_once(self):
         printed, _ = self.run_issues(wanted=3, traces=1)


### PR DESCRIPTION
The first real dispatch failed with a 400: `'sample_error_reports' field only supports the values 0 and 1`. PR #201 fed `--reports` into `errorIssues:search`'s `sampleErrorReportLimit`, and 25 is not a legal value.

The reports we print come from `errorReports:search`, so `--reports` now drives only its `pageSize`, and the cluster search asks for 1 whatever the flag says.

The stub accepted any value, so no test could see the limit. One now pins the cluster search to 1 across three `--reports` values.
