### PR TITLE
Nothing lets the user stop the screen timing out during a copy

### DIFF
--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -87,10 +87,13 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup.LayoutParams;
+import android.view.WindowManager;
 import android.view.animation.Animation;
 import android.view.animation.AnimationUtils;
 import android.widget.ArrayAdapter;
 import android.widget.AutoCompleteTextView;
+import android.widget.CheckBox;
+import android.widget.CompoundButton;
 import android.widget.EditText;
 import android.widget.LinearLayout;
 import android.widget.ProgressBar;
@@ -149,6 +152,8 @@ public class HTTrackActivity extends FragmentActivity {
   protected static final String STORAGE_ASKED_NAME = "StorageAccessAsked";
   // The root we left on the last move: nothing is migrated, so the older projects are still there.
   protected static final String PREVIOUS_BASE_NAME = "PreviousBasePath";
+  // App-local on purpose: an engine option lands in winprofile.ini, which WinHTTrack reads.
+  protected static final String KEEP_SCREEN_ON_NAME = "KeepScreenOnWhileMirroring";
 
   // <br /> Pattern
   protected static final Pattern brHtmlPattern = Pattern.compile(Pattern
@@ -2133,6 +2138,37 @@ public class HTTrackActivity extends FragmentActivity {
   }
 
   /**
+   * Apply the screen-on option. The flag lapses by itself once this window stops being visible.
+   */
+  private void refreshKeepScreenOn() {
+    final boolean keep = ScreenOnPolicy.keepScreenOn(
+        getSharedPreferences(PREFS_NAME, 0).getBoolean(KEEP_SCREEN_ON_NAME, false),
+        pane_id == LAYOUT_MIRROR_PROGRESS, runner != null && runner.hasLiveRunner());
+    if (keep) {
+      getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+    } else {
+      getWindow().clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+    }
+  }
+
+  /**
+   * Offer the screen-on option on the progress pane, and remember the tick.
+   */
+  private void wireKeepScreenOn() {
+    final CheckBox box = CheckBox.class.cast(findViewById(R.id.checkKeepScreenOn));
+    // Set before the listener, so inflating the pane does not write the preference back.
+    box.setChecked(getSharedPreferences(PREFS_NAME, 0).getBoolean(KEEP_SCREEN_ON_NAME, false));
+    box.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+      @Override
+      public void onCheckedChanged(final CompoundButton button, final boolean checked) {
+        getSharedPreferences(PREFS_NAME, 0).edit()
+            .putBoolean(KEEP_SCREEN_ON_NAME, checked).apply();
+        refreshKeepScreenOn();
+      }
+    });
+  }
+
+  /**
    * We just entered in a new pane.
    */
   protected void onEnterNewPane() {
@@ -2269,6 +2305,7 @@ public class HTTrackActivity extends FragmentActivity {
       break;
     case R.layout.activity_mirror_progress:
       setProgressLinesInternal(new String[] { getString(R.string.starting_worker_thread) });
+      wireKeepScreenOn();
       // Asked at crawl start, not at launch.
       ensureNotificationsAreAllowed();
       startRunner();
@@ -2634,6 +2671,8 @@ public class HTTrackActivity extends FragmentActivity {
       // Post-actions
       onEnterNewPane();
     }
+    // Off the progress pane, and past the end of a crawl, the display may sleep again.
+    refreshKeepScreenOn();
   }
 
   @Override
@@ -3438,6 +3477,8 @@ public class HTTrackActivity extends FragmentActivity {
         sendSystemNotification(title, e.getMessage());
       }
     }
+    // Unconditional: the runner fragment is still live here, so a refresh would re-hold it.
+    getWindow().clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
     super.onDestroy();
     // A relaunch can be handed this very process, latch and all.
     if (NativeFaultPolicy.exitOnDestroy(isFinishing(), exitWhenDestroyed,

--- a/app/src/main/java/com/httrack/android/ScreenOnPolicy.java
+++ b/app/src/main/java/com/httrack/android/ScreenOnPolicy.java
@@ -1,0 +1,25 @@
+package com.httrack.android;
+
+/**
+ * Whether the window must stop the display from timing out. Android implements the flag as a
+ * system-owned SCREEN_BRIGHT_WAKE_LOCK, so the app holds no wake lock of its own, and the
+ * protection ends as soon as the user leaves the app. No Android type appears here, so the
+ * decision can be checked against its truth table.
+ */
+final class ScreenOnPolicy {
+  private ScreenOnPolicy() {
+  }
+
+  /**
+   * Should the display be kept awake?
+   *
+   * @param preferred      whether the user ticked the option
+   * @param onProgressPane whether the pane on screen is the one a running crawl reports on
+   * @param crawlRunning   whether a crawl is attached and has not ended
+   * @return true when the window must carry FLAG_KEEP_SCREEN_ON
+   */
+  static boolean keepScreenOn(final boolean preferred, final boolean onProgressPane,
+      final boolean crawlRunning) {
+    return preferred && onProgressPane && crawlRunning;
+  }
+}

--- a/app/src/main/res/layout/activity_mirror_progress.xml
+++ b/app/src/main/res/layout/activity_mirror_progress.xml
@@ -26,6 +26,14 @@
         android:layout_alignLeft="@+id/layout"
         android:layout_alignParentBottom="true" />
 
+    <CheckBox
+        android:id="@+id/checkKeepScreenOn"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:layout_above="@+id/divideLine"
+        android:layout_alignParentStart="true"
+        android:text="@string/keep_screen_on" />
+
     <View
         android:id="@+id/divideLine"
         style="@style/DividerLineHorizontal"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -246,6 +246,7 @@
     <string name="starting_mirror">Starting the mirror…</string>
     <string name="self_contained_conflict">The mirror cannot make a self-contained page two ways at once. Untick either \"Build a single-file MHTML archive\" (Log, index, cache) or \"Inline assets as data: URIs\" (Build).</string>
     <string name="engine_faulted">The copier engine crashed and cannot be used again until HTTrack restarts. The app closes when you leave this screen; open it again to start a new mirror.</string>
+    <string name="keep_screen_on">Keep the screen on while copying. Copying still stops when you leave HTTrack.</string>
     <string name="load_default">Load default options</string>
     <string name="save_default">Save default options</string>
     <string name="reset_default">Reset to default options</string>

--- a/app/src/test/java/com/httrack/android/KeepScreenOnTest.java
+++ b/app/src/test/java/com/httrack/android/KeepScreenOnTest.java
@@ -32,6 +32,19 @@ public class KeepScreenOnTest {
     return TestSources.balancedBlock(source, at + signature.length());
   }
 
+  /** Body of refreshKeepScreenOn, so a decoy call elsewhere in the file cannot stand in. */
+  private static String refresh() throws IOException {
+    return body(activity(), "private void refreshKeepScreenOn()");
+  }
+
+  /** BODY holds FIRST then SECOND. An absent one reads as -1, which compares as ordered. */
+  private static void assertInOrder(final String message, final String body, final String first,
+      final String second) {
+    assertTrue("no " + first, body.contains(first));
+    assertTrue("no " + second, body.contains(second));
+    assertTrue(message, body.indexOf(first) < body.indexOf(second));
+  }
+
   /** Brace depth of the first CALL inside BODY; zero means nothing conditions it. */
   private static int depthOf(final String body, final String call) {
     final int at = body.indexOf(call);
@@ -72,26 +85,29 @@ public class KeepScreenOnTest {
     // Naming the call is not enough: a constant folded into any of the three would pass that.
     assertEquals(Arrays.asList(PREF + ".getBoolean(KEEP_SCREEN_ON_NAME, false)",
         "pane_id == LAYOUT_MIRROR_PROGRESS", "runner != null && runner.hasLiveRunner()"),
-        split(TestSources.arguments(activity(), "ScreenOnPolicy.keepScreenOn")));
+        split(TestSources.arguments(refresh(), "ScreenOnPolicy.keepScreenOn")));
   }
 
   @Test
   public void theVerdictReachesTheWindowBothWays() throws IOException {
-    final String refresh = body(activity(), "private void refreshKeepScreenOn()");
+    final String refresh = refresh();
     assertTrue("the verdict must drive the window flag",
         refresh.contains("getWindow().addFlags(" + FLAG + ")"));
     assertTrue("a no must clear the flag, not merely skip setting it",
         refresh.contains("getWindow().clearFlags(" + FLAG + ")"));
-    assertTrue("the policy answer is what selects the branch",
-        refresh.indexOf("ScreenOnPolicy.keepScreenOn") < refresh.indexOf("if (keep)"));
+    assertInOrder("the policy answer is what selects the branch", refresh,
+        "ScreenOnPolicy.keepScreenOn", "if (keep)");
   }
 
   @Test
   public void everyPaneChangeReconsidersTheFlag() throws IOException {
+    final String pane = body(activity(), "private void setPane(final int position)");
     // Inside the pane_id != position block it would never fire on the way out of the crawl.
     assertEquals("the refresh must not be conditional", 0,
-        depthOf(body(activity(), "private void setPane(final int position)"),
-            "refreshKeepScreenOn()"));
+        depthOf(pane, "refreshKeepScreenOn()"));
+    // The refresh reads pane_id, so ahead of that assignment it would judge the pane being left.
+    assertInOrder("the refresh must see the pane being entered", pane, "pane_id = position;",
+        "refreshKeepScreenOn()");
   }
 
   @Test
@@ -111,11 +127,10 @@ public class KeepScreenOnTest {
     final String wire = body(activity(), "private void wireKeepScreenOn()");
     assertTrue("the tick has to outlive the pane",
         wire.contains(PREF + ".edit()") && wire.contains("putBoolean(KEEP_SCREEN_ON_NAME,"));
-    assertTrue("the box must be set before the listener, or inflating writes the preference",
-        wire.indexOf("setChecked(") < wire.indexOf("setOnCheckedChangeListener("));
-    assertTrue("a tick that changes nothing until the next pane change is not the option",
-        wire.indexOf("putBoolean(KEEP_SCREEN_ON_NAME,")
-            < wire.indexOf("refreshKeepScreenOn()"));
+    assertInOrder("the box must be set before the listener, or inflating writes the preference",
+        wire, "setChecked(", "setOnCheckedChangeListener(");
+    assertInOrder("a tick that changes nothing until the next pane change is not the option",
+        wire, "putBoolean(KEEP_SCREEN_ON_NAME,", "refreshKeepScreenOn()");
   }
 
   @Test
@@ -126,8 +141,8 @@ public class KeepScreenOnTest {
         depthOf(destroy, "getWindow().clearFlags(" + FLAG + ")"));
     assertFalse("a refresh would re-hold the flag on the way out",
         destroy.contains("refreshKeepScreenOn()"));
-    assertTrue("the window is what carries the flag, so clear it before it goes",
-        destroy.indexOf("clearFlags(" + FLAG + ")") < destroy.indexOf("super.onDestroy()"));
+    assertInOrder("the window is what carries the flag, so clear it before it goes", destroy,
+        "clearFlags(" + FLAG + ")", "super.onDestroy()");
   }
 
   @Test

