### PR TITLE
The engine's worker threads have no crash handler, so a fault there kills the app

### DIFF
--- a/app/src/main/jni/htslibjni.c
+++ b/app/src/main/jni/htslibjni.c
@@ -40,6 +40,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "httrack-library.h"
 #include "htsdefines.h"
 #include "htscore.h"
+#include "htsthread.h"
 
 #define USE_COFFEECATCH
 
@@ -68,6 +69,28 @@ static volatile int engineFaulted = 0;
     } COFFEE_END();                        \
   } while(0)
 #endif
+
+/* What a worker thread recovered from, for the crawl thread to report: a worker has no JNIEnv
+ * to throw with. The flag publishes the message, so read them in that order. */
+static char workerFaultMessage[512];
+static int workerFaulted = 0;
+
+/* The crawl being run, so a faulting worker can end it. Its own lock, because the context one
+ * is destroyed before the opt is freed. */
+static httrackp *runningOpt = NULL;
+static pthread_mutex_t runningOptLock = PTHREAD_MUTEX_INITIALIZER;
+
+/* Did a thread the engine spawned for itself recover from a fault? */
+static int hasWorkerFaulted(void) {
+  return __atomic_load_n(&workerFaulted, __ATOMIC_ACQUIRE) != 0;
+}
+
+/* Disarm the watchdog a faulting worker left armed. */
+static void clearWorkerFaultWatchdog(void) {
+#ifdef USE_COFFEECATCH
+  coffeecatch_cancel_pending_alarm();
+#endif
+}
 
 #include "htslibjni.h"
 #include "htslibjni-private.h"
@@ -136,6 +159,69 @@ static void error(const char *format, ...) {
   __android_log_vprint(ANDROID_LOG_ERROR, "httrack", format, args);
   va_end(args);
 }
+
+#ifdef USE_COFFEECATCH
+/* Names one frame of the faulting worker's stack in the log. */
+static void logWorkerFrame(void *arg, const char *module, uintptr_t addr,
+                           const char *function, uintptr_t offset) {
+  int *const index = (int*) arg;
+
+  error("worker frame #%02d %p %s (%s+0x%x)", (*index)++, (void*) addr,
+        module != NULL ? module : "?", function != NULL ? function : "?",
+        (unsigned) offset);
+}
+
+static void reportWorkerFault(void) {
+  const char *const message = coffeecatch_get_message();
+  int index = 0;
+
+  snprintf(workerFaultMessage, sizeof(workerFaultMessage),
+           "the engine faulted on a worker thread: %s",
+           message != NULL ? message : "unknown fault");
+  error("%s", workerFaultMessage);
+  /* Only the log gets the frames: a tombstone would have named the fault, and this recovery
+     replaces it. */
+  coffeecatch_get_backtrace_info(logWorkerFrame, &index);
+  engineFaulted = 1;
+  __atomic_store_n(&workerFaulted, 1, __ATOMIC_RELEASE);
+  /* Cut the crawl's wait for this worker short, which the DNS resolver answers at once and an
+     FTP fetch at the next progress tick. Ending the crawl is what makes the watchdog
+     temporary, so with no crawl to end, nothing is waiting on this worker and the watchdog has
+     nothing to guard. */
+  MUTEX_LOCK(runningOptLock);
+  if (runningOpt != NULL) {
+    hts_request_stop(runningOpt, 1);
+  } else {
+    clearWorkerFaultWatchdog();
+  }
+  MUTEX_UNLOCK(runningOptLock);
+}
+
+/* Wraps every thread the engine spawns for itself -- a DNS resolver per hostname, an FTP fetch
+ * -- which no JNI entry point covers, so a fault there took the process down with it. The
+ * 30s watchdog the catch arms is deliberately left running: this thread unwound nothing, so it
+ * may hold a lock the crawl needs, and HTTrackLib_main() clears the watchdog only once the
+ * crawl has come back. */
+static void workerThreadRunner(void (*fun)(void *arg), void *arg) {
+  volatile int unprotected = 0;
+
+  COFFEE_TRY() {
+    fun(arg);
+  } COFFEE_CATCH() {
+    if (coffeecatch_get_signal() > 0) {
+      reportWorkerFault();
+    } else {
+      unprotected = 1;
+    }
+  } COFFEE_END();
+
+  /* No handler could be installed, and the body never ran: run it as the engine did before
+     this hook rather than hand the caller a worker that did nothing. */
+  if (unprotected) {
+    fun(arg);
+  }
+}
+#endif
 
 /* Thread variable holding context. */
 static pthread_key_t thread_variables;
