### PR TITLE
A crawl that ends without its activity records no resume marker

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -34,6 +34,7 @@
         <activity
             android:name="com.httrack.android.HTTrackActivity"
             android:label="@string/title_activity_startup"
+            android:launchMode="singleTop"
             android:exported="true" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -826,11 +826,11 @@ public class HTTrackActivity extends FragmentActivity {
     Log.d(getClass().getSimpleName(), "onNewIntent");
     super.onNewIntent(intent);
 
-    // singleTop delivers a notification tap here instead of through onCreate.
-    setIntent(intent);
+    // A state we refuse must not become the intent restartActivity() would reopen.
     final Bundle extras = intent.getExtras();
-    if (ResumePolicy.restoresIntentState(extras != null, runner != null)) {
-      restoreInstanceState(extras);
+    if (ResumePolicy.restoresIntentState(extras != null, hasLiveRunner())
+        && restoreInstanceState(extras)) {
+      setIntent(intent);
     }
   }
 
@@ -1238,7 +1238,7 @@ public class HTTrackActivity extends FragmentActivity {
   }
 
   /**
-   * Build the top index.
+   * Build the top index, synchronized because a browse-all tap and a finishing run race here.
    *
    * @param context
    *          Any context, used to dump a native fault
@@ -1248,13 +1248,8 @@ public class HTTrackActivity extends FragmentActivity {
    *          The extracted HTML resource directory
    * @return 1 upon success
    */
-  protected static int buildTopIndex(final Context context,
+  protected static synchronized int buildTopIndex(final Context context,
       final File projectRoot, final File resources) {
-    if (!ResumePolicy.topIndexRunsHeadless(projectRoot, resources)) {
-      Log.w(HTTrackActivity.class.getSimpleName(),
-          "no resources to build the top index with");
-      return 0;
-    }
     try {
       return HTTrackLib.buildTopIndex(projectRoot, resources);
     } catch (final Throwable t) {
@@ -1364,6 +1359,8 @@ public class HTTrackActivity extends FragmentActivity {
     private volatile File runResources;
     private boolean mirrorRefresh;
     protected HTTrackStats lastStats;
+    // Set as soon as the run knows what it left behind, so a late stop cannot overwrite it.
+    private volatile boolean verdictRecorded;
     private volatile boolean ended;
     private volatile boolean interrupted;
     private volatile boolean interruptedHard;
@@ -1562,6 +1559,7 @@ public class HTTrackActivity extends FragmentActivity {
         final MirrorOutcome.Stop stop = interrupted ? MirrorOutcome.Stop.USER
             : engine.wasStopped() ? MirrorOutcome.Stop.ENGINE : MirrorOutcome.Stop.NONE;
         pendingWork = leavesPendingWork(stop != MirrorOutcome.Stop.NONE, code);
+        verdictRecorded = true;
 
         final MirrorOutcome.Verdict verdict = MirrorOutcome.decide(code, stop,
             engine.abortCode(), lastStats);
@@ -1621,18 +1619,12 @@ public class HTTrackActivity extends FragmentActivity {
       displayFinishedPanel(displayMessage, errorsCount, mirrorFolder);
     }
 
-    /*
-     * An activity adds nothing to a top index, so it is built from the paths the run captured
-     * rather than queued, which would leave the mirror with no index until one attached.
-     */
+    /* Built rather than queued, since a queue leaves the mirror indexless until one attaches. */
     private void buildTopIndex() {
       HTTrackActivity.buildTopIndex(appContext, runProjectRoot, runResources);
     }
 
-    /*
-     * Trunk to parent.displayFinishedPanel(). Still queued when detached, because only a pane
-     * can show it and a re-attach does fire it.
-     */
+    /* Trunk to parent.displayFinishedPanel(), still queued because only a pane can show it. */
     private synchronized void displayFinishedPanel(final String displayMessage,
         final long errorsCount, final File mirrorFolder) {
       if (parent != null) {
@@ -1647,14 +1639,11 @@ public class HTTrackActivity extends FragmentActivity {
       }
     }
 
-    /*
-     * Stamp the directory the run wrote to, so a run whose activity is gone still records
-     * whether it left work behind.
-     */
+    /* Stamped against the run's own directory, so a detached end still records its verdict. */
     private synchronized void setInterruptedProfile(final boolean interrupted)
         throws IOException {
-      final File target = ResumePolicy.markerDirectory(runTarget,
-          parent != null ? parent.getTargetFile() : null);
+      final File target = runTarget != null ? runTarget
+          : parent != null ? parent.getTargetFile() : null;
       if (target == null) {
         throw new IOException("no project directory for the resume marker");
       }
@@ -1681,9 +1670,8 @@ public class HTTrackActivity extends FragmentActivity {
       }
       // Stop engine
       final boolean stopSent = engine.stop(force);
-      // Only a stop that lands on a live crawl leaves work behind: the finished pane asks for one
-      // too, and the engine answers it long after runInternal recorded the real outcome.
-      if (!ended) {
+      // The finished pane asks for a stop too, long after the run decided the real outcome.
+      if (ResumePolicy.stopWritesMarker(ended, verdictRecorded)) {
         try {
           setInterruptedProfile(true);
         } catch (final IOException io) {
@@ -2164,7 +2152,8 @@ public class HTTrackActivity extends FragmentActivity {
       // Nothing else on a cold launch points at a project a crawl left unfinished.
       final String unfinished = ResumePolicy.resumeNotice(
           getString(R.string.unfinished_downloads_xx),
-          ResumePolicy.resumableProjects(getProjectRootFile(), getProjectNames()));
+          getString(R.string.unfinished_downloads_more_xx),
+          getProjectRootFile(), getProjectNames());
       if (unfinished != null) {
         html.append("<br /><br /><b>").append(TextUtils.htmlEncode(unfinished))
             .append("</b>");
@@ -3328,13 +3317,13 @@ public class HTTrackActivity extends FragmentActivity {
     sendSystemNotification(new Intent(), title, text);
   }
 
-  /** Restore a saved instance state. **/
-  protected void restoreInstanceState(final Bundle savedInstanceState) {
+  /** Restore a saved instance state; false when the bundle was refused. **/
+  protected boolean restoreInstanceState(final Bundle savedInstanceState) {
     // Check version ID
     final int version = savedInstanceState.getInt(VERSION_CODE_NAME);
     if (version != versionCode) {
       Log.d(getClass().getSimpleName(), "refused bundle version " + version);
-      return;
+      return false;
     }
 
     // Serialized session ID
@@ -3377,6 +3366,7 @@ public class HTTrackActivity extends FragmentActivity {
         dirtyNamePane = true;
       }
     }
+    return true;
   }
 
   @Override

--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -821,6 +821,19 @@ public class HTTrackActivity extends FragmentActivity {
     }
   }
 
+  @Override
+  protected void onNewIntent(final Intent intent) {
+    Log.d(getClass().getSimpleName(), "onNewIntent");
+    super.onNewIntent(intent);
+
+    // singleTop delivers a notification tap here instead of through onCreate.
+    setIntent(intent);
+    final Bundle extras = intent.getExtras();
+    if (ResumePolicy.restoresIntentState(extras != null, runner != null)) {
+      restoreInstanceState(extras);
+    }
+  }
+
   /* Install/Update time. */
   private long installOrUpdateTime() {
     final ApplicationInfo appInfo = getApplicationInfo();
@@ -1220,18 +1233,34 @@ public class HTTrackActivity extends FragmentActivity {
    * @return 1 upon success
    */
   protected synchronized int buildTopIndex() {
-    // Build top index
-    final File rsc = getResourceFile();
-    if (rsc != null) {
-      try {
-        return HTTrackLib.buildTopIndex(getProjectRootFile(), rsc);
-      } catch (final Throwable t) {
-        // The fault is latched; report it and let the app end the process on its way out.
-        Log.e(getClass().getSimpleName(), "could not build top index", t);
-        emergencyDump(getApplicationContext(), t);
-        return 0;
-      }
-    } else {
+    return buildTopIndex(getApplicationContext(), getProjectRootFile(),
+        getResourceFile());
+  }
+
+  /**
+   * Build the top index.
+   *
+   * @param context
+   *          Any context, used to dump a native fault
+   * @param projectRoot
+   *          The directory holding every project
+   * @param resources
+   *          The extracted HTML resource directory
+   * @return 1 upon success
+   */
+  protected static int buildTopIndex(final Context context,
+      final File projectRoot, final File resources) {
+    if (!ResumePolicy.topIndexRunsHeadless(projectRoot, resources)) {
+      Log.w(HTTrackActivity.class.getSimpleName(),
+          "no resources to build the top index with");
+      return 0;
+    }
+    try {
+      return HTTrackLib.buildTopIndex(projectRoot, resources);
+    } catch (final Throwable t) {
+      // The fault is latched; report it and let the app end the process on its way out.
+      Log.e(HTTrackActivity.class.getSimpleName(), "could not build top index", t);
+      emergencyDump(context, t);
       return 0;
     }
   }
@@ -1329,6 +1358,10 @@ public class HTTrackActivity extends FragmentActivity {
     // Application context, captured once and never detached, so a crash after detach() still dumps.
     private final Context appContext;
     private final List<Runnable> pendingParentActions = new ArrayList<Runnable>();
+    // Captured when the run starts, so its finish path needs no activity.
+    private volatile File runTarget;
+    private volatile File runProjectRoot;
+    private volatile File runResources;
     private boolean mirrorRefresh;
     protected HTTrackStats lastStats;
     private volatile boolean ended;
@@ -1464,6 +1497,9 @@ public class HTTrackActivity extends FragmentActivity {
         if (target == null) {
           throw new IOException("no project name defined!");
         }
+        runTarget = target;
+        runProjectRoot = parent.getProjectRootFile();
+        runResources = parent.getResourceFile();
 
         // Progress info for slow phones
         setProgressLines(new String[] { string_creating_project });
@@ -1586,23 +1622,16 @@ public class HTTrackActivity extends FragmentActivity {
     }
 
     /*
-     * Trunk to parent.buildTopIndex().
+     * An activity adds nothing to a top index, so it is built from the paths the run captured
+     * rather than queued, which would leave the mirror with no index until one attached.
      */
-    private synchronized void buildTopIndex() {
-      if (parent != null) {
-        parent.buildTopIndex();
-      } else {
-        pendingParentActions.add(new Runnable() {
-          @Override
-          public void run() {
-            parent.buildTopIndex();
-          }
-        });
-      }
+    private void buildTopIndex() {
+      HTTrackActivity.buildTopIndex(appContext, runProjectRoot, runResources);
     }
 
     /*
-     * Trunk to parent.displayFinishedPanel().
+     * Trunk to parent.displayFinishedPanel(). Still queued when detached, because only a pane
+     * can show it and a re-attach does fire it.
      */
     private synchronized void displayFinishedPanel(final String displayMessage,
         final long errorsCount, final File mirrorFolder) {
@@ -1619,14 +1648,17 @@ public class HTTrackActivity extends FragmentActivity {
     }
 
     /*
-     * Trunk to parent.setInterruptedProfile().
+     * Stamp the directory the run wrote to, so a run whose activity is gone still records
+     * whether it left work behind.
      */
     private synchronized void setInterruptedProfile(final boolean interrupted)
         throws IOException {
-      if (parent == null) {
-        throw new IOException("parent has been detached");
+      final File target = ResumePolicy.markerDirectory(runTarget,
+          parent != null ? parent.getTargetFile() : null);
+      if (target == null) {
+        throw new IOException("no project directory for the resume marker");
       }
-      parent.setInterruptedProfile(interrupted);
+      HTTrackActivity.setInterruptedProfile(target, interrupted);
     }
 
     /*
@@ -1952,23 +1984,6 @@ public class HTTrackActivity extends FragmentActivity {
   }
 
   /**
-   * Set the "interrupted" flag.
-   * 
-   * @param interrupted
-   *          Interrupted mirror ?
-   * @throws IOException
-   *           Upon I/O error.
-   */
-  protected synchronized void setInterruptedProfile(final boolean interrupted)
-      throws IOException {
-    final File target = getTargetFile();
-    if (target == null) {
-      throw new IOException("no project name defined!");
-    }
-    setInterruptedProfile(target, interrupted);
-  }
-
-  /**
    * Get the profile target file for a given project.
    * 
    * @return The profile target file.
@@ -2141,10 +2156,20 @@ public class HTTrackActivity extends FragmentActivity {
           .findViewById(R.id.fieldDebug));
 
       // Welcome message.
-      final String html = getString(R.string.welcome_message)
-          .replace("\n-", "\n•").replace("\n", "<br />")
-          .replace("HTTrack Website Copier", "<b>HTTrack Website Copier</b>");
-      text.setText(Html.fromHtml(html));
+      final StringBuilder html = new StringBuilder(
+          getString(R.string.welcome_message).replace("\n-", "\n•")
+              .replace("\n", "<br />")
+              .replace("HTTrack Website Copier", "<b>HTTrack Website Copier</b>"));
+
+      // Nothing else on a cold launch points at a project a crawl left unfinished.
+      final String unfinished = ResumePolicy.resumeNotice(
+          getString(R.string.unfinished_downloads_xx),
+          ResumePolicy.resumableProjects(getProjectRootFile(), getProjectNames()));
+      if (unfinished != null) {
+        html.append("<br /><br /><b>").append(TextUtils.htmlEncode(unfinished))
+            .append("</b>");
+      }
+      text.setText(Html.fromHtml(html.toString()));
 
       // Debugging and information.
       final StringBuilder str = new StringBuilder();

--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -212,9 +212,6 @@ public class HTTrackActivity extends FragmentActivity {
   // Is the application "started" ? (ie. visible to user)
   protected volatile boolean started;
 
-  // Is the application paused (pending visible state) ?
-  protected volatile boolean paused;
-
   // "Project name" pane is dirty
   protected boolean dirtyNamePane;
 
@@ -3377,14 +3374,12 @@ public class HTTrackActivity extends FragmentActivity {
   protected void onPause() {
     Log.d(getClass().getSimpleName(), "onPause");
     super.onPause();
-    paused = true;
   }
 
   @Override
   protected void onResume() {
     Log.d(getClass().getSimpleName(), "onResume");
     super.onResume();
-    paused = false;
     // Returning from the all-files-access settings screen can change what we can write.
     // Never while a crawl runs, since the engine already holds the destination.
     if (runner == null) {

--- a/app/src/main/java/com/httrack/android/ResumePolicy.java
+++ b/app/src/main/java/com/httrack/android/ResumePolicy.java
@@ -1,0 +1,89 @@
+package com.httrack.android;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * What a crawl left behind, and what the app does about it once the activity that started it is
+ * gone. Only files and flags appear here, so each decision can be checked against its truth
+ * table.
+ */
+final class ResumePolicy {
+  private ResumePolicy() {
+  }
+
+  /**
+   * Where the resume marker goes, the run's own directory first so a detached end can still
+   * stamp it.
+   *
+   * @param runTarget      the project directory the run captured when it started
+   * @param attachedTarget the directory the activity names now, if one is attached
+   * @return the directory to stamp, or null when neither is known
+   */
+  static File markerDirectory(final File runTarget, final File attachedTarget) {
+    return runTarget != null ? runTarget : attachedTarget;
+  }
+
+  /**
+   * Can the top index be built with no activity? It takes two paths and the engine, and a
+   * missing one leaves nothing an activity could add later.
+   *
+   * @param projectRoot the directory holding every project
+   * @param resources   the extracted HTML resource directory
+   * @return true when the build can run as it stands
+   */
+  static boolean topIndexRunsHeadless(final File projectRoot, final File resources) {
+    return projectRoot != null && resources != null;
+  }
+
+  /**
+   * The projects a crawl left unfinished, in listing order.
+   *
+   * @param root  the directory holding every project
+   * @param names the project names to examine, as listed on disk
+   * @return the names that reopen on "Continue interrupted download"
+   */
+  static List<String> resumableProjects(final File root, final String[] names) {
+    final List<String> resumable = new ArrayList<String>();
+    if (root != null && names != null) {
+      for (final String name : names) {
+        if (name != null
+            && HTTrackActivity.isInterruptedProfile(new File(root, name))) {
+          resumable.add(name);
+        }
+      }
+    }
+    return resumable;
+  }
+
+  /**
+   * What the welcome pane says about them, since a cold launch carries no state pointing at one.
+   *
+   * @param template a message with a single %s for the names
+   * @param names    the unfinished projects
+   * @return the message, or null when there is nothing to say
+   */
+  static String resumeNotice(final String template, final List<String> names) {
+    if (template == null || names == null || names.isEmpty()) {
+      return null;
+    }
+    final StringBuilder joined = new StringBuilder();
+    for (final String name : names) {
+      joined.append(joined.length() == 0 ? "" : ", ").append(name);
+    }
+    return template.replace("%s", joined.toString());
+  }
+
+  /**
+   * Should an intent's saved state be loaded? A notification carries the project it was posted
+   * for, which would overwrite the settings of a crawl still running.
+   *
+   * @param hasExtras     whether the intent carries a saved state
+   * @param crawlAttached whether a runner is attached to the activity
+   * @return true when the state may be restored
+   */
+  static boolean restoresIntentState(final boolean hasExtras, final boolean crawlAttached) {
+    return hasExtras && !crawlAttached;
+  }
+}

--- a/app/src/main/java/com/httrack/android/ResumePolicy.java
+++ b/app/src/main/java/com/httrack/android/ResumePolicy.java
@@ -1,76 +1,51 @@
 package com.httrack.android;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * What a crawl left behind, and what the app does about it once the activity that started it is
- * gone. Only files and flags appear here, so each decision can be checked against its truth
- * table.
+ * gone. Each decision takes its inputs explicitly, so it can be checked against a truth table;
+ * the resume offer also reads the project directories to find them.
  */
 final class ResumePolicy {
+  // The notice is one line of the welcome pane, not a project listing.
+  private static final int MAX_NAMED = 3;
+
   private ResumePolicy() {
   }
 
   /**
-   * Where the resume marker goes, the run's own directory first so a detached end can still
-   * stamp it.
-   *
-   * @param runTarget      the project directory the run captured when it started
-   * @param attachedTarget the directory the activity names now, if one is attached
-   * @return the directory to stamp, or null when neither is known
-   */
-  static File markerDirectory(final File runTarget, final File attachedTarget) {
-    return runTarget != null ? runTarget : attachedTarget;
-  }
-
-  /**
-   * Can the top index be built with no activity? It takes two paths and the engine, and a
-   * missing one leaves nothing an activity could add later.
-   *
-   * @param projectRoot the directory holding every project
-   * @param resources   the extracted HTML resource directory
-   * @return true when the build can run as it stands
-   */
-  static boolean topIndexRunsHeadless(final File projectRoot, final File resources) {
-    return projectRoot != null && resources != null;
-  }
-
-  /**
-   * The projects a crawl left unfinished, in listing order.
-   *
-   * @param root  the directory holding every project
-   * @param names the project names to examine, as listed on disk
-   * @return the names that reopen on "Continue interrupted download"
-   */
-  static List<String> resumableProjects(final File root, final String[] names) {
-    final List<String> resumable = new ArrayList<String>();
-    if (root != null && names != null) {
-      for (final String name : names) {
-        if (name != null
-            && HTTrackActivity.isInterruptedProfile(new File(root, name))) {
-          resumable.add(name);
-        }
-      }
-    }
-    return resumable;
-  }
-
-  /**
-   * What the welcome pane says about them, since a cold launch carries no state pointing at one.
+   * What the welcome pane says about the projects a crawl left unfinished, since nothing else on
+   * a cold launch points at one.
    *
    * @param template a message with a single %s for the names
-   * @param names    the unfinished projects
-   * @return the message, or null when there is nothing to say
+   * @param andMore  a suffix with a single %s for the count the names leave out
+   * @param root     the directory holding every project
+   * @param names    the project names to examine, as listed on disk
+   * @return the message, or null when nothing reopens on "Continue interrupted download"
    */
-  static String resumeNotice(final String template, final List<String> names) {
-    if (template == null || names == null || names.isEmpty()) {
+  static String resumeNotice(final String template, final String andMore,
+      final File root, final String[] names) {
+    if (template == null || root == null || names == null) {
       return null;
     }
     final StringBuilder joined = new StringBuilder();
+    int resumable = 0;
     for (final String name : names) {
-      joined.append(joined.length() == 0 ? "" : ", ").append(name);
+      if (name == null
+          || !HTTrackActivity.isInterruptedProfile(new File(root, name))) {
+        continue;
+      }
+      if (resumable++ < MAX_NAMED) {
+        joined.append(joined.length() == 0 ? "" : ", ").append(name);
+      }
+    }
+    if (resumable == 0) {
+      return null;
+    }
+    if (resumable > MAX_NAMED && andMore != null) {
+      joined.append(", ")
+          .append(andMore.replace("%s", String.valueOf(resumable - MAX_NAMED)));
     }
     return template.replace("%s", joined.toString());
   }
@@ -79,11 +54,25 @@ final class ResumePolicy {
    * Should an intent's saved state be loaded? A notification carries the project it was posted
    * for, which would overwrite the settings of a crawl still running.
    *
-   * @param hasExtras     whether the intent carries a saved state
-   * @param crawlAttached whether a runner is attached to the activity
+   * @param hasExtras whether the intent carries a saved state
+   * @param crawlLive whether a crawl is still running in this activity
    * @return true when the state may be restored
    */
-  static boolean restoresIntentState(final boolean hasExtras, final boolean crawlAttached) {
-    return hasExtras && !crawlAttached;
+  static boolean restoresIntentState(final boolean hasExtras,
+      final boolean crawlLive) {
+    return hasExtras && !crawlLive;
+  }
+
+  /**
+   * Should a stop write the "work left" marker? Only one that lands before the run reached its
+   * own verdict, which is the reading the finished mirror keeps.
+   *
+   * @param ended           whether the run has left runInternal()
+   * @param verdictRecorded whether the run already decided what it left behind
+   * @return true when the stop is the only thing that can record an interruption
+   */
+  static boolean stopWritesMarker(final boolean ended,
+      final boolean verdictRecorded) {
+    return !ended && !verdictRecorded;
   }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,6 +7,7 @@
     <string name="action_settings">Options</string>
     <string name="welcome_message">Welcome to HTTrack Website Copier!\n\nPlease click on the NEXT button to\n\n- start a new project\n- or resume a partial download</string>
     <string name="unfinished_downloads_xx">Unfinished download: %s. Open the project and select \"Continue interrupted download\".</string>
+    <string name="unfinished_downloads_more_xx">and %s more</string>
     <string name="tab_next">Next</string>
     <string name="title_activity_proj_name">New project</string>
     <string name="project_name">Project name</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,6 +6,7 @@
     <string name="title_activity_cleanup">Delete</string>
     <string name="action_settings">Options</string>
     <string name="welcome_message">Welcome to HTTrack Website Copier!\n\nPlease click on the NEXT button to\n\n- start a new project\n- or resume a partial download</string>
+    <string name="unfinished_downloads_xx">Unfinished download: %s. Open the project and select \"Continue interrupted download\".</string>
     <string name="tab_next">Next</string>
     <string name="title_activity_proj_name">New project</string>
     <string name="project_name">Project name</string>

--- a/app/src/test/java/com/httrack/android/DetachedRunTest.java
+++ b/app/src/test/java/com/httrack/android/DetachedRunTest.java
@@ -10,7 +10,7 @@ import org.junit.Test;
 
 /** A crawl outlives the activity that started it, so its finish path must reach disk with no
  *  parent attached. ResumePolicyTest holds the truth tables; these read the wiring that feeds
- *  them, pinning whole argument lists because every path here is same-typed. */
+ *  them, pinning whole argument lists so a dropped, duplicated or swapped argument reds. */
 public class DetachedRunTest {
   private static String source() throws IOException {
     return TestSources
@@ -54,8 +54,9 @@ public class DetachedRunTest {
   public void aDetachedRunStillStampsItsVerdict() throws Exception {
     final String body = runnerBody(
         "private synchronized void setInterruptedProfile(final boolean interrupted)");
-    assertTrue("the marker must go to the directory the run captured",
-        body.contains("runTarget != null ? runTarget"));
+    assertTrue("a stop before the capture stamps the activity's directory rather than nothing",
+        body.replaceAll("\\s+", " ").contains("final File target = runTarget != null "
+            + "? runTarget : parent != null ? parent.getTargetFile() : null;"));
     assertFalse("a marker write through the activity cannot happen once detached",
         body.contains("parent.setInterruptedProfile"));
     assertEquals("gated on a parent, a detached run stamps nothing", 0,

--- a/app/src/test/java/com/httrack/android/DetachedRunTest.java
+++ b/app/src/test/java/com/httrack/android/DetachedRunTest.java
@@ -1,0 +1,140 @@
+package com.httrack.android;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+/** A crawl outlives the activity that started it, so its finish path must reach disk with no
+ *  parent attached. ResumePolicyTest holds the truth tables; these read the wiring that feeds
+ *  them, pinning whole argument lists because every path here is same-typed. */
+public class DetachedRunTest {
+  private static String source() throws IOException {
+    return TestSources
+        .withoutCommentsAndStrings(TestSources.javaSource("HTTrackActivity"));
+  }
+
+  /** Body of the runner's own METHOD declaration; RunnerFragment declares some of the same
+   *  names, and it is the trunk rather than the thing that acts. */
+  private static String runnerBody(final String declaration) throws IOException {
+    final String source = source();
+    final int runner = source
+        .indexOf("protected static class Runner extends AsyncTask");
+    assertTrue("no Runner class", runner != -1);
+    final String body = TestSources.balancedBlock(source, runner);
+    final int at = body.indexOf(declaration);
+    assertTrue(declaration + " is gone", at != -1);
+    return TestSources.balancedBlock(body, at);
+  }
+
+  /** Arguments of the call to NAME, whitespace collapsed. */
+  private static String callArguments(final String source, final String name) {
+    return TestSources.arguments(source, name).trim().replaceAll("\\s+", " ");
+  }
+
+  /** Brace depth of TEXT within BODY; zero means a statement of the method itself. */
+  private static int depthOf(final String body, final String text) {
+    final int at = body.indexOf(text);
+    assertTrue(text + " is gone", at != -1);
+    int depth = 0;
+    for (int i = 0; i < at; i++) {
+      if (body.charAt(i) == '{') {
+        depth++;
+      } else if (body.charAt(i) == '}') {
+        depth--;
+      }
+    }
+    return depth;
+  }
+
+  @Test
+  public void aDetachedRunStillStampsItsVerdict() throws Exception {
+    final String body = runnerBody(
+        "private synchronized void setInterruptedProfile(final boolean interrupted)");
+    assertTrue("the marker must go to the directory the run captured",
+        body.contains("runTarget != null ? runTarget"));
+    assertFalse("a marker write through the activity cannot happen once detached",
+        body.contains("parent.setInterruptedProfile"));
+    assertEquals("gated on a parent, a detached run stamps nothing", 0,
+        depthOf(body, "HTTrackActivity.setInterruptedProfile(target, interrupted)"));
+  }
+
+  @Test
+  public void aLateStopDoesNotOverwriteTheVerdict() throws Exception {
+    final String body = runnerBody("public boolean stopMirror(final boolean force)");
+    assertEquals("ended alone is set after the top index, leaving a window",
+        "ended, verdictRecorded",
+        callArguments(body, "ResumePolicy.stopWritesMarker"));
+    assertTrue("the verdict has to be latched where it is computed",
+        TestSources.between(source(), "pendingWork = leavesPendingWork",
+            "MirrorOutcome.Verdict verdict").contains("verdictRecorded = true"));
+  }
+
+  @Test
+  public void theTopIndexIsBuiltRatherThanQueued() throws Exception {
+    final String body = runnerBody("private void buildTopIndex()");
+    assertFalse("a queued build waits for an activity that adds nothing to it",
+        body.contains("pendingParentActions"));
+    assertEquals("the two paths are same-typed, so a swap compiles",
+        "appContext, runProjectRoot, runResources",
+        callArguments(body, "HTTrackActivity.buildTopIndex"));
+    assertTrue("a browse-all tap and a finishing run reach this on separate threads",
+        source().contains("protected static synchronized int buildTopIndex("));
+  }
+
+  /** Everything above reads what the run captured, so the capture has to precede the engine. */
+  @Test
+  public void theRunCapturesWhatItsFinishPathNeeds() throws Exception {
+    final String body = TestSources.between(source(), "protected void runInternal()",
+        "engine.main(cargs)");
+    for (final String field : new String[] { "runTarget =", "runProjectRoot =",
+        "runResources =" }) {
+      assertTrue(field + " is not captured before the engine runs", body.contains(field));
+    }
+  }
+
+  @Test
+  public void aNotificationTapReachesTheLiveActivity() throws Exception {
+    final String source = source();
+    final int at = source.indexOf("protected void onNewIntent(final Intent intent)");
+    assertTrue("with no onNewIntent a tap re-enters through onCreate", at != -1);
+    final String body = TestSources.balancedBlock(source, at);
+    assertEquals("runner stays non-null once a crawl ends, so it is not liveness",
+        "extras != null, hasLiveRunner()",
+        callArguments(body, "ResumePolicy.restoresIntentState"));
+    assertTrue("a refused bundle must not become the intent restartActivity() reopens",
+        depthOf(body, "setIntent(intent)") > 0);
+    assertTrue("without singleTop the tap builds a second activity",
+        TestSources.read(TestSources.mainFile("AndroidManifest.xml"))
+            .contains("android:launchMode=\"singleTop\""));
+  }
+
+  @Test
+  public void theWelcomePaneNamesAnUnfinishedProject() throws Exception {
+    final String startup = TestSources.between(source(),
+        "case R.layout.activity_startup:", "case R.layout.activity_proj_name:");
+    assertEquals("both templates are strings, so a swap compiles",
+        "getString(R.string.unfinished_downloads_xx), "
+            + "getString(R.string.unfinished_downloads_more_xx), "
+            + "getProjectRootFile(), getProjectNames()",
+        callArguments(startup, "ResumePolicy.resumeNotice"));
+    assertTrue("a project name is user-supplied and the pane renders HTML",
+        startup.contains("TextUtils.htmlEncode("));
+  }
+
+  /** resumeNotice fills a single %s, so a template with none says nothing and one with two
+   *  repeats the names. */
+  @Test
+  public void theNoticeStringsCarryOnePlaceholderEach() throws Exception {
+    final String strings = TestSources.read(TestSources.resFile("values/strings.xml"));
+    for (final String name : new String[] { "unfinished_downloads_xx",
+        "unfinished_downloads_more_xx" }) {
+      final String text = TestSources.between(strings, "name=\"" + name + "\"",
+          "</string>");
+      assertEquals(text, 1, TestSources.occurrences(text, "%s"));
+    }
+  }
+}

--- a/app/src/test/java/com/httrack/android/InterruptedLockTest.java
+++ b/app/src/test/java/com/httrack/android/InterruptedLockTest.java
@@ -116,7 +116,7 @@ public class InterruptedLockTest {
   @Test
   public void aStopAfterTheCrawlEndedIsIgnored() throws Exception {
     assertTrue("the finished pane's own stopMirror() would mark every project resumable",
-        stopMirrorBody().contains("if (!ended)"));
+        stopMirrorBody().contains("ResumePolicy.stopWritesMarker(ended,"));
   }
 
   /** The verdict belongs to the run, so it is written where the run ends. */

--- a/app/src/test/java/com/httrack/android/ResumePolicyTest.java
+++ b/app/src/test/java/com/httrack/android/ResumePolicyTest.java
@@ -75,7 +75,9 @@ public class ResumePolicyTest {
   public void nothingResumableSaysNothing() throws Exception {
     project("done", null);
     assertNull(notice("done"));
-    assertNull(ResumePolicy.resumeNotice(null, AND_MORE, root, new String[] {}));
+    project("stopped", "ours");
+    assertNull("a resumable project with no template to fill says nothing rather than throwing",
+        ResumePolicy.resumeNotice(null, AND_MORE, root, new String[] { "stopped" }));
   }
 
   /** Four unfinished projects is a plausible backlog, and their names are user-supplied. */

--- a/app/src/test/java/com/httrack/android/ResumePolicyTest.java
+++ b/app/src/test/java/com/httrack/android/ResumePolicyTest.java
@@ -7,8 +7,6 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collections;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -16,9 +14,12 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 /** Truth tables for what a crawl whose activity is gone does with its verdict, and for what a
- *  cold launch says about the project it left behind. The source-text checks below prove the
+ *  cold launch says about the project it left behind. DetachedRunTest next door proves the
  *  activity and the runner delegate here. */
 public class ResumePolicyTest {
+  private static final String TEMPLATE = "left: %s.";
+  private static final String AND_MORE = "and %s more";
+
   @Rule
   public final TemporaryFolder tmp = new TemporaryFolder();
 
@@ -41,75 +42,63 @@ public class ResumePolicyTest {
     return target;
   }
 
-  @Test
-  public void theRunsOwnDirectoryTakesTheMarker() {
-    final File run = new File("/projects/run");
-    final File attached = new File("/projects/other");
-    assertEquals("the run wrote there, whatever the activity names now", run,
-        ResumePolicy.markerDirectory(run, attached));
-    assertEquals(run, ResumePolicy.markerDirectory(run, null));
-  }
-
-  @Test
-  public void aStopBeforeTheRunClaimedADirectoryAsksTheActivity() {
-    final File attached = new File("/projects/other");
-    assertEquals(attached, ResumePolicy.markerDirectory(null, attached));
-  }
-
-  @Test
-  public void withNoDirectoryAtAllNothingIsStamped() {
-    assertNull(ResumePolicy.markerDirectory(null, null));
-  }
-
-  @Test
-  public void theTopIndexNeedsBothPaths() {
-    final File path = new File("/projects");
-    assertTrue(ResumePolicy.topIndexRunsHeadless(path, path));
-    assertFalse(ResumePolicy.topIndexRunsHeadless(null, path));
-    assertFalse(ResumePolicy.topIndexRunsHeadless(path, null));
-    assertFalse(ResumePolicy.topIndexRunsHeadless(null, null));
+  private String notice(final String... names) {
+    return ResumePolicy.resumeNotice(TEMPLATE, AND_MORE, root, names);
   }
 
   @Test
   public void bothMarkersMakeAProjectResumable() throws Exception {
     project("ours", "ours");
     project("engine", "engine");
-    assertEquals(Arrays.asList("ours", "engine"),
-        ResumePolicy.resumableProjects(root, new String[] { "ours", "engine" }));
+    assertEquals("left: ours, engine.", notice("ours", "engine"));
   }
 
   @Test
   public void aProjectThatFinishedIsNotOffered() throws Exception {
     project("done", null);
     project("stopped", "ours");
-    assertEquals(Collections.singletonList("stopped"),
-        ResumePolicy.resumableProjects(root, new String[] { "done", "stopped" }));
+    assertEquals("left: stopped.", notice("done", "stopped"));
   }
 
   /** getProjectNames() returns null when the root is missing, and a name can go away between
    *  the listing and the check. */
   @Test
-  public void nothingToListMeansNothingToOffer() throws Exception {
-    assertTrue(ResumePolicy.resumableProjects(root, null).isEmpty());
-    assertTrue(ResumePolicy.resumableProjects(null, new String[] { "gone" }).isEmpty());
-    assertTrue(ResumePolicy.resumableProjects(root, new String[] {}).isEmpty());
-    assertTrue(ResumePolicy.resumableProjects(root, new String[] { "gone", null })
-        .isEmpty());
+  public void nothingToListMeansNothingToSay() throws Exception {
+    assertNull(notice((String[]) null));
+    assertNull(notice());
+    assertNull(notice("gone", null));
+    assertNull(ResumePolicy.resumeNotice(TEMPLATE, AND_MORE, null,
+        new String[] { "gone" }));
   }
 
   @Test
-  public void theNoticeNamesEveryUnfinishedProject() {
-    assertEquals("left: one", ResumePolicy.resumeNotice("left: %s",
-        Collections.singletonList("one")));
-    assertEquals("left: one, two",
-        ResumePolicy.resumeNotice("left: %s", Arrays.asList("one", "two")));
+  public void nothingResumableSaysNothing() throws Exception {
+    project("done", null);
+    assertNull(notice("done"));
+    assertNull(ResumePolicy.resumeNotice(null, AND_MORE, root, new String[] {}));
   }
 
+  /** Four unfinished projects is a plausible backlog, and their names are user-supplied. */
   @Test
-  public void nothingUnfinishedSaysNothing() {
-    assertNull(ResumePolicy.resumeNotice("left: %s", Collections.<String> emptyList()));
-    assertNull(ResumePolicy.resumeNotice("left: %s", null));
-    assertNull(ResumePolicy.resumeNotice(null, Collections.singletonList("one")));
+  public void theNoticeNamesThreeAndCountsTheRest() throws Exception {
+    final String[] names = new String[] { "a", "b", "c", "d", "e" };
+    for (final String name : names) {
+      project(name, "ours");
+    }
+    assertEquals("left: a, b, c.", notice("a", "b", "c"));
+    assertEquals("left: a, b, c, and 1 more.", notice("a", "b", "c", "d"));
+    assertEquals("left: a, b, c, and 2 more.", notice(names));
+  }
+
+  /** A missing suffix string drops the count rather than the whole notice. */
+  @Test
+  public void theCountIsOptional() throws Exception {
+    for (final String name : new String[] { "a", "b", "c", "d" }) {
+      project(name, "ours");
+    }
+    assertEquals("left: a, b, c.",
+        ResumePolicy.resumeNotice(TEMPLATE, null, root, new String[] { "a", "b",
+            "c", "d" }));
   }
 
   @Test
@@ -122,77 +111,14 @@ public class ResumePolicyTest {
     assertFalse(ResumePolicy.restoresIntentState(false, true));
   }
 
-  private static String source() throws IOException {
-    return TestSources.withoutCommentsAndStrings(TestSources.javaSource("HTTrackActivity"));
-  }
-
-  /** Body of the runner's own METHOD declaration. */
-  private static String runnerBody(final String declaration) throws IOException {
-    final String source = source();
-    final int at = source.indexOf(declaration);
-    assertTrue(declaration + " is gone", at != -1);
-    return TestSources.balancedBlock(source, at);
-  }
-
   @Test
-  public void aDetachedRunStillStampsItsVerdict() throws Exception {
-    final String body = runnerBody(
-        "private synchronized void setInterruptedProfile(final boolean interrupted)");
-    assertTrue("the marker must go to the directory the run captured",
-        body.contains("ResumePolicy.markerDirectory(runTarget"));
-    assertFalse("a marker write through the activity cannot happen once detached",
-        body.contains("parent.setInterruptedProfile"));
-  }
-
-  @Test
-  public void theTopIndexIsBuiltRatherThanQueued() throws Exception {
-    final String body = runnerBody("private void buildTopIndex()");
-    assertFalse("a queued build waits for an activity that adds nothing to it",
-        body.contains("pendingParentActions"));
-    assertTrue(body.contains("HTTrackActivity.buildTopIndex(appContext"));
-  }
-
-  /** Everything above reads what the run captured, so the capture has to precede the engine. */
-  @Test
-  public void theRunCapturesWhatItsFinishPathNeeds() throws Exception {
-    final String body = TestSources.between(source(), "protected void runInternal()",
-        "engine.main(cargs)");
-    for (final String field : new String[] { "runTarget =", "runProjectRoot =",
-        "runResources =" }) {
-      assertTrue(field + " is not captured before the engine runs", body.contains(field));
-    }
-  }
-
-  @Test
-  public void aNotificationTapReachesTheLiveActivity() throws Exception {
-    final String source = source();
-    final int at = source.indexOf("protected void onNewIntent(final Intent intent)");
-    assertTrue("with no onNewIntent a tap re-enters through onCreate", at != -1);
-    final String body = TestSources.balancedBlock(source, at);
-    assertTrue("the tapped intent must replace the one onCreate read",
-        body.contains("setIntent(intent)"));
-    assertTrue(body.contains("ResumePolicy.restoresIntentState("));
-    assertTrue("without singleTop the tap builds a second activity",
-        TestSources.read(TestSources.mainFile("AndroidManifest.xml"))
-            .contains("android:launchMode=\"singleTop\""));
-  }
-
-  @Test
-  public void theWelcomePaneNamesAnUnfinishedProject() throws Exception {
-    final String startup = TestSources.between(source(), "case R.layout.activity_startup:",
-        "case R.layout.activity_proj_name:");
-    assertTrue(startup.contains("ResumePolicy.resumeNotice("));
-    assertTrue("a project name is user-supplied and the pane renders HTML",
-        startup.contains("TextUtils.htmlEncode("));
-  }
-
-  /** resumeNotice fills a single %s, so a template with none says nothing and one with two
-   *  repeats the names. */
-  @Test
-  public void theNoticeStringCarriesOnePlaceholder() throws Exception {
-    final String notice = TestSources.between(
-        TestSources.read(TestSources.resFile("values/strings.xml")),
-        "name=\"unfinished_downloads_xx\"", "</string>");
-    assertEquals(notice, 1, TestSources.occurrences(notice, "%s"));
+  public void onlyAStopAheadOfTheVerdictWritesTheMarker() {
+    assertTrue("nothing else has decided yet",
+        ResumePolicy.stopWritesMarker(false, false));
+    assertFalse("the run already recorded what it left behind",
+        ResumePolicy.stopWritesMarker(false, true));
+    assertFalse("the finished pane's own stop is not an interruption",
+        ResumePolicy.stopWritesMarker(true, true));
+    assertFalse(ResumePolicy.stopWritesMarker(true, false));
   }
 }

--- a/app/src/test/java/com/httrack/android/ResumePolicyTest.java
+++ b/app/src/test/java/com/httrack/android/ResumePolicyTest.java
@@ -1,0 +1,198 @@
+package com.httrack.android;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/** Truth tables for what a crawl whose activity is gone does with its verdict, and for what a
+ *  cold launch says about the project it left behind. The source-text checks below prove the
+ *  activity and the runner delegate here. */
+public class ResumePolicyTest {
+  @Rule
+  public final TemporaryFolder tmp = new TemporaryFolder();
+
+  private File root;
+
+  @Before
+  public void setUp() throws Exception {
+    root = tmp.newFolder("projects");
+  }
+
+  /** A project directory, left interrupted by "ours", by the engine's own lock, or by nothing. */
+  private File project(final String name, final String marker) throws IOException {
+    final File target = new File(root, name);
+    assertTrue(new File(target, "hts-cache").mkdirs());
+    if ("ours".equals(marker)) {
+      HTTrackActivity.setInterruptedProfile(target, true);
+    } else if ("engine".equals(marker)) {
+      assertTrue(new File(target, "hts-in_progress.lock").createNewFile());
+    }
+    return target;
+  }
+
+  @Test
+  public void theRunsOwnDirectoryTakesTheMarker() {
+    final File run = new File("/projects/run");
+    final File attached = new File("/projects/other");
+    assertEquals("the run wrote there, whatever the activity names now", run,
+        ResumePolicy.markerDirectory(run, attached));
+    assertEquals(run, ResumePolicy.markerDirectory(run, null));
+  }
+
+  @Test
+  public void aStopBeforeTheRunClaimedADirectoryAsksTheActivity() {
+    final File attached = new File("/projects/other");
+    assertEquals(attached, ResumePolicy.markerDirectory(null, attached));
+  }
+
+  @Test
+  public void withNoDirectoryAtAllNothingIsStamped() {
+    assertNull(ResumePolicy.markerDirectory(null, null));
+  }
+
+  @Test
+  public void theTopIndexNeedsBothPaths() {
+    final File path = new File("/projects");
+    assertTrue(ResumePolicy.topIndexRunsHeadless(path, path));
+    assertFalse(ResumePolicy.topIndexRunsHeadless(null, path));
+    assertFalse(ResumePolicy.topIndexRunsHeadless(path, null));
+    assertFalse(ResumePolicy.topIndexRunsHeadless(null, null));
+  }
+
+  @Test
+  public void bothMarkersMakeAProjectResumable() throws Exception {
+    project("ours", "ours");
+    project("engine", "engine");
+    assertEquals(Arrays.asList("ours", "engine"),
+        ResumePolicy.resumableProjects(root, new String[] { "ours", "engine" }));
+  }
+
+  @Test
+  public void aProjectThatFinishedIsNotOffered() throws Exception {
+    project("done", null);
+    project("stopped", "ours");
+    assertEquals(Collections.singletonList("stopped"),
+        ResumePolicy.resumableProjects(root, new String[] { "done", "stopped" }));
+  }
+
+  /** getProjectNames() returns null when the root is missing, and a name can go away between
+   *  the listing and the check. */
+  @Test
+  public void nothingToListMeansNothingToOffer() throws Exception {
+    assertTrue(ResumePolicy.resumableProjects(root, null).isEmpty());
+    assertTrue(ResumePolicy.resumableProjects(null, new String[] { "gone" }).isEmpty());
+    assertTrue(ResumePolicy.resumableProjects(root, new String[] {}).isEmpty());
+    assertTrue(ResumePolicy.resumableProjects(root, new String[] { "gone", null })
+        .isEmpty());
+  }
+
+  @Test
+  public void theNoticeNamesEveryUnfinishedProject() {
+    assertEquals("left: one", ResumePolicy.resumeNotice("left: %s",
+        Collections.singletonList("one")));
+    assertEquals("left: one, two",
+        ResumePolicy.resumeNotice("left: %s", Arrays.asList("one", "two")));
+  }
+
+  @Test
+  public void nothingUnfinishedSaysNothing() {
+    assertNull(ResumePolicy.resumeNotice("left: %s", Collections.<String> emptyList()));
+    assertNull(ResumePolicy.resumeNotice("left: %s", null));
+    assertNull(ResumePolicy.resumeNotice(null, Collections.singletonList("one")));
+  }
+
+  @Test
+  public void anIntentsStateLoadsOnlyWhenThereIsSomeAndNoCrawlToLose() {
+    assertTrue(ResumePolicy.restoresIntentState(true, false));
+    assertFalse("a launcher tap carries no project",
+        ResumePolicy.restoresIntentState(false, false));
+    assertFalse("restoring would overwrite the running crawl's settings",
+        ResumePolicy.restoresIntentState(true, true));
+    assertFalse(ResumePolicy.restoresIntentState(false, true));
+  }
+
+  private static String source() throws IOException {
+    return TestSources.withoutCommentsAndStrings(TestSources.javaSource("HTTrackActivity"));
+  }
+
+  /** Body of the runner's own METHOD declaration. */
+  private static String runnerBody(final String declaration) throws IOException {
+    final String source = source();
+    final int at = source.indexOf(declaration);
+    assertTrue(declaration + " is gone", at != -1);
+    return TestSources.balancedBlock(source, at);
+  }
+
+  @Test
+  public void aDetachedRunStillStampsItsVerdict() throws Exception {
+    final String body = runnerBody(
+        "private synchronized void setInterruptedProfile(final boolean interrupted)");
+    assertTrue("the marker must go to the directory the run captured",
+        body.contains("ResumePolicy.markerDirectory(runTarget"));
+    assertFalse("a marker write through the activity cannot happen once detached",
+        body.contains("parent.setInterruptedProfile"));
+  }
+
+  @Test
+  public void theTopIndexIsBuiltRatherThanQueued() throws Exception {
+    final String body = runnerBody("private void buildTopIndex()");
+    assertFalse("a queued build waits for an activity that adds nothing to it",
+        body.contains("pendingParentActions"));
+    assertTrue(body.contains("HTTrackActivity.buildTopIndex(appContext"));
+  }
+
+  /** Everything above reads what the run captured, so the capture has to precede the engine. */
+  @Test
+  public void theRunCapturesWhatItsFinishPathNeeds() throws Exception {
+    final String body = TestSources.between(source(), "protected void runInternal()",
+        "engine.main(cargs)");
+    for (final String field : new String[] { "runTarget =", "runProjectRoot =",
+        "runResources =" }) {
+      assertTrue(field + " is not captured before the engine runs", body.contains(field));
+    }
+  }
+
+  @Test
+  public void aNotificationTapReachesTheLiveActivity() throws Exception {
+    final String source = source();
+    final int at = source.indexOf("protected void onNewIntent(final Intent intent)");
+    assertTrue("with no onNewIntent a tap re-enters through onCreate", at != -1);
+    final String body = TestSources.balancedBlock(source, at);
+    assertTrue("the tapped intent must replace the one onCreate read",
+        body.contains("setIntent(intent)"));
+    assertTrue(body.contains("ResumePolicy.restoresIntentState("));
+    assertTrue("without singleTop the tap builds a second activity",
+        TestSources.read(TestSources.mainFile("AndroidManifest.xml"))
+            .contains("android:launchMode=\"singleTop\""));
+  }
+
+  @Test
+  public void theWelcomePaneNamesAnUnfinishedProject() throws Exception {
+    final String startup = TestSources.between(source(), "case R.layout.activity_startup:",
+        "case R.layout.activity_proj_name:");
+    assertTrue(startup.contains("ResumePolicy.resumeNotice("));
+    assertTrue("a project name is user-supplied and the pane renders HTML",
+        startup.contains("TextUtils.htmlEncode("));
+  }
+
+  /** resumeNotice fills a single %s, so a template with none says nothing and one with two
+   *  repeats the names. */
+  @Test
+  public void theNoticeStringCarriesOnePlaceholder() throws Exception {
+    final String notice = TestSources.between(
+        TestSources.read(TestSources.resFile("values/strings.xml")),
+        "name=\"unfinished_downloads_xx\"", "</string>");
+    assertEquals(notice, 1, TestSources.occurrences(notice, "%s"));
+  }
+}

--- a/app/src/test/java/com/httrack/android/TestSources.java
+++ b/app/src/test/java/com/httrack/android/TestSources.java
@@ -48,6 +48,11 @@ final class TestSources {
     return files;
   }
 
+  /** A file below src/main, such as "AndroidManifest.xml". */
+  static File mainFile(final String name) {
+    return new File(dir("src/main"), name);
+  }
+
   /** A file below res/, such as "values/strings.xml". */
   static File resFile(final String name) {
     return new File(dir("src/main/res"), name);


### PR DESCRIPTION
A crawl that ended with no activity attached recorded nothing. The marker write threw `IOException("parent has been detached")` and its caller only logged it, so the project stopped offering "Continue interrupted download". The run now captures its project directory before the engine starts. That also fixes a wrong-directory write when the user switched project mid-crawl.

A stop arriving after the run recorded its verdict overwrote it, so a drained mirror could come back offering to continue. The top index queued itself into `pendingParentActions`, which never runs unless an activity re-attaches, so a detached finish left no index.

A cold launch pointed at nothing, so the welcome pane now names up to three unfinished projects. `singleTop` and `onNewIntent` land a notification tap on the live activity, which the abort notification already needs. It also deletes the dead `paused` field.

356 tests pass. The source guards now pin each call site's full argument list, and each guard fails under its own mutation.

Part of #74, phase 1 of 4. Design: `httrack-works/issue-74-background-crawl/`.