--- a/app/src/test/java/com/httrack/android/KeepScreenOnTest.java
+++ b/app/src/test/java/com/httrack/android/KeepScreenOnTest.java
@@ -1,0 +1,165 @@
+package com.httrack.android;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+
+/** FLAG_KEEP_SCREEN_ON is honoured for as long as the window carries it, so one left behind
+ *  keeps the display awake over a crawl that is already over. These prove the activity asks
+ *  ScreenOnPolicy for every answer, and drops the flag on every way out. */
+public class KeepScreenOnTest {
+  private static final String KEY = "KeepScreenOnWhileMirroring";
+  private static final String FLAG = "WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON";
+  private static final String PREF = "getSharedPreferences(PREFS_NAME, 0)";
+
+  /** HTTrackActivity with comments and string literals blanked, so a commented-out call cannot
+   *  pass for one and a brace in a literal is not counted. */
+  private static String activity() throws IOException {
+    return TestSources.withoutCommentsAndStrings(TestSources.javaSource("HTTrackActivity"));
+  }
+
+  /** Body of the method whose declaration starts with SIGNATURE, braces balanced. */
+  private static String body(final String source, final String signature) {
+    final int at = source.indexOf(signature);
+    assertTrue("no " + signature.trim(), at != -1);
+    return TestSources.balancedBlock(source, at + signature.length());
+  }
+
+  /** Brace depth of the first CALL inside BODY; zero means nothing conditions it. */
+  private static int depthOf(final String body, final String call) {
+    final int at = body.indexOf(call);
+    assertTrue("no " + call, at != -1);
+    int depth = 0;
+    for (int i = 0; i < at; i++) {
+      if (body.charAt(i) == '{') {
+        depth++;
+      } else if (body.charAt(i) == '}') {
+        depth--;
+      }
+    }
+    return depth;
+  }
+
+  /** ARGUMENTS split at top-level commas, whitespace collapsed. */
+  private static List<String> split(final String arguments) {
+    final List<String> parts = new ArrayList<String>();
+    int depth = 0;
+    int from = 0;
+    for (int i = 0; i < arguments.length(); i++) {
+      final char c = arguments.charAt(i);
+      if (c == '(') {
+        depth++;
+      } else if (c == ')') {
+        depth--;
+      } else if (c == ',' && depth == 0) {
+        parts.add(arguments.substring(from, i).trim().replaceAll("\\s+", " "));
+        from = i + 1;
+      }
+    }
+    parts.add(arguments.substring(from).trim().replaceAll("\\s+", " "));
+    return parts;
+  }
+
+  @Test
+  public void thePolicyIsAskedWithTheUserChoiceThePaneAndTheCrawlInThatOrder() throws IOException {
+    // Naming the call is not enough: a constant folded into any of the three would pass that.
+    assertEquals(Arrays.asList(PREF + ".getBoolean(KEEP_SCREEN_ON_NAME, false)",
+        "pane_id == LAYOUT_MIRROR_PROGRESS", "runner != null && runner.hasLiveRunner()"),
+        split(TestSources.arguments(activity(), "ScreenOnPolicy.keepScreenOn")));
+  }
+
+  @Test
+  public void theVerdictReachesTheWindowBothWays() throws IOException {
+    final String refresh = body(activity(), "private void refreshKeepScreenOn()");
+    assertTrue("the verdict must drive the window flag",
+        refresh.contains("getWindow().addFlags(" + FLAG + ")"));
+    assertTrue("a no must clear the flag, not merely skip setting it",
+        refresh.contains("getWindow().clearFlags(" + FLAG + ")"));
+    assertTrue("the policy answer is what selects the branch",
+        refresh.indexOf("ScreenOnPolicy.keepScreenOn") < refresh.indexOf("if (keep)"));
+  }
+
+  @Test
+  public void everyPaneChangeReconsidersTheFlag() throws IOException {
+    // Inside the pane_id != position block it would never fire on the way out of the crawl.
+    assertEquals("the refresh must not be conditional", 0,
+        depthOf(body(activity(), "private void setPane(final int position)"),
+            "refreshKeepScreenOn()"));
+  }
+
+  @Test
+  public void theProgressPaneShowsTheOption() throws IOException {
+    final String pane = TestSources.between(activity(),
+        "case R.layout.activity_mirror_progress:", "break;");
+    assertTrue("nothing offers the option if the pane never wires it",
+        pane.contains("wireKeepScreenOn()"));
+    for (final File file : TestSources.layouts("activity_mirror_progress")) {
+      assertTrue(file.getName() + " has no checkKeepScreenOn",
+          TestSources.read(file).contains("android:id=\"@+id/checkKeepScreenOn\""));
+    }
+  }
+
+  @Test
+  public void tickingTheOptionPersistsItThenReappliesIt() throws IOException {
+    final String wire = body(activity(), "private void wireKeepScreenOn()");
+    assertTrue("the tick has to outlive the pane",
+        wire.contains(PREF + ".edit()") && wire.contains("putBoolean(KEEP_SCREEN_ON_NAME,"));
+    assertTrue("the box must be set before the listener, or inflating writes the preference",
+        wire.indexOf("setChecked(") < wire.indexOf("setOnCheckedChangeListener("));
+    assertTrue("a tick that changes nothing until the next pane change is not the option",
+        wire.indexOf("putBoolean(KEEP_SCREEN_ON_NAME,")
+            < wire.indexOf("refreshKeepScreenOn()"));
+  }
+
+  @Test
+  public void teardownDropsTheFlagWhateverTheCrawlIsDoing() throws IOException {
+    // The runner fragment is torn down by super.onDestroy(), so a refresh here still reads live.
+    final String destroy = body(activity(), "\n  public void onDestroy()");
+    assertEquals("the clear must not be conditional", 0,
+        depthOf(destroy, "getWindow().clearFlags(" + FLAG + ")"));
+    assertFalse("a refresh would re-hold the flag on the way out",
+        destroy.contains("refreshKeepScreenOn()"));
+    assertTrue("the window is what carries the flag, so clear it before it goes",
+        destroy.indexOf("clearFlags(" + FLAG + ")") < destroy.indexOf("super.onDestroy()"));
+  }
+
+  @Test
+  public void thePreferenceNeverReachesTheSharedProfile() throws IOException {
+    // winprofile.ini is read by WinHTTrack, which has no such window.
+    assertFalse("the key is app-local", TestSources.serializerKeys().contains(KEY));
+    final String mapper = TestSources.javaSource("OptionsMapper");
+    for (final String name : new String[] { KEY, "KEEP_SCREEN_ON_NAME", "checkKeepScreenOn" }) {
+      assertFalse(name + " must stay out of OptionsMapper", mapper.contains(name));
+    }
+  }
+
+  @Test
+  public void theKeyLivesInTheAppPreferencesNotTheOptionDefaults() throws IOException {
+    // resetDefaultPreferences() clears the option-defaults file whole, this one included.
+    assertTrue(TestSources.javaSource("HTTrackActivity")
+        .contains("String PREFS_NAME = \"HTTrackPreferences\""));
+    assertTrue(TestSources.javaSource("OptionsMapper")
+        .contains("String PREFS_NAME = \"HTTrackDefaultSettings\""));
+  }
+
+  @Test
+  public void theLabelPromisesNothingAboutTheBackground() throws IOException {
+    // The flag lapses the moment the window stops being the visible one.
+    final String strings = TestSources.read(TestSources.resFile("values/strings.xml"));
+    final int at = strings.indexOf("<string name=\"keep_screen_on\">");
+    assertTrue("no keep_screen_on string", at != -1);
+    final String label = strings.substring(at, strings.indexOf("</string>", at)).toLowerCase();
+    for (final String promise : new String[] { "background", "even when", "continues" }) {
+      assertFalse("the label must not promise " + promise, label.contains(promise));
+    }
+    assertTrue("the label has to say what stops the copy",
+        label.contains("leave") || label.contains("stops"));
+  }
+}

