### PR TITLE
Unticking the cache makes Continue re-download the whole site

### DIFF
--- a/app/src/main/java/com/httrack/android/CachePolicy.java
+++ b/app/src/main/java/com/httrack/android/CachePolicy.java
@@ -8,7 +8,7 @@ package com.httrack.android;
  */
 final class CachePolicy {
   /** Action radio index of "Continue interrupted download". */
-  static final String ACTION_CONTINUE = "0";
+  static final int ACTION_CONTINUE = 0;
 
   /** Cache checkbox value asking for no cache, which is the only one that emits anything. */
   static final String CACHE_UNTICKED = "0";
@@ -27,7 +27,14 @@ final class CachePolicy {
    */
   static boolean emitsCacheOption(final String action,
       final String cachePreference) {
-    return !ACTION_CONTINUE.equals(action)
-        && CACHE_UNTICKED.equals(cachePreference);
+    // The checkbox is compared as text because SimpleOptionFlag reads it that way.
+    return !isContinue(action) && CACHE_UNTICKED.equals(cachePreference);
+  }
+
+  /** Does the action select "Continue interrupted download"? */
+  private static boolean isContinue(final String action) {
+    // MultipleChoicesOption picks -iC1 off the parsed index, so "00" is Continue as much as "0".
+    return OptionValues.isDigits(action)
+        && OptionValues.parseInt(action, -1) == ACTION_CONTINUE;
   }
 }

--- a/app/src/main/java/com/httrack/android/CachePolicy.java
+++ b/app/src/main/java/com/httrack/android/CachePolicy.java
@@ -1,0 +1,33 @@
+package com.httrack.android;
+
+/**
+ * Whether the cache checkbox reaches the engine as -C0. The engine raises HTS_CACHE_PRIORITY on
+ * finding hts-cache/hts-in_progress.lock and only then parses -C, so a -C0 undoes the resume and
+ * re-downloads the whole site. No Android type appears here, so the decision can be checked
+ * against its truth table.
+ */
+final class CachePolicy {
+  /** Action radio index of "Continue interrupted download". */
+  static final String ACTION_CONTINUE = "0";
+
+  /** Cache checkbox value asking for no cache, which is the only one that emits anything. */
+  static final String CACHE_UNTICKED = "0";
+
+  private CachePolicy() {
+  }
+
+  /**
+   * Is the cache option emitted?
+   *
+   * @param action
+   *          the action radio value, or null when no mirror exists to continue or update
+   * @param cachePreference
+   *          the cache checkbox value
+   * @return true when -C0 must reach the engine
+   */
+  static boolean emitsCacheOption(final String action,
+      final String cachePreference) {
+    return !ACTION_CONTINUE.equals(action)
+        && CACHE_UNTICKED.equals(cachePreference);
+  }
+}

--- a/app/src/main/java/com/httrack/android/OptionsMapper.java
+++ b/app/src/main/java/com/httrack/android/OptionsMapper.java
@@ -54,6 +54,9 @@ public class OptionsMapper {
   protected static final String PREFS_NAME = "HTTrackDefaultSettings";
   protected static final String BASE_NAME = "BasePath";
 
+  /** Serialization key of the cache checkbox, which CachePolicy gates on the action. */
+  static final String CACHE_KEY = "Cache";
+
   // Fields used in serialization
   // note: names tend to match the Windows winprofile.ini version
   @SuppressWarnings("unchecked")
@@ -374,8 +377,8 @@ public class OptionsMapper {
       new Pair<String, OptionMapper>("Index", new SimpleOptionFlag("I0", true)),
       new Pair<String, OptionMapper>("WordIndex", new SimpleOptionFlag("%I")),
       new Pair<String, OptionMapper>("MailIndex", new SimpleOptionFlag("%M")),
-      /* Ticked emits nothing: the action token carries the cache mode in its
-         own digit (-iC1), and a -C here would overwrite it. */
+      /* Ticked emits nothing, and buildCommandline() drops the unticked -C0
+         when the action is Continue. See CachePolicy. */
       new Pair<String, OptionMapper>("Cache",
           new SimpleOptionFlag("C0", true)),
       new Pair<String, OptionMapper>("PrimaryScan",
@@ -2312,12 +2315,18 @@ public class OptionsMapper {
    */
   public List<String> buildCommandline() {
     final List<String> args = new ArrayList<String>();
+    final String action = getMap(R.id.radioAction);
 
     // Map all options
     for (final Pair<Integer, String> field : OptionsMapper.fieldsSerializer) {
       final String value = getMap(field.first);
       final String key = field.second;
       if (value != null) {
+        // Only here can one option see another: the table entries are blind to each other.
+        if (CACHE_KEY.equals(key)
+            && !CachePolicy.emitsCacheOption(action, value)) {
+          continue;
+        }
         final OptionMapper map = fieldsNameToMapper.get(key);
         if (map == null) {
           Log.v(getClass().getSimpleName(), "option not mapped: " + key + "="

--- a/app/src/test/java/android/util/Log.java
+++ b/app/src/test/java/android/util/Log.java
@@ -1,0 +1,48 @@
+package android.util;
+
+/** Stands in for the mockable android.jar, whose Log throws "not mocked". */
+public class Log {
+  public static int v(final String tag, final String msg) {
+    return 0;
+  }
+
+  public static int v(final String tag, final String msg, final Throwable tr) {
+    return 0;
+  }
+
+  public static int d(final String tag, final String msg) {
+    return 0;
+  }
+
+  public static int d(final String tag, final String msg, final Throwable tr) {
+    return 0;
+  }
+
+  public static int i(final String tag, final String msg) {
+    return 0;
+  }
+
+  public static int i(final String tag, final String msg, final Throwable tr) {
+    return 0;
+  }
+
+  public static int w(final String tag, final String msg) {
+    return 0;
+  }
+
+  public static int w(final String tag, final String msg, final Throwable tr) {
+    return 0;
+  }
+
+  public static int e(final String tag, final String msg) {
+    return 0;
+  }
+
+  public static int e(final String tag, final String msg, final Throwable tr) {
+    return 0;
+  }
+
+  public static String getStackTraceString(final Throwable tr) {
+    return "";
+  }
+}

--- a/app/src/test/java/android/util/Pair.java
+++ b/app/src/test/java/android/util/Pair.java
@@ -1,0 +1,16 @@
+package android.util;
+
+/** Stands in for the mockable android.jar, whose Pair constructor drops both fields. */
+public class Pair<F, S> {
+  public final F first;
+  public final S second;
+
+  public Pair(final F first, final S second) {
+    this.first = first;
+    this.second = second;
+  }
+
+  public static <A, B> Pair<A, B> create(final A a, final B b) {
+    return new Pair<A, B>(a, b);
+  }
+}

--- a/app/src/test/java/android/util/Pair.java
+++ b/app/src/test/java/android/util/Pair.java
@@ -1,5 +1,7 @@
 package android.util;
 
+import java.util.Objects;
+
 /** Stands in for the mockable android.jar, whose Pair constructor drops both fields. */
 public class Pair<F, S> {
   public final F first;
@@ -12,5 +14,28 @@ public class Pair<F, S> {
 
   public static <A, B> Pair<A, B> create(final A a, final B b) {
     return new Pair<A, B>(a, b);
+  }
+
+  /** Value equality over both fields, as the real class has. */
+  @Override
+  public boolean equals(final Object o) {
+    if (!(o instanceof Pair)) {
+      return false;
+    }
+    final Pair<?, ?> other = Pair.class.cast(o);
+    return Objects.equals(other.first, first)
+        && Objects.equals(other.second, second);
+  }
+
+  @Override
+  public int hashCode() {
+    // The real class XORs the two, so a swapped pair collides here too.
+    return (first == null ? 0 : first.hashCode())
+        ^ (second == null ? 0 : second.hashCode());
+  }
+
+  @Override
+  public String toString() {
+    return "Pair{" + String.valueOf(first) + " " + String.valueOf(second) + "}";
   }
 }

--- a/app/src/test/java/android/util/SparseArray.java
+++ b/app/src/test/java/android/util/SparseArray.java
@@ -1,0 +1,61 @@
+package android.util;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.TreeMap;
+
+/** Stands in for the mockable android.jar, whose SparseArray throws "not mocked". */
+public class SparseArray<E> implements Cloneable {
+  private final TreeMap<Integer, E> entries = new TreeMap<Integer, E>();
+
+  public SparseArray() {
+  }
+
+  public SparseArray(final int initialCapacity) {
+  }
+
+  public void put(final int key, final E value) {
+    entries.put(key, value);
+  }
+
+  public E get(final int key) {
+    return entries.get(key);
+  }
+
+  public E get(final int key, final E valueIfKeyNotFound) {
+    final E value = entries.get(key);
+    return value != null ? value : valueIfKeyNotFound;
+  }
+
+  public void delete(final int key) {
+    entries.remove(key);
+  }
+
+  public void remove(final int key) {
+    delete(key);
+  }
+
+  public void clear() {
+    entries.clear();
+  }
+
+  public int size() {
+    return entries.size();
+  }
+
+  public int keyAt(final int index) {
+    return keys().get(index);
+  }
+
+  public E valueAt(final int index) {
+    return entries.get(keyAt(index));
+  }
+
+  public int indexOfKey(final int key) {
+    return keys().indexOf(key);
+  }
+
+  private List<Integer> keys() {
+    return new ArrayList<Integer>(entries.keySet());
+  }
+}

--- a/app/src/test/java/android/util/SparseArray.java
+++ b/app/src/test/java/android/util/SparseArray.java
@@ -6,7 +6,7 @@ import java.util.TreeMap;
 
 /** Stands in for the mockable android.jar, whose SparseArray throws "not mocked". */
 public class SparseArray<E> implements Cloneable {
-  private final TreeMap<Integer, E> entries = new TreeMap<Integer, E>();
+  private TreeMap<Integer, E> entries = new TreeMap<Integer, E>();
 
   public SparseArray() {
   }
@@ -23,8 +23,8 @@ public class SparseArray<E> implements Cloneable {
   }
 
   public E get(final int key, final E valueIfKeyNotFound) {
-    final E value = entries.get(key);
-    return value != null ? value : valueIfKeyNotFound;
+    // A key held with a null value returns that null, as the real class does.
+    return entries.containsKey(key) ? entries.get(key) : valueIfKeyNotFound;
   }
 
   public void delete(final int key) {
@@ -53,6 +53,20 @@ public class SparseArray<E> implements Cloneable {
 
   public int indexOfKey(final int key) {
     return keys().indexOf(key);
+  }
+
+  /** Copies the container and shares the values, as the real clone() does. */
+  @Override
+  @SuppressWarnings("unchecked")
+  public SparseArray<E> clone() {
+    try {
+      // super.clone() so a subclass keeps its own runtime type.
+      final SparseArray<E> copy = (SparseArray<E>) super.clone();
+      copy.entries = new TreeMap<Integer, E>(entries);
+      return copy;
+    } catch (final CloneNotSupportedException cnse) {
+      throw new AssertionError(cnse);
+    }
   }
 
   private List<Integer> keys() {

--- a/app/src/test/java/com/httrack/android/AndroidStubFidelityTest.java
+++ b/app/src/test/java/com/httrack/android/AndroidStubFidelityTest.java
@@ -1,0 +1,92 @@
+package com.httrack.android;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import android.util.Pair;
+import android.util.SparseArray;
+import org.junit.Test;
+
+/** The local android.util stubs stand in for classes the mockable android.jar cannot run, so a
+ *  stub that answers differently from the real class quietly grades every test that uses it. */
+public class AndroidStubFidelityTest {
+  /** Real SparseArray keeps a DELETED sentinel apart from a stored null, so a key present with
+   *  a null value answers with that null and not with the caller's fallback. */
+  @Test
+  public void aKeyHeldWithANullValueAnswersNull() {
+    final SparseArray<String> array = new SparseArray<String>();
+    array.put(1, null);
+    assertNull("stored null, not the fallback", array.get(1, "fallback"));
+    assertEquals("absent key takes the fallback", "fallback",
+        array.get(2, "fallback"));
+    assertEquals("a present key still wins", "held",
+        newArray(3, "held").get(3, "fallback"));
+  }
+
+  @Test
+  public void cloneCopiesTheContainer() {
+    final SparseArray<String> array = newArray(1, "one");
+    final SparseArray<String> copy = array.clone();
+    array.put(2, "two");
+    assertEquals("the copy did not follow", 1, copy.size());
+    copy.put(3, "three");
+    assertEquals("and the original did not follow", 2, array.size());
+    assertSame("the values themselves are shared", array.get(1),
+        copy.get(1));
+  }
+
+  /** Object.clone() is what the real class calls, so a subclass gets back its own type. */
+  @Test
+  public void cloneKeepsTheRuntimeType() {
+    final NamedArray subclass = new NamedArray();
+    subclass.put(1, "one");
+    assertTrue("a plain SparseArray would be the wrong type",
+        subclass.clone() instanceof NamedArray);
+  }
+
+  @Test
+  public void pairComparesByValue() {
+    assertEquals("equal fields make equal pairs", Pair.create("a", "b"),
+        Pair.create("a", "b"));
+    assertFalse("a differing first", Pair.create("a", "b").equals(
+        Pair.create("z", "b")));
+    assertFalse("a differing second", Pair.create("a", "b").equals(
+        Pair.create("a", "z")));
+    assertEquals("null fields compare too", Pair.create(null, null),
+        Pair.create(null, null));
+    assertFalse("a null against a value", Pair.create("a", null).equals(
+        Pair.create("a", "b")));
+    assertFalse("a non-pair", Pair.create("a", "b").equals("a"));
+  }
+
+  @Test
+  public void pairHashesBothFields() {
+    assertEquals("equal pairs must agree", Pair.create("a", "b").hashCode(),
+        Pair.create("a", "b").hashCode());
+    // The real class XORs the two fields, so record that a swap collides.
+    assertEquals("a swap collides, as upstream", Pair.create("a", "b")
+        .hashCode(), Pair.create("b", "a").hashCode());
+    assertEquals("null fields hash as zero", 0, Pair.create(null, null)
+        .hashCode());
+  }
+
+  @Test
+  public void pairPrintsBothFields() {
+    assertEquals("Pair{a b}", Pair.create("a", "b").toString());
+    assertEquals("Pair{null null}", Pair.create(null, null).toString());
+  }
+
+  private static SparseArray<String> newArray(final int key,
+      final String value) {
+    final SparseArray<String> array = new SparseArray<String>();
+    array.put(key, value);
+    return array;
+  }
+
+  /** A subclass, as SparseArraySerializable is, so clone() has a runtime type to keep. */
+  private static class NamedArray extends SparseArray<String> {
+  }
+}

--- a/app/src/test/java/com/httrack/android/CachePolicyTest.java
+++ b/app/src/test/java/com/httrack/android/CachePolicyTest.java
@@ -58,6 +58,45 @@ public class CachePolicyTest {
         argv(UPDATE, TICKED).contains("-C0"));
   }
 
+  /** MultipleChoicesOption selects -iC1 off the parsed index, not off the spelling, and
+   *  CurrentAction also arrives from winprofile.ini and from saved preferences, so a value the
+   *  RadioGroup would never write is reachable. */
+  @Test
+  public void theActionIsReadAsAnIndexAndNotAsText() {
+    // Parse to index 0, so the engine gets -iC1 and a -C0 would undo the resume.
+    assertEquals("\"00\" is index 0", false,
+        CachePolicy.emitsCacheOption("00", UNTICKED));
+    assertEquals("\"000\" is index 0", false,
+        CachePolicy.emitsCacheOption("000", UNTICKED));
+    // Parse to index 1, which is Update, so the untick still asks for -C0.
+    assertEquals("\"01\" is index 1", true,
+        CachePolicy.emitsCacheOption("01", UNTICKED));
+    assertEquals("\"1\" is index 1", true,
+        CachePolicy.emitsCacheOption("1", UNTICKED));
+    // isDigits rejects these, so no -iC reaches the engine and there is no resume to protect.
+    assertEquals("trailing space is not digits", true,
+        CachePolicy.emitsCacheOption("0 ", UNTICKED));
+    assertEquals("empty is not digits", true,
+        CachePolicy.emitsCacheOption("", UNTICKED));
+    assertEquals("no action selected", true,
+        CachePolicy.emitsCacheOption(null, UNTICKED));
+    assertEquals("non-numeric is not digits", true,
+        CachePolicy.emitsCacheOption("zero", UNTICKED));
+    // All digits yet past int range, so parseInt yields no index and nothing is resumed.
+    assertEquals("overflowing digit run", true,
+        CachePolicy.emitsCacheOption("99999999999999999999", UNTICKED));
+    assertEquals("\"00\"/ticked", false,
+        CachePolicy.emitsCacheOption("00", TICKED));
+  }
+
+  /** The pair -iC1 with -C0 is the shipped bug, so assert against the assembled argv. */
+  @Test
+  public void aNonCanonicalContinueKeepsItsCacheMode() {
+    final List<String> cmd = argv("00", UNTICKED);
+    assertTrue("-iC1 must carry the resume", cmd.contains("-iC1"));
+    assertFalse("-C0 would overwrite it", cmd.contains("-C0"));
+  }
+
   @Test
   public void aNewProjectHonoursTheBox() {
     final List<String> cmd = argv(NEW, UNTICKED);

--- a/app/src/test/java/com/httrack/android/CachePolicyTest.java
+++ b/app/src/test/java/com/httrack/android/CachePolicyTest.java
@@ -1,0 +1,70 @@
+package com.httrack.android;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+import org.junit.Test;
+
+/** Truth table for the cache-token decision, then the same decision read off the production
+ *  option table and the real buildCommandline(). */
+public class CachePolicyTest {
+  private static final String CONTINUE = "0";
+  private static final String UPDATE = "1";
+  private static final String NEW = null;
+  private static final String TICKED = "1";
+  private static final String UNTICKED = "0";
+
+  /** Each answer is written out rather than computed, so the table cannot agree with a change
+   *  to the expression it checks. Arguments are the action radio and the cache checkbox. */
+  @Test
+  public void continueNeverEmitsTheCacheOption() {
+    assertEquals("continue/ticked", false,
+        CachePolicy.emitsCacheOption(CONTINUE, TICKED));
+    assertEquals("continue/unticked", false,
+        CachePolicy.emitsCacheOption(CONTINUE, UNTICKED));
+    assertEquals("update/ticked", false,
+        CachePolicy.emitsCacheOption(UPDATE, TICKED));
+    assertEquals("update/unticked", true,
+        CachePolicy.emitsCacheOption(UPDATE, UNTICKED));
+    assertEquals("new/ticked", false,
+        CachePolicy.emitsCacheOption(NEW, TICKED));
+    assertEquals("new/unticked", true,
+        CachePolicy.emitsCacheOption(NEW, UNTICKED));
+  }
+
+  /* The shipped mapper, driven through the shipped assembly path. */
+  private static List<String> argv(final String action, final String cache) {
+    final OptionsMapper mapper = new OptionsMapper();
+    mapper.setMap(R.id.radioAction, action);
+    mapper.setMap(R.id.checkUseCacheForUpdates, cache);
+    return mapper.buildCommandline();
+  }
+
+  @Test
+  public void continueKeepsItsCacheModeWhenTheBoxIsUnticked() {
+    final List<String> cmd = argv(CONTINUE, UNTICKED);
+    assertTrue("-iC1 must carry the resume", cmd.contains("-iC1"));
+    assertFalse("-C0 would overwrite it", cmd.contains("-C0"));
+  }
+
+  @Test
+  public void updateStillHonoursTheBox() {
+    final List<String> cmd = argv(UPDATE, UNTICKED);
+    assertTrue("-iC2 must select update", cmd.contains("-iC2"));
+    assertTrue("-C0 is what the untick asks for", cmd.contains("-C0"));
+    assertFalse("a ticked box asks for nothing",
+        argv(UPDATE, TICKED).contains("-C0"));
+  }
+
+  @Test
+  public void aNewProjectHonoursTheBox() {
+    final List<String> cmd = argv(NEW, UNTICKED);
+    assertFalse("no mirror to resume or update", cmd.contains("-iC1"));
+    assertFalse("no mirror to resume or update", cmd.contains("-iC2"));
+    assertTrue("-C0 is what the untick asks for", cmd.contains("-C0"));
+    assertFalse("a ticked box asks for nothing",
+        argv(NEW, TICKED).contains("-C0"));
+  }
+}

--- a/app/src/test/java/com/httrack/android/TestSources.java
+++ b/app/src/test/java/com/httrack/android/TestSources.java
@@ -239,8 +239,8 @@ final class TestSources {
     return keys;
   }
 
-  /** The winprofile.ini keys fieldsSerializer declares, in order. The table
-   *  pulls in R.id, which the stub android.jar cannot load. */
+  /** The winprofile.ini keys fieldsSerializer declares, in order. R.id loads fine and the
+   *  Pair stub keeps both fields, so neither one forces the scrape below any more. */
   static List<String> serializerKeys() throws IOException {
     return tableKeys("fieldsSerializer",
         "new Pair<Integer, String>\\(\\s*R\\.id\\.\\w+\\s*,\\s*\"([^\"]+)\"\\s*\\)");

--- a/app/src/test/java/com/httrack/android/WinProfileOmissionTest.java
+++ b/app/src/test/java/com/httrack/android/WinProfileOmissionTest.java
@@ -60,7 +60,8 @@ public class WinProfileOmissionTest {
     return rows;
   }
 
-  /* fieldsDefaults pulls in Pair, whose stub constructor drops both fields. */
+  /* Scraped from the source text. The Pair stub keeps both fields now, so reading
+     fieldsDefaults directly would work, and switching to it is a separate change. */
   private static Map<String, String> ourDefaults() throws IOException {
     final String source = TestSources.javaSource("OptionsMapper");
     final int from = source.indexOf("fieldsDefaults[] = new Pair[] {");


### PR DESCRIPTION
Unticking the cache checkbox emits `-C0`, which is `HTS_CACHE_NONE`. The engine raises `HTS_CACHE_PRIORITY` when it finds `hts-cache/hts-in_progress.lock`, then parses `-C` later in the same function, so `-C0` undoes that. A user who unticks the cache and chooses "Continue interrupted download" re-downloads the whole site, and nothing says so.

Continue now ignores the checkbox. Update and a new project still honour it. Xavier chose that over hiding Continue while the cache is off. The decision reads the PARSED action index, because `MultipleChoicesOption` does, so `"00"` counts as Continue too.

The suppression sits in `buildCommandline()`, the only place that sees two options at once. Table entries are blind to each other, which is the root cause of this bug class here. `SimpleOptionFlag` is untouched.

The option wiring is also testable now. Test-only stubs for `Pair`, `Log` and `SparseArray` shadow the mockable `android.jar`, whose `Pair` constructor drops both fields. So `CachePolicyTest` builds a real `OptionsMapper` and asserts on the argv production emits. Neutralising the gate reds that test alone, so it reads production wiring rather than its own copy.

378 tests pass, up from 366.