@@ -378,6 +464,11 @@ JNICALL void Java_com_httrack_android_jni_HTTrackLib_initStatic(JNIEnv* env, jcl
 
   /* Register log callback */
   hts_set_log_vprint_callback(httrackLogCallback);
+
+#ifdef USE_COFFEECATCH
+  /* Cover the engine's own threads, which the entry points above do not. */
+  hts_set_thread_runner(workerThreadRunner);
+#endif
 }
 
 static void HTTrackLib_initRootPath(JNIEnv* env, jclass clazz, jstring opath) {
@@ -840,6 +931,11 @@ static int htsshow_loop(t_hts_callbackarg * carg, httrackp * opt,
     return 0;
   }
 
+  /* A worker faulted: end the mirror now, rather than let its stop request drain the queue. */
+  if (hasWorkerFaulted()) {
+    return 0;
+  }
+
   /* pass to internal version */
   return htsshow_loop_internal(t, opt, back, back_max, back_index,
       lien_n, lien_tot, stat_time, stats);
@@ -1005,6 +1101,9 @@ jint HTTrackLib_main(JNIEnv* env, jobject object, jobjectArray stringArray) {
       /* Create opt tab */
       context->opt = hts_create_opt();
       context->stop = 0;
+      MUTEX_LOCK(runningOptLock);
+      runningOpt = context->opt;
+      MUTEX_UNLOCK(runningOptLock);
       CHAIN_FUNCTION(context->opt, loop, htsshow_loop, &t);
     } else {
       already_running = 1;
@@ -1016,6 +1115,11 @@ jint HTTrackLib_main(JNIEnv* env, jobject object, jobjectArray stringArray) {
 
       /* Rock'in! */
       code = hts_main2(argc, argv, context->opt);
+
+      /* The destructor frees this opt, so no worker may reach it from here on. */
+      MUTEX_LOCK(runningOptLock);
+      runningOpt = NULL;
+      MUTEX_UNLOCK(runningOptLock);
 
       /* Fetch last stats before cleaning up */
       stats = hts_get_stats(context->opt);
@@ -1059,6 +1163,17 @@ jint HTTrackLib_main(JNIEnv* env, jobject object, jobjectArray stringArray) {
     if (t.pendingException != NULL) {
       (*env)->Throw(env, t.pendingException);
       (*env)->DeleteGlobalRef(env, t.pendingException);
+      code = -1;
+    }
+
+    /* Reported here because the worker had no JNIEnv, and as the java.lang.Error coffeecatch
+       throws for a fault on this thread. */
+    if (hasWorkerFaulted()) {
+      if (!(*env)->ExceptionCheck(env)) {
+        throwException(env, "java/lang/Error", workerFaultMessage);
+      }
+      /* Getting here is what rules out the deadlock the watchdog guards against. */
+      clearWorkerFaultWatchdog();
       code = -1;
     }
 

--- a/app/src/main/jni/htslibjni.c
+++ b/app/src/main/jni/htslibjni.c
@@ -71,7 +71,7 @@ static volatile int engineFaulted = 0;
 #endif
 
 /* What a worker thread recovered from, for the crawl thread to report: a worker has no JNIEnv
- * to throw with. The flag publishes the message, so read them in that order. */
+ * to throw with. Reading the flag first is what makes the message visible. */
 static char workerFaultMessage[512];
 static int workerFaulted = 0;
 
@@ -85,7 +85,8 @@ static int hasWorkerFaulted(void) {
   return __atomic_load_n(&workerFaulted, __ATOMIC_ACQUIRE) != 0;
 }
 
-/* Disarm the watchdog a faulting worker left armed. */
+/* Disarm the watchdog a faulting worker left armed. Whoever first shows the crawl thread still
+ * runs calls this, because that is the deadlock the watchdog is there for. */
 static void clearWorkerFaultWatchdog(void) {
 #ifdef USE_COFFEECATCH
   coffeecatch_cancel_pending_alarm();
@@ -172,38 +173,38 @@ static void logWorkerFrame(void *arg, const char *module, uintptr_t addr,
 }
 
 static void reportWorkerFault(void) {
+  /* Read before this fault latches it: already set means the crawl thread faulted first, so
+     its opt is one nothing may touch again. */
+  const int alreadyFaulted = engineFaulted;
   const char *const message = coffeecatch_get_message();
   int index = 0;
 
+  /* Latched first, because the logging below can itself wedge on a lock this thread faulted
+     holding, and every guard on the engine reads this flag. */
+  engineFaulted = 1;
   snprintf(workerFaultMessage, sizeof(workerFaultMessage),
            "the engine faulted on a worker thread: %s",
            message != NULL ? message : "unknown fault");
   error("%s", workerFaultMessage);
-  /* Only the log gets the frames: a tombstone would have named the fault, and this recovery
-     replaces it. */
+  /* Only the log gets the frames, because the tombstone that would have named them is what
+     this recovery replaces. */
   coffeecatch_get_backtrace_info(logWorkerFrame, &index);
-  engineFaulted = 1;
   __atomic_store_n(&workerFaulted, 1, __ATOMIC_RELEASE);
-  /* Cut the crawl's wait for this worker short, which the DNS resolver answers at once and an
-     FTP fetch at the next progress tick. Ending the crawl is what makes the watchdog
-     temporary, so with no crawl to end, nothing is waiting on this worker and the watchdog has
-     nothing to guard. */
+  /* Cut the crawl's wait for this worker short, which the DNS resolver answers at once. With
+     no crawl to cut short, nothing will show the crawl thread alive, so disarm here. */
   MUTEX_LOCK(runningOptLock);
-  if (runningOpt != NULL) {
-    hts_request_stop(runningOpt, 1);
+  if (!alreadyFaulted && runningOpt != NULL) {
+    hts_request_stop(runningOpt, 1 /* keep_resume */);
   } else {
     clearWorkerFaultWatchdog();
   }
   MUTEX_UNLOCK(runningOptLock);
 }
 
-/* Wraps every thread the engine spawns for itself -- a DNS resolver per hostname, an FTP fetch
- * -- which no JNI entry point covers, so a fault there took the process down with it. The
- * 30s watchdog the catch arms is deliberately left running: this thread unwound nothing, so it
- * may hold a lock the crawl needs, and HTTrackLib_main() clears the watchdog only once the
- * crawl has come back. */
+/* Wraps every thread the engine spawns for itself, a DNS resolver per hostname and an FTP
+ * fetch, which no JNI entry point covers, so a fault there took the process down with it. */
 static void workerThreadRunner(void (*fun)(void *arg), void *arg) {
-  volatile int unprotected = 0;
+  volatile int bodyNeverRan = 0;
 
   COFFEE_TRY() {
     fun(arg);
@@ -211,13 +212,13 @@ static void workerThreadRunner(void (*fun)(void *arg), void *arg) {
     if (coffeecatch_get_signal() > 0) {
       reportWorkerFault();
     } else {
-      unprotected = 1;
+      bodyNeverRan = 1;
     }
   } COFFEE_END();
 
-  /* No handler could be installed, and the body never ran: run it as the engine did before
-     this hook rather than hand the caller a worker that did nothing. */
-  if (unprotected) {
+  /* No handler could be installed, so run the body as the engine did before this hook rather
+     than hand the caller a worker that did nothing. */
+  if (bodyNeverRan) {
     fun(arg);
   }
 }
@@ -931,8 +932,11 @@ static int htsshow_loop(t_hts_callbackarg * carg, httrackp * opt,
     return 0;
   }
 
-  /* A worker faulted: end the mirror now, rather than let its stop request drain the queue. */
+  /* A worker faulted: end the mirror now, rather than let its stop request drain the queue.
+     This tick is also the first proof that no lock the worker left held blocks this thread, and
+     the wind-down after it has no bound the watchdog could outlast. */
   if (hasWorkerFaulted()) {
+    clearWorkerFaultWatchdog();
     return 0;
   }
 
@@ -1170,9 +1174,13 @@ jint HTTrackLib_main(JNIEnv* env, jobject object, jobjectArray stringArray) {
        throws for a fault on this thread. */
     if (hasWorkerFaulted()) {
       if (!(*env)->ExceptionCheck(env)) {
-        throwException(env, "java/lang/Error", workerFaultMessage);
+        char reported[sizeof(workerFaultMessage)];
+
+        /* Copied first, because a second worker can rewrite the buffer while it is read. */
+        snprintf(reported, sizeof(reported), "%s", workerFaultMessage);
+        throwException(env, "java/lang/Error", reported);
       }
-      /* Getting here is what rules out the deadlock the watchdog guards against. */
+      /* Getting here shows this thread was never wedged, whether or not a tick did already. */
       clearWorkerFaultWatchdog();
       code = -1;
     }

--- a/app/src/main/jni/htslibjni.c
+++ b/app/src/main/jni/htslibjni.c
@@ -70,8 +70,8 @@ static volatile int engineFaulted = 0;
   } while(0)
 #endif
 
-/* What a worker thread recovered from, for the crawl thread to report: a worker has no JNIEnv
- * to throw with. Reading the flag first is what makes the message visible. */
+/* What a worker thread recovered from, for the crawl thread to report, because a worker has no
+ * JNIEnv to throw with. Reading the flag before the message is what makes the message safe. */
 static char workerFaultMessage[512];
 static int workerFaulted = 0;
 
@@ -85,8 +85,9 @@ static int hasWorkerFaulted(void) {
   return __atomic_load_n(&workerFaulted, __ATOMIC_ACQUIRE) != 0;
 }
 
-/* Disarm the watchdog a faulting worker left armed. Whoever first shows the crawl thread still
- * runs calls this, because that is the deadlock the watchdog is there for. */
+/* Disarm the watchdog coffeecatch arms when it catches a fault. Only reportWorkerFault() calls
+ * this, and only once it has done everything that can block, because a handler that blocks is
+ * the wedge the watchdog exists to kill. Nothing bounds what the crawl does afterwards. */
 static void clearWorkerFaultWatchdog(void) {
 #ifdef USE_COFFEECATCH
   coffeecatch_cancel_pending_alarm();
@@ -172,9 +173,11 @@ static void logWorkerFrame(void *arg, const char *module, uintptr_t addr,
         (unsigned) offset);
 }
 
+/* Names the fault in the log, hands its message to the crawl thread, and ends the mirror. */
 static void reportWorkerFault(void) {
-  /* Read before this fault latches it: already set means the crawl thread faulted first, so
-     its opt is one nothing may touch again. */
+  /* Read before the latch below, because a flag already set means the engine faulted before
+     this worker did, and that opt must not be touched again. A fault landing on the crawl
+     thread while this handler runs is not seen, and costs one stop request on a leaked opt. */
   const int alreadyFaulted = engineFaulted;
   const char *const message = coffeecatch_get_message();
   int index = 0;
@@ -186,19 +189,19 @@ static void reportWorkerFault(void) {
            "the engine faulted on a worker thread: %s",
            message != NULL ? message : "unknown fault");
   error("%s", workerFaultMessage);
-  /* Only the log gets the frames, because the tombstone that would have named them is what
-     this recovery replaces. */
+  /* Only the log gets the frames, because this recovery replaces the tombstone that would
+     have named them. */
   coffeecatch_get_backtrace_info(logWorkerFrame, &index);
   __atomic_store_n(&workerFaulted, 1, __ATOMIC_RELEASE);
-  /* Cut the crawl's wait for this worker short, which the DNS resolver answers at once. With
-     no crawl to cut short, nothing will show the crawl thread alive, so disarm here. */
+  /* Cut the crawl's wait for this worker short, which the DNS resolver answers at once. */
   MUTEX_LOCK(runningOptLock);
   if (!alreadyFaulted && runningOpt != NULL) {
     hts_request_stop(runningOpt, 1 /* keep_resume */);
-  } else {
-    clearWorkerFaultWatchdog();
   }
   MUTEX_UNLOCK(runningOptLock);
+  /* Last, because everything above can block on a lock this thread faulted holding, and the
+     watchdog is what ends the process when one does. */
+  clearWorkerFaultWatchdog();
 }
 
 /* Wraps every thread the engine spawns for itself, a DNS resolver per hostname and an FTP
@@ -932,11 +935,8 @@ static int htsshow_loop(t_hts_callbackarg * carg, httrackp * opt,
     return 0;
   }
 
-  /* A worker faulted: end the mirror now, rather than let its stop request drain the queue.
-     This tick is also the first proof that no lock the worker left held blocks this thread, and
-     the wind-down after it has no bound the watchdog could outlast. */
+  /* A worker faulted, so end the mirror now rather than let its stop request drain the queue. */
   if (hasWorkerFaulted()) {
-    clearWorkerFaultWatchdog();
     return 0;
   }
 
@@ -1180,8 +1180,6 @@ jint HTTrackLib_main(JNIEnv* env, jobject object, jobjectArray stringArray) {
         snprintf(reported, sizeof(reported), "%s", workerFaultMessage);
         throwException(env, "java/lang/Error", reported);
       }
-      /* Getting here shows this thread was never wedged, whether or not a tick did already. */
-      clearWorkerFaultWatchdog();
       code = -1;
     }
 

--- a/app/src/test/java/com/httrack/android/CoffeeCatchAlarmTest.java
+++ b/app/src/test/java/com/httrack/android/CoffeeCatchAlarmTest.java
@@ -30,9 +30,12 @@ public class CoffeeCatchAlarmTest {
   @Test
   public void everyProtectedBlockGoesThroughTheWrapper() throws IOException {
     final String source = jni();
-    // Two COFFEE_TRY(): the wrapper's own, and the engine worker runner's, which hands its
-    // watchdog to the crawl thread instead of cancelling it. See WorkerThreadFaultTest.
+    // Two COFFEE_TRY(): the wrapper's own, and the engine worker runner's, which leaves its
+    // watchdog to the crawl thread. See WorkerThreadFaultTest.
     assertEquals(2, TestSources.occurrences(source, "COFFEE_TRY()"));
+    final int runner = source.indexOf("static void workerThreadRunner(");
+    assertTrue(runner != -1
+        && source.indexOf("COFFEE_TRY()", runner) < source.indexOf("COFFEE_END()", runner));
     assertTrue(TestSources.occurrences(source, "COFFEE_TRY_JNI_RECOVER(") > 1);
   }
 

--- a/app/src/test/java/com/httrack/android/CoffeeCatchAlarmTest.java
+++ b/app/src/test/java/com/httrack/android/CoffeeCatchAlarmTest.java
@@ -30,9 +30,9 @@ public class CoffeeCatchAlarmTest {
   @Test
   public void everyProtectedBlockGoesThroughTheWrapper() throws IOException {
     final String source = jni();
-    // The lone COFFEE_TRY() is the wrapper's own; a hand-rolled one would skip
-    // the cancel.
-    assertEquals(1, TestSources.occurrences(source, "COFFEE_TRY()"));
+    // Two COFFEE_TRY(): the wrapper's own, and the engine worker runner's, which hands its
+    // watchdog to the crawl thread instead of cancelling it. See WorkerThreadFaultTest.
+    assertEquals(2, TestSources.occurrences(source, "COFFEE_TRY()"));
     assertTrue(TestSources.occurrences(source, "COFFEE_TRY_JNI_RECOVER(") > 1);
   }
 

--- a/app/src/test/java/com/httrack/android/CoffeeCatchAlarmTest.java
+++ b/app/src/test/java/com/httrack/android/CoffeeCatchAlarmTest.java
@@ -30,12 +30,9 @@ public class CoffeeCatchAlarmTest {
   @Test
   public void everyProtectedBlockGoesThroughTheWrapper() throws IOException {
     final String source = jni();
-    // Two COFFEE_TRY(): the wrapper's own, and the engine worker runner's, which leaves its
-    // watchdog to the crawl thread. See WorkerThreadFaultTest.
+    // Two COFFEE_TRY(): the wrapper's own, and the engine worker runner's, which disarms the
+    // watchdog itself. See WorkerThreadFaultTest.
     assertEquals(2, TestSources.occurrences(source, "COFFEE_TRY()"));
-    final int runner = source.indexOf("static void workerThreadRunner(");
-    assertTrue(runner != -1
-        && source.indexOf("COFFEE_TRY()", runner) < source.indexOf("COFFEE_END()", runner));
     assertTrue(TestSources.occurrences(source, "COFFEE_TRY_JNI_RECOVER(") > 1);
   }
 

--- a/app/src/test/java/com/httrack/android/WorkerThreadFaultTest.java
+++ b/app/src/test/java/com/httrack/android/WorkerThreadFaultTest.java
@@ -1,150 +1,212 @@
 package com.httrack.android;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.junit.Test;
 
 /** The engine spawns detached threads for itself, a DNS resolver per hostname and an FTP fetch,
- *  and no JNI entry point covers them: a fault there used to take the process down. The thread
- *  runner catches it on the worker, and the crawl thread is what reports it to Java. */
+ *  and no JNI entry point covers them, so a fault there used to take the process down. The
+ *  thread runner catches it on the worker, and the crawl thread is what reports it to Java.
+ *
+ *  Assertions here compare whole statement lists rather than searching for text, because a
+ *  search cannot tell `f()` from `if (0) { f(); }`. */
 public class WorkerThreadFaultTest {
-  /** Reads htslibjni.c with comments and string literals blanked, so a commented-out call
-   *  cannot pass for one. */
-  private String jni() throws IOException {
-    return TestSources.withoutCommentsAndStrings(TestSources.jniSource("htslibjni.c"));
+  /** htslibjni.c as written. */
+  private static String raw() throws IOException {
+    return TestSources.jniSource("htslibjni.c");
   }
 
-  /** Returns function NAME's body, braces balanced, outer pair left out. */
-  private static String function(final String source, final String name) {
+  /** htslibjni.c with comments and string literals blanked, offsets unchanged, so a
+   *  commented-out call cannot pass for one and a raw slice still lines up. */
+  private static String blanked() throws IOException {
+    return TestSources.withoutCommentsAndStrings(raw());
+  }
+
+  /** Offsets of the block starting at the first '{' at or after AT, the braces left out. */
+  private static int[] blockAt(final String source, final int at) {
+    final int from = source.indexOf('{', at);
+    assertTrue("no block at " + at, from != -1);
+    int depth = 0;
+    for (int i = from; i < source.length(); i++) {
+      if (source.charAt(i) == '{') {
+        depth++;
+      } else if (source.charAt(i) == '}' && --depth == 0) {
+        return new int[] { from + 1, i };
+      }
+    }
+    throw new IllegalStateException("block at " + from + " never closes");
+  }
+
+  /** Offsets of function NAME's body. */
+  private static int[] function(final String source, final String name) {
     final Matcher m = Pattern.compile("(?m)^[\\w *]+\\b" + name + "\\s*\\(").matcher(source);
     assertTrue("no function " + name, m.find());
-    return TestSources.balancedBlock(source, m.end());
+    return blockAt(source, m.end());
   }
 
-  /** Returns CONDITION's own block in BODY. */
-  private static String blockBody(final String body, final String condition) {
-    final int at = body.indexOf(condition);
-    assertTrue("no " + condition, at != -1);
-    return TestSources.balancedBlock(body, at);
+  /** Offsets of CONDITION's own block inside RANGE. */
+  private static int[] thenBlock(final String source, final int[] range, final String condition) {
+    final int at = source.indexOf(condition, range[0]);
+    assertTrue("no " + condition, at != -1 && at < range[1]);
+    return blockAt(source, at);
   }
 
-  /** Returns the block CONDITION falls through to in BODY. */
-  private static String elseBlock(final String body, final String condition) {
-    final int at = body.indexOf(condition);
-    assertTrue("no " + condition, at != -1);
-    final int fallthrough = body.indexOf("} else {", at);
-    assertTrue(condition + " has no else", fallthrough != -1);
-    return TestSources.balancedBlock(body, fallthrough + 1);
+  /** Offsets of the block CONDITION falls through to, which must directly follow its own. */
+  private static int[] elseBlock(final String source, final int[] range, final String condition) {
+    final int[] taken = thenBlock(source, range, condition);
+    final String between = source.substring(taken[1] + 1);
+    assertTrue(condition + " has no else", between.trim().startsWith("else"));
+    return blockAt(source, taken[1] + 1 + between.indexOf("else"));
+  }
+
+  /** Statements of RANGE, in order, stripped of spaces, braces and preprocessor lines. A
+   *  statement wrapped in a new block keeps that block's condition, so it reads as one entry
+   *  no expected list matches. */
+  private static List<String> statements(final String source, final int[] range) {
+    final String body = source.substring(range[0], range[1])
+        .replaceAll("(?m)^\\s*#.*$", "");
+    final List<String> out = new ArrayList<String>();
+    for (final String statement : body.split(";")) {
+      final String bare = statement.replaceAll("[\\s{}]+", "");
+      if (!bare.isEmpty()) {
+        out.add(bare);
+      }
+    }
+    return out;
+  }
+
+  private static String text(final String source, final int[] range) {
+    return source.substring(range[0], range[1]);
   }
 
   @Test
   public void theRunnerIsInstalledBeforeAnythingCanSpawnAWorker() throws IOException {
-    final String source = jni();
+    final String source = blanked();
     assertEquals(1, TestSources.occurrences(source, "hts_set_thread_runner("));
-    assertEquals("workerThreadRunner",
-        TestSources.arguments(source, "hts_set_thread_runner").trim());
     assertTrue("the engine reads the runner unlocked, so it must be set at class load",
-        function(source, "Java_com_httrack_android_jni_HTTrackLib_initStatic")
-            .contains("hts_set_thread_runner("));
+        statements(source,
+            function(source, "Java_com_httrack_android_jni_HTTrackLib_initStatic"))
+            .contains("hts_set_thread_runner(workerThreadRunner)"));
   }
 
   @Test
   public void onlyASignalCountsAsAFault() throws IOException {
-    final String runner = function(jni(), "workerThreadRunner");
-    final String faulted = blockBody(runner, "if (coffeecatch_get_signal() > 0)");
-    assertTrue("COFFEE_CATCH is entered on a setup failure too, with the engine intact",
-        faulted.contains("reportWorkerFault()"));
-    assertFalse("a body that faulted has run, so running it again would fault again",
-        faulted.contains("bodyNeverRan = 1"));
-    assertTrue(elseBlock(runner, "if (coffeecatch_get_signal() > 0)")
-        .contains("bodyNeverRan = 1"));
+    final String source = blanked();
+    final int[] runner = function(source, "workerThreadRunner");
+    final String gate = "if (coffeecatch_get_signal() > 0)";
+    assertEquals("COFFEE_CATCH is entered on a setup failure too, with the engine intact",
+        Arrays.asList("reportWorkerFault()"),
+        statements(source, thenBlock(source, runner, gate)));
+    assertEquals("a body that faulted has already run, and running it again would fault again",
+        Arrays.asList("bodyNeverRan=1"),
+        statements(source, elseBlock(source, runner, gate)));
   }
 
   @Test
   public void aWorkerWhoseBodyNeverRanRunsItUnprotected() throws IOException {
-    final String runner = function(jni(), "workerThreadRunner");
-    final int end = runner.indexOf("COFFEE_END()");
-    assertTrue(end != -1);
-    assertTrue("dropping the body would hand the caller a worker that did nothing",
-        blockBody(runner.substring(end), "if (bodyNeverRan)").contains("fun(arg)"));
+    final String source = blanked();
+    final int[] runner = function(source, "workerThreadRunner");
+    final int end = source.indexOf("COFFEE_END()", runner[0]);
+    assertTrue(end != -1 && end < runner[1]);
+    assertEquals("dropping the body would hand the caller a worker that did nothing",
+        Arrays.asList("fun(arg)"),
+        statements(source, thenBlock(source, new int[] { end, runner[1] }, "if (bodyNeverRan)")));
   }
 
   @Test
   public void theLatchIsSetBeforeAnythingThatCanWedge() throws IOException {
-    final String report = function(jni(), "reportWorkerFault");
+    final String source = blanked();
+    final String report = text(source, function(source, "reportWorkerFault"));
     final int latched = report.indexOf("engineFaulted = 1");
-    final int logged = report.indexOf("error(");
-    final int written = report.indexOf("snprintf(workerFaultMessage");
-    final int published = report.indexOf("__ATOMIC_RELEASE");
-    assertTrue("logging can wedge on a lock this thread faulted holding, and every guard on"
-        + " the engine reads this flag",
-        latched != -1 && logged > latched);
+    assertTrue(latched != -1);
+    for (final String wedges : new String[] { "error(", "coffeecatch_get_backtrace_info(",
+        "MUTEX_LOCK(runningOptLock)" }) {
+      assertTrue(wedges + " can block on a lock this thread faulted holding, and every guard"
+          + " on the engine reads the flag", report.indexOf(wedges) > latched);
+    }
     assertTrue("the crawl thread reads the message once it sees the flag",
-        written != -1 && published > written);
+        report.indexOf("__ATOMIC_RELEASE") > report.indexOf("snprintf(workerFaultMessage"));
   }
 
   @Test
   public void theFaultEndsTheMirrorAndKeepsWhatAContinueNeeds() throws IOException {
-    final String report = function(jni(), "reportWorkerFault");
+    final String source = blanked();
+    final int[] report = function(source, "reportWorkerFault");
     final String stopping = "if (!alreadyFaulted && runningOpt != NULL)";
-    assertTrue("the worker reads runningOpt under its own lock, which is all that keeps the"
-        + " crawl thread from retracting it mid-call",
-        report.contains("MUTEX_LOCK(runningOptLock)")
-            && report.contains("MUTEX_UNLOCK(runningOptLock)"));
-    final String stopped = blockBody(report, stopping);
-    assertTrue("0 would report the mirror as complete and drop the resume metadata",
-        stopped.contains("hts_request_stop(runningOpt, 1"));
-    assertFalse("the crawl is what will disarm the watchdog, once it shows it still runs",
-        stopped.contains("clearWorkerFaultWatchdog"));
-    final String nothingToStop = elseBlock(report, stopping);
-    assertTrue("with no crawl to stop, nothing else would ever disarm it",
-        nothingToStop.contains("clearWorkerFaultWatchdog()"));
-    assertFalse(nothingToStop.contains("hts_request_stop"));
+    assertEquals("0 would report the mirror as complete and drop the resume metadata",
+        Arrays.asList("hts_request_stop(runningOpt,1)"),
+        statements(source, thenBlock(source, report, stopping)));
+    final String body = text(source, report);
+    assertTrue("runningOpt is read under its own lock, which is what keeps the crawl thread"
+        + " from retracting it mid-call",
+        body.indexOf("MUTEX_LOCK(runningOptLock)") < body.indexOf(stopping)
+            && body.indexOf(stopping) < body.indexOf("MUTEX_UNLOCK(runningOptLock)"));
   }
 
   @Test
   public void aPoisonedOptIsNeverStopped() throws IOException {
-    final String report = function(jni(), "reportWorkerFault");
-    final int read = report.indexOf("alreadyFaulted = engineFaulted");
-    final int latched = report.indexOf("engineFaulted = 1");
-    assertTrue("read after the latch, this would always be true",
-        read != -1 && latched > read);
+    final String source = blanked();
+    final String report = text(source, function(source, "reportWorkerFault"));
+    assertTrue("any other expression here would stop an opt the crawl thread faulted out of",
+        report.contains("const int alreadyFaulted = engineFaulted;"));
+    assertTrue("read after the latch, the snapshot would always be true",
+        report.indexOf("alreadyFaulted = engineFaulted")
+            < report.indexOf("engineFaulted = 1"));
   }
 
   @Test
-  public void theMirrorEndsAtTheNextTickAndThatTickDisarmsTheWatchdog() throws IOException {
-    final String guard = blockBody(function(jni(), "htsshow_loop"), "if (hasWorkerFaulted())");
-    assertTrue("the progress callback aborts the mirror by returning 0",
-        guard.contains("return 0"));
-    assertTrue("this tick is the first proof no lock the worker held blocks the crawl thread,"
-        + " and the wind-down after it has no bound the watchdog could outlast",
-        guard.contains("clearWorkerFaultWatchdog()"));
+  public void theWatchdogIsDisarmedOnceAndLast() throws IOException {
+    final String source = blanked();
+    assertEquals("a second caller would disarm a watchdog another fault still needs", 1,
+        TestSources.occurrences(source, "clearWorkerFaultWatchdog()"));
+    final List<String> report = statements(source, function(source, "reportWorkerFault"));
+    assertEquals("everything above it can block on a lock this thread faulted holding, and"
+        + " the watchdog is what ends the process when one does",
+        "clearWorkerFaultWatchdog()", report.get(report.size() - 1));
   }
 
   @Test
-  public void theCrawlThreadReportsTheFaultAndDisarmsTheWatchdog() throws IOException {
-    final String source = jni();
+  public void theMirrorEndsAtTheNextTick() throws IOException {
+    final String source = blanked();
+    assertEquals("the progress callback aborts the mirror by returning 0",
+        Arrays.asList("return0"),
+        statements(source, thenBlock(source, function(source, "htsshow_loop"),
+            "if (hasWorkerFaulted())")));
+  }
+
+  @Test
+  public void theCrawlThreadReportsTheFault() throws IOException {
+    final String source = blanked();
     assertTrue("a plain load would let the crawl thread read the message half-written",
-        function(source, "hasWorkerFaulted").contains("__ATOMIC_ACQUIRE"));
-    final String main = function(source, "HTTrackLib_main");
-    final String reported = blockBody(main, "if (hasWorkerFaulted())");
-    assertTrue("getSafeCopy() sizes its buffer from one read and copies on a second, so a"
+        text(source, function(source, "hasWorkerFaulted")).contains("__ATOMIC_ACQUIRE"));
+    final int[] main = function(source, "HTTrackLib_main");
+    final int[] reported = thenBlock(source, main, "if (hasWorkerFaulted())");
+    assertTrue("an exception is already pending and JNI forbids a second one",
+        statements(source, reported).contains("code=-1"));
+    final int[] thrown = thenBlock(source, reported, "if (!(*env)->ExceptionCheck(env))");
+    assertEquals("getSafeCopy() sizes its buffer from one read and copies on a second, so a"
         + " second faulting worker could grow the string in between",
-        reported.contains("snprintf(reported,") && reported.contains("throwException(env,"));
-    assertTrue(reported.contains("clearWorkerFaultWatchdog()")
-        && reported.contains("code = -1"));
+        Arrays.asList("charreported[sizeof(workerFaultMessage)]",
+            "snprintf(reported,sizeof(reported),,workerFaultMessage)",
+            "throwException(env,,reported)"),
+        statements(source, thrown));
+    // The class is a string literal, which the blanked source cannot see, so read the raw
+    // text. A commented-out call would satisfy that on its own, hence the count.
+    final String slice = text(raw(), thrown);
+    assertEquals(1, TestSources.occurrences(slice, "throwException("));
     assertTrue("java.lang.Error is what coffeecatch throws for a fault on this thread",
-        TestSources.jniSource("htslibjni.c")
-            .contains("throwException(env, \"java/lang/Error\", reported)"));
-    final int ran = main.indexOf("hts_main2(");
-    final int retracted = main.indexOf("runningOpt = NULL");
-    final int stats = main.indexOf("hts_get_stats(");
+        slice.contains("\"java/lang/Error\""));
+    final String body = text(source, main);
+    final int ran = body.indexOf("hts_main2(");
+    final int retracted = body.indexOf("runningOpt = NULL");
     assertTrue("the destructor frees the opt, so a worker must not still hold it",
-        ran != -1 && retracted > ran && retracted < stats);
+        ran != -1 && retracted > ran && retracted < body.indexOf("hts_get_stats("));
   }
 }

--- a/app/src/test/java/com/httrack/android/WorkerThreadFaultTest.java
+++ b/app/src/test/java/com/httrack/android/WorkerThreadFaultTest.java
@@ -1,0 +1,119 @@
+package com.httrack.android;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.junit.Test;
+
+/** The engine spawns detached threads for itself, a DNS resolver per hostname and an FTP fetch,
+ *  and no JNI entry point covers them: a fault there used to take the process down. The thread
+ *  runner catches it on the worker, and the crawl thread is what reports it to Java. */
+public class WorkerThreadFaultTest {
+  /** htslibjni.c with comments and string literals blanked, so a commented-out call cannot pass
+   *  for one. */
+  private String jni() throws IOException {
+    return TestSources.withoutCommentsAndStrings(TestSources.jniSource("htslibjni.c"));
+  }
+
+  /** Body of the static function NAME, braces balanced and the outer pair left out. */
+  private static String function(final String source, final String name) {
+    final Matcher m = Pattern.compile("(?m)^[\\w *]+\\b" + name + "\\s*\\(")
+        .matcher(source);
+    assertTrue("no function " + name, m.find());
+    return TestSources.balancedBlock(source, m.end());
+  }
+
+  /** Body of the JNI entry point NAME. */
+  private static String entryPoint(final String source, final String name) {
+    final int at = source.indexOf("Java_com_httrack_android_jni_HTTrackLib_" + name + "(");
+    assertTrue("no entry point " + name, at != -1);
+    return TestSources.balancedBlock(source, at);
+  }
+
+  /** Body of the CONDITION block inside SOURCE. */
+  private static String guard(final String source, final String condition) {
+    final int at = source.indexOf(condition);
+    assertTrue("no " + condition, at != -1);
+    return TestSources.balancedBlock(source, at);
+  }
+
+  @Test
+  public void theRunnerIsInstalledBeforeAnythingCanSpawnAWorker() throws IOException {
+    final String source = jni();
+    assertEquals(1, TestSources.occurrences(source, "hts_set_thread_runner("));
+    assertEquals("workerThreadRunner",
+        TestSources.arguments(source, "hts_set_thread_runner").trim());
+    assertTrue("the engine reads the runner unlocked, so it must be set at class load",
+        entryPoint(source, "initStatic").contains("hts_set_thread_runner("));
+  }
+
+  @Test
+  public void onlyASignalCountsAsAFault() throws IOException {
+    final String runner = function(jni(), "workerThreadRunner");
+    assertTrue("COFFEE_CATCH is entered on a setup failure too, with the engine intact",
+        guard(runner, "if (coffeecatch_get_signal() > 0)").contains("reportWorkerFault()"));
+  }
+
+  @Test
+  public void aWorkerWhoseBodyNeverRanRunsItUnprotected() throws IOException {
+    final String runner = function(jni(), "workerThreadRunner");
+    final int end = runner.indexOf("COFFEE_END()");
+    assertTrue(end != -1);
+    assertTrue("dropping the body would hand the caller a worker that did nothing",
+        guard(runner.substring(end), "if (unprotected)").contains("fun(arg)"));
+  }
+
+  @Test
+  public void theMessageIsWrittenBeforeTheFlagThatPublishesIt() throws IOException {
+    final String report = function(jni(), "reportWorkerFault");
+    final int written = report.indexOf("snprintf(workerFaultMessage");
+    final int published = report.indexOf("__ATOMIC_RELEASE");
+    assertTrue("the crawl thread reads the message once it sees the flag",
+        written != -1 && published > written);
+    assertTrue("every entry point back into the engine reads this one",
+        report.contains("engineFaulted = 1"));
+  }
+
+  @Test
+  public void theFaultEndsTheMirrorAndKeepsWhatAContinueNeeds() throws IOException {
+    final String source = jni();
+    assertTrue("0 would report the mirror as complete and drop the resume metadata",
+        function(source, "reportWorkerFault").contains("hts_request_stop(runningOpt, 1)"));
+    assertTrue("the progress callback aborts the mirror by returning 0",
+        guard(function(source, "htsshow_loop"), "if (hasWorkerFaulted())").contains("return 0"));
+  }
+
+  @Test
+  public void theWorkerLeavesTheWatchdogToTheCrawlThread() throws IOException {
+    final String source = jni();
+    final String runner = function(source, "workerThreadRunner");
+    assertFalse("a worker that unwound nothing may hold a lock the crawl needs, and the"
+        + " watchdog is the only thing that would then end the process",
+        runner.contains("coffeecatch_cancel_pending_alarm")
+            || runner.contains("clearWorkerFaultWatchdog"));
+    assertTrue("with no crawl to end, nothing waits on this worker and nothing would disarm it",
+        guard(function(source, "reportWorkerFault"), "if (runningOpt != NULL)").length() > 0
+            && function(source, "reportWorkerFault").contains("clearWorkerFaultWatchdog()"));
+  }
+
+  @Test
+  public void theCrawlThreadReportsTheFaultAndDisarmsTheWatchdog() throws IOException {
+    final String source = jni();
+    final String main = function(source, "HTTrackLib_main");
+    final String reported = guard(main, "if (hasWorkerFaulted())");
+    assertTrue(reported.contains("workerFaultMessage")
+        && reported.contains("clearWorkerFaultWatchdog()"));
+    assertTrue("java.lang.Error is what coffeecatch throws for a fault on this thread",
+        TestSources.jniSource("htslibjni.c")
+            .contains("throwException(env, \"java/lang/Error\", workerFaultMessage)"));
+    final int ran = main.indexOf("hts_main2(");
+    final int retracted = main.indexOf("runningOpt = NULL");
+    final int stats = main.indexOf("hts_get_stats(");
+    assertTrue("the destructor frees the opt, so a worker must not still hold it",
+        ran != -1 && retracted > ran && retracted < stats);
+  }
+}

--- a/app/src/test/java/com/httrack/android/WorkerThreadFaultTest.java
+++ b/app/src/test/java/com/httrack/android/WorkerThreadFaultTest.java
@@ -13,32 +13,33 @@ import org.junit.Test;
  *  and no JNI entry point covers them: a fault there used to take the process down. The thread
  *  runner catches it on the worker, and the crawl thread is what reports it to Java. */
 public class WorkerThreadFaultTest {
-  /** htslibjni.c with comments and string literals blanked, so a commented-out call cannot pass
-   *  for one. */
+  /** Reads htslibjni.c with comments and string literals blanked, so a commented-out call
+   *  cannot pass for one. */
   private String jni() throws IOException {
     return TestSources.withoutCommentsAndStrings(TestSources.jniSource("htslibjni.c"));
   }
 
-  /** Body of the static function NAME, braces balanced and the outer pair left out. */
+  /** Returns function NAME's body, braces balanced, outer pair left out. */
   private static String function(final String source, final String name) {
-    final Matcher m = Pattern.compile("(?m)^[\\w *]+\\b" + name + "\\s*\\(")
-        .matcher(source);
+    final Matcher m = Pattern.compile("(?m)^[\\w *]+\\b" + name + "\\s*\\(").matcher(source);
     assertTrue("no function " + name, m.find());
     return TestSources.balancedBlock(source, m.end());
   }
 
-  /** Body of the JNI entry point NAME. */
-  private static String entryPoint(final String source, final String name) {
-    final int at = source.indexOf("Java_com_httrack_android_jni_HTTrackLib_" + name + "(");
-    assertTrue("no entry point " + name, at != -1);
-    return TestSources.balancedBlock(source, at);
+  /** Returns CONDITION's own block in BODY. */
+  private static String blockBody(final String body, final String condition) {
+    final int at = body.indexOf(condition);
+    assertTrue("no " + condition, at != -1);
+    return TestSources.balancedBlock(body, at);
   }
 
-  /** Body of the CONDITION block inside SOURCE. */
-  private static String guard(final String source, final String condition) {
-    final int at = source.indexOf(condition);
+  /** Returns the block CONDITION falls through to in BODY. */
+  private static String elseBlock(final String body, final String condition) {
+    final int at = body.indexOf(condition);
     assertTrue("no " + condition, at != -1);
-    return TestSources.balancedBlock(source, at);
+    final int fallthrough = body.indexOf("} else {", at);
+    assertTrue(condition + " has no else", fallthrough != -1);
+    return TestSources.balancedBlock(body, fallthrough + 1);
   }
 
   @Test
@@ -48,14 +49,20 @@ public class WorkerThreadFaultTest {
     assertEquals("workerThreadRunner",
         TestSources.arguments(source, "hts_set_thread_runner").trim());
     assertTrue("the engine reads the runner unlocked, so it must be set at class load",
-        entryPoint(source, "initStatic").contains("hts_set_thread_runner("));
+        function(source, "Java_com_httrack_android_jni_HTTrackLib_initStatic")
+            .contains("hts_set_thread_runner("));
   }
 
   @Test
   public void onlyASignalCountsAsAFault() throws IOException {
     final String runner = function(jni(), "workerThreadRunner");
+    final String faulted = blockBody(runner, "if (coffeecatch_get_signal() > 0)");
     assertTrue("COFFEE_CATCH is entered on a setup failure too, with the engine intact",
-        guard(runner, "if (coffeecatch_get_signal() > 0)").contains("reportWorkerFault()"));
+        faulted.contains("reportWorkerFault()"));
+    assertFalse("a body that faulted has run, so running it again would fault again",
+        faulted.contains("bodyNeverRan = 1"));
+    assertTrue(elseBlock(runner, "if (coffeecatch_get_signal() > 0)")
+        .contains("bodyNeverRan = 1"));
   }
 
   @Test
@@ -64,52 +71,76 @@ public class WorkerThreadFaultTest {
     final int end = runner.indexOf("COFFEE_END()");
     assertTrue(end != -1);
     assertTrue("dropping the body would hand the caller a worker that did nothing",
-        guard(runner.substring(end), "if (unprotected)").contains("fun(arg)"));
+        blockBody(runner.substring(end), "if (bodyNeverRan)").contains("fun(arg)"));
   }
 
   @Test
-  public void theMessageIsWrittenBeforeTheFlagThatPublishesIt() throws IOException {
+  public void theLatchIsSetBeforeAnythingThatCanWedge() throws IOException {
     final String report = function(jni(), "reportWorkerFault");
+    final int latched = report.indexOf("engineFaulted = 1");
+    final int logged = report.indexOf("error(");
     final int written = report.indexOf("snprintf(workerFaultMessage");
     final int published = report.indexOf("__ATOMIC_RELEASE");
+    assertTrue("logging can wedge on a lock this thread faulted holding, and every guard on"
+        + " the engine reads this flag",
+        latched != -1 && logged > latched);
     assertTrue("the crawl thread reads the message once it sees the flag",
         written != -1 && published > written);
-    assertTrue("every entry point back into the engine reads this one",
-        report.contains("engineFaulted = 1"));
   }
 
   @Test
   public void theFaultEndsTheMirrorAndKeepsWhatAContinueNeeds() throws IOException {
-    final String source = jni();
+    final String report = function(jni(), "reportWorkerFault");
+    final String stopping = "if (!alreadyFaulted && runningOpt != NULL)";
+    assertTrue("the worker reads runningOpt under its own lock, which is all that keeps the"
+        + " crawl thread from retracting it mid-call",
+        report.contains("MUTEX_LOCK(runningOptLock)")
+            && report.contains("MUTEX_UNLOCK(runningOptLock)"));
+    final String stopped = blockBody(report, stopping);
     assertTrue("0 would report the mirror as complete and drop the resume metadata",
-        function(source, "reportWorkerFault").contains("hts_request_stop(runningOpt, 1)"));
-    assertTrue("the progress callback aborts the mirror by returning 0",
-        guard(function(source, "htsshow_loop"), "if (hasWorkerFaulted())").contains("return 0"));
+        stopped.contains("hts_request_stop(runningOpt, 1"));
+    assertFalse("the crawl is what will disarm the watchdog, once it shows it still runs",
+        stopped.contains("clearWorkerFaultWatchdog"));
+    final String nothingToStop = elseBlock(report, stopping);
+    assertTrue("with no crawl to stop, nothing else would ever disarm it",
+        nothingToStop.contains("clearWorkerFaultWatchdog()"));
+    assertFalse(nothingToStop.contains("hts_request_stop"));
   }
 
   @Test
-  public void theWorkerLeavesTheWatchdogToTheCrawlThread() throws IOException {
-    final String source = jni();
-    final String runner = function(source, "workerThreadRunner");
-    assertFalse("a worker that unwound nothing may hold a lock the crawl needs, and the"
-        + " watchdog is the only thing that would then end the process",
-        runner.contains("coffeecatch_cancel_pending_alarm")
-            || runner.contains("clearWorkerFaultWatchdog"));
-    assertTrue("with no crawl to end, nothing waits on this worker and nothing would disarm it",
-        guard(function(source, "reportWorkerFault"), "if (runningOpt != NULL)").length() > 0
-            && function(source, "reportWorkerFault").contains("clearWorkerFaultWatchdog()"));
+  public void aPoisonedOptIsNeverStopped() throws IOException {
+    final String report = function(jni(), "reportWorkerFault");
+    final int read = report.indexOf("alreadyFaulted = engineFaulted");
+    final int latched = report.indexOf("engineFaulted = 1");
+    assertTrue("read after the latch, this would always be true",
+        read != -1 && latched > read);
+  }
+
+  @Test
+  public void theMirrorEndsAtTheNextTickAndThatTickDisarmsTheWatchdog() throws IOException {
+    final String guard = blockBody(function(jni(), "htsshow_loop"), "if (hasWorkerFaulted())");
+    assertTrue("the progress callback aborts the mirror by returning 0",
+        guard.contains("return 0"));
+    assertTrue("this tick is the first proof no lock the worker held blocks the crawl thread,"
+        + " and the wind-down after it has no bound the watchdog could outlast",
+        guard.contains("clearWorkerFaultWatchdog()"));
   }
 
   @Test
   public void theCrawlThreadReportsTheFaultAndDisarmsTheWatchdog() throws IOException {
     final String source = jni();
+    assertTrue("a plain load would let the crawl thread read the message half-written",
+        function(source, "hasWorkerFaulted").contains("__ATOMIC_ACQUIRE"));
     final String main = function(source, "HTTrackLib_main");
-    final String reported = guard(main, "if (hasWorkerFaulted())");
-    assertTrue(reported.contains("workerFaultMessage")
-        && reported.contains("clearWorkerFaultWatchdog()"));
+    final String reported = blockBody(main, "if (hasWorkerFaulted())");
+    assertTrue("getSafeCopy() sizes its buffer from one read and copies on a second, so a"
+        + " second faulting worker could grow the string in between",
+        reported.contains("snprintf(reported,") && reported.contains("throwException(env,"));
+    assertTrue(reported.contains("clearWorkerFaultWatchdog()")
+        && reported.contains("code = -1"));
     assertTrue("java.lang.Error is what coffeecatch throws for a fault on this thread",
         TestSources.jniSource("htslibjni.c")
-            .contains("throwException(env, \"java/lang/Error\", workerFaultMessage)"));
+            .contains("throwException(env, \"java/lang/Error\", reported)"));
     final int ran = main.indexOf("hts_main2(");
     final int retracted = main.indexOf("runningOpt = NULL");
     final int stats = main.indexOf("hts_get_stats(");


### PR DESCRIPTION
coffeecatch covers the three JNI entry points, which means the crawl thread and nothing else. The engine spawns detached workers of its own through `hts_newthread()`: a DNS resolver per hostname, and one per FTP fetch. A fault there reached the default handler, so the app died with a tombstone naming `AsyncTask #3` and the user got no message.

The engine already exports the seam (xroche/httrack#1630). A runner installed there logs the fault with its frames, latches `engineFaulted`, and asks the crawl to stop with its resume data kept. `HTTrackLib_main()` then throws the `java.lang.Error` coffeecatch would have thrown on the crawl thread. It disarms coffeecatch's 30s watchdog last of all, so a handler still blocked on a lock the fault left held ends the process instead.

One gap is left. A recovered FTP worker never leaves `ftp_workers`, so the crawl waits on it forever. That one needs an engine fix.

Device-verified on an API 36 emulator with the engine's own `-#c=threadsegv` and `-#c=threadstack`. Both gave the named log line, the `java.lang.Error`, the panel text, no tombstone, and a process alive 45 seconds later. A control build with no runner installed writes a tombstone and dies. The recipe and the logs are in `httrack-works/android-thread-runner/`.