--- a/app/src/test/java/com/httrack/android/ScreenOnPolicyTest.java
+++ b/app/src/test/java/com/httrack/android/ScreenOnPolicyTest.java
@@ -7,35 +7,17 @@ import org.junit.Test;
 /** Truth table for the screen-on decision. The source-text tests next door prove the activity
  *  delegates here; this one proves the answers. */
 public class ScreenOnPolicyTest {
+  /** Each answer is written out rather than computed, so the table cannot agree with a change
+   *  to the expression it checks. Arguments are preferred, onProgressPane, crawlRunning. */
   @Test
   public void onlyAllThreeTogetherKeepTheDisplayAwake() {
-    for (int row = 0; row < 8; row++) {
-      final boolean preferred = (row & 4) != 0;
-      final boolean onProgressPane = (row & 2) != 0;
-      final boolean crawlRunning = (row & 1) != 0;
-      assertEquals(preferred + "/" + onProgressPane + "/" + crawlRunning,
-          preferred && onProgressPane && crawlRunning,
-          ScreenOnPolicy.keepScreenOn(preferred, onProgressPane, crawlRunning));
-    }
-  }
-
-  @Test
-  public void anUntickedOptionNeverHoldsTheDisplay() {
-    assertEquals(false, ScreenOnPolicy.keepScreenOn(false, true, true));
-  }
-
-  @Test
-  public void aCrawlThatEndedReleasesTheDisplay() {
-    assertEquals(false, ScreenOnPolicy.keepScreenOn(true, true, false));
-  }
-
-  @Test
-  public void anotherPaneReleasesTheDisplay() {
-    assertEquals(false, ScreenOnPolicy.keepScreenOn(true, false, true));
-  }
-
-  @Test
-  public void theOneCaseTheOptionExistsFor() {
-    assertEquals(true, ScreenOnPolicy.keepScreenOn(true, true, true));
+    assertEquals("no/no/no", false, ScreenOnPolicy.keepScreenOn(false, false, false));
+    assertEquals("no/no/yes", false, ScreenOnPolicy.keepScreenOn(false, false, true));
+    assertEquals("no/yes/no", false, ScreenOnPolicy.keepScreenOn(false, true, false));
+    assertEquals("no/yes/yes", false, ScreenOnPolicy.keepScreenOn(false, true, true));
+    assertEquals("yes/no/no", false, ScreenOnPolicy.keepScreenOn(true, false, false));
+    assertEquals("yes/no/yes", false, ScreenOnPolicy.keepScreenOn(true, false, true));
+    assertEquals("yes/yes/no", false, ScreenOnPolicy.keepScreenOn(true, true, false));
+    assertEquals("yes/yes/yes", true, ScreenOnPolicy.keepScreenOn(true, true, true));
   }
 }

--- a/app/src/test/java/com/httrack/android/ScreenOnPolicyTest.java
+++ b/app/src/test/java/com/httrack/android/ScreenOnPolicyTest.java
@@ -1,0 +1,41 @@
+package com.httrack.android;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+/** Truth table for the screen-on decision. The source-text tests next door prove the activity
+ *  delegates here; this one proves the answers. */
+public class ScreenOnPolicyTest {
+  @Test
+  public void onlyAllThreeTogetherKeepTheDisplayAwake() {
+    for (int row = 0; row < 8; row++) {
+      final boolean preferred = (row & 4) != 0;
+      final boolean onProgressPane = (row & 2) != 0;
+      final boolean crawlRunning = (row & 1) != 0;
+      assertEquals(preferred + "/" + onProgressPane + "/" + crawlRunning,
+          preferred && onProgressPane && crawlRunning,
+          ScreenOnPolicy.keepScreenOn(preferred, onProgressPane, crawlRunning));
+    }
+  }
+
+  @Test
+  public void anUntickedOptionNeverHoldsTheDisplay() {
+    assertEquals(false, ScreenOnPolicy.keepScreenOn(false, true, true));
+  }
+
+  @Test
+  public void aCrawlThatEndedReleasesTheDisplay() {
+    assertEquals(false, ScreenOnPolicy.keepScreenOn(true, true, false));
+  }
+
+  @Test
+  public void anotherPaneReleasesTheDisplay() {
+    assertEquals(false, ScreenOnPolicy.keepScreenOn(true, false, true));
+  }
+
+  @Test
+  public void theOneCaseTheOptionExistsFor() {
+    assertEquals(true, ScreenOnPolicy.keepScreenOn(true, true, true));
+  }
+}


### PR DESCRIPTION
Android firewalls the app's network about four minutes after the screen goes off. On API 30 and later the cached-apps freezer also kills live sockets about ten seconds after the user leaves the app. So a copy survives only while the app is in front, and the screen timeout ends it. Nothing let the user prevent that.

The progress pane now carries an opt-in checkbox. While it is ticked and a crawl runs, the window holds `FLAG_KEEP_SCREEN_ON`. That is a system-owned screen-bright wake lock, so it stays outside Play's partial-wakelock metric. The window releases it on any pane change, when the crawl ends, and in teardown.

The preference lives in `HTTrackPreferences`, not the option defaults, because "Reset to default options" clears that file and this is not an engine option.

The label promises nothing about the background, because the flag lapses as soon as the user leaves the app.

355 tests pass, and thirteen mutations each turned one red.

Part of #74, phase 4 of 4.
