### PR TITLE
A second crawl on the same project reports a crash instead of refusing

### DIFF
--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -37,6 +37,7 @@ import java.net.NetworkInterface;
 import java.net.SocketException;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
+import java.nio.channels.OverlappingFileLockException;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.HashSet;
@@ -197,9 +198,9 @@ public class HTTrackActivity extends FragmentActivity {
   protected static final int ACTIVITY_CLEANUP = 3;
   protected static final int ACTIVITY_IMPORT_TREE = 4;
 
-  // Process unique session ID for the fragment identifier
-  protected String sessionID = "runner_task" + "_"
-      + Long.toString(System.nanoTime());
+  // Constant on purpose: a per-process tag travels through saved state and through notification
+  // extras, so a cold launch would adopt a dead process's tag.
+  protected static final String RUNNER_FRAGMENT_TAG = "runner_task";
 
   // Project path
   protected File projectPath;
@@ -259,14 +260,10 @@ public class HTTrackActivity extends FragmentActivity {
   protected String versionName;
 
   /*
-   * Mark this profile as in use.
+   * Mark this profile as in use; false when another run holds it already.
    */
-  protected static synchronized void markRunningInstance(final File profile)
-      throws IOException {
-    if (runningInstances.contains(profile.getAbsolutePath())) {
-      throw new IOException("This project is already in progress");
-    }
-    runningInstances.add(profile.getAbsolutePath());
+  protected static synchronized boolean markRunningInstance(final File profile) {
+    return runningInstances.add(profile.getAbsolutePath());
   }
 
   /*
@@ -1384,6 +1381,7 @@ public class HTTrackActivity extends FragmentActivity {
     private String string_creating_project;
     private String string_starting_mirror;
     private String string_self_contained_conflict;
+    private String string_already_in_progress;
     private String string_engine_faulted;
     private String string_mirror_finished;
 
@@ -1434,6 +1432,8 @@ public class HTTrackActivity extends FragmentActivity {
       string_starting_mirror = getParentString(R.string.starting_mirror);
       string_self_contained_conflict = getParentString(
           R.string.self_contained_conflict);
+      string_already_in_progress = getParentString(
+          R.string.mirror_already_in_progress);
       string_engine_faulted = getParentString(R.string.engine_faulted);
       string_mirror_finished = getParentString(R.string.mirror_finished);
 
@@ -1483,6 +1483,9 @@ public class HTTrackActivity extends FragmentActivity {
       RandomAccessFile outLock = null;
       FileLock lock = null;
       File profile = null;
+      // Only the run that registered the profile may deregister it, or a refused second run
+      // would release the live one's claim.
+      boolean profileMarked = false;
       // Did the engine get as far as running, and if so did it leave anything to resume?
       boolean engineRan = false;
       boolean pendingWork = true;
@@ -1514,14 +1517,21 @@ public class HTTrackActivity extends FragmentActivity {
 
         // Inter-thread locking
         profile = parent.createProfileDirectory();
-        markRunningInstance(profile);
+        profileMarked = markRunningInstance(profile);
 
         // "rw" creates winprofile.ini without emptying it, so a refused lock
         // still leaves the settings behind.
         outLock = new RandomAccessFile(profile, "rw");
-        lock = outLock.getChannel().tryLock();
-        if (lock == null) {
-          throw new IOException("This project is already in progress");
+        boolean lockOverlapped = false;
+        try {
+          lock = outLock.getChannel().tryLock();
+        } catch (final OverlappingFileLockException overlap) {
+          // A lock this JVM already holds is thrown, not returned as null.
+          lockOverlapped = true;
+        }
+        if (ProfileLockPolicy.alreadyInProgress(!profileMarked, lock == null,
+            lockOverlapped)) {
+          throw new IOException(string_already_in_progress);
         }
 
         // Args list
@@ -1595,13 +1605,19 @@ public class HTTrackActivity extends FragmentActivity {
         }
       } finally {
         // Release inter-thread lock
-        if (profile != null) {
+        if (profileMarked) {
           clearRunningInstance(profile);
         }
         // Release lock
         if (lock != null) {
           try {
             lock.release();
+          } catch (IOException io) {
+          }
+        }
+        // Closed whatever the lock did, or a refused run leaks the handle it opened.
+        if (outLock != null) {
+          try {
             outLock.close();
           } catch (IOException io) {
           }
@@ -2114,7 +2130,7 @@ public class HTTrackActivity extends FragmentActivity {
    * change with a live, non-ended runner; false after process death (fragment restored empty).
    */
   protected boolean hasLiveRunner() {
-    final Fragment f = getSupportFragmentManager().findFragmentByTag(sessionID);
+    final Fragment f = getSupportFragmentManager().findFragmentByTag(RUNNER_FRAGMENT_TAG);
     return f instanceof RunnerFragment && ((RunnerFragment) f).hasLiveRunner();
   }
 
@@ -2125,7 +2141,7 @@ public class HTTrackActivity extends FragmentActivity {
     // First attempt to reclaim a running one (orientation change)
     if (runner == null) {
       final FragmentManager fm = getSupportFragmentManager();
-      runner = (RunnerFragment) fm.findFragmentByTag(sessionID);
+      runner = (RunnerFragment) fm.findFragmentByTag(RUNNER_FRAGMENT_TAG);
       // onAttach() should be called.
     }
     // Then, create one if necessary
@@ -2133,7 +2149,7 @@ public class HTTrackActivity extends FragmentActivity {
       final FragmentManager fm = getSupportFragmentManager();
       runner = new RunnerFragment();
       runner.setParent(this);
-      fm.beginTransaction().add(runner, sessionID).commit();
+      fm.beginTransaction().add(runner, RUNNER_FRAGMENT_TAG).commit();
     }
   }
 
@@ -3232,9 +3248,6 @@ public class HTTrackActivity extends FragmentActivity {
 
     // Save settings to bundle
 
-    // Serialized session ID, used to reclain the fragment runner if any
-    outState.putString("com.httrack.android.sessionID", sessionID);
-
     // Version ID
     outState.putInt(VERSION_CODE_NAME, versionCode);
 
@@ -3364,9 +3377,6 @@ public class HTTrackActivity extends FragmentActivity {
       Log.d(getClass().getSimpleName(), "refused bundle version " + version);
       return false;
     }
-
-    // Serialized session ID
-    sessionID = savedInstanceState.getString("com.httrack.android.sessionID");
 
     // Switch pane id
     final int id = savedInstanceState.getInt(PANE_NAME);

--- a/app/src/main/java/com/httrack/android/ProfileLockPolicy.java
+++ b/app/src/main/java/com/httrack/android/ProfileLockPolicy.java
@@ -12,14 +12,16 @@ final class ProfileLockPolicy {
   /**
    * Is a mirror of this project already running?
    *
-   * @param instanceMarked whether this process already registered a run on the profile
-   * @param lockRefused    whether tryLock() returned null, so another process holds the lock
-   * @param lockOverlapped whether tryLock() threw OverlappingFileLockException, which is how it
-   *                       reports a lock held by this same JVM
+   * @param claimHeldByAnother whether markRunningInstance() returned false, so another run
+   *                           already holds the profile
+   * @param lockRefused        whether tryLock() returned null, so another process holds the lock
+   * @param lockOverlapped     whether tryLock() threw OverlappingFileLockException, which is how
+   *                           it reports a lock held by this same JVM
    * @return true when the run must report that a mirror is already in progress
    */
-  static boolean alreadyInProgress(final boolean instanceMarked, final boolean lockRefused,
+  static boolean alreadyInProgress(final boolean claimHeldByAnother, final boolean lockRefused,
       final boolean lockOverlapped) {
-    return instanceMarked || lockRefused || lockOverlapped;
+    // A symmetric OR, so no truth table can catch a caller that reads the name backwards.
+    return claimHeldByAnother || lockRefused || lockOverlapped;
   }
 }

--- a/app/src/main/java/com/httrack/android/ProfileLockPolicy.java
+++ b/app/src/main/java/com/httrack/android/ProfileLockPolicy.java
@@ -1,0 +1,25 @@
+package com.httrack.android;
+
+/**
+ * Whether a second crawl may take the project profile. Three mechanisms refuse it, and one of
+ * them throws where the others return, so a refusal read as a run failure reports a crash to the
+ * user. No Android type appears here, so the decision can be checked against its truth table.
+ */
+final class ProfileLockPolicy {
+  private ProfileLockPolicy() {
+  }
+
+  /**
+   * Is a mirror of this project already running?
+   *
+   * @param instanceMarked whether this process already registered a run on the profile
+   * @param lockRefused    whether tryLock() returned null, so another process holds the lock
+   * @param lockOverlapped whether tryLock() threw OverlappingFileLockException, which is how it
+   *                       reports a lock held by this same JVM
+   * @return true when the run must report that a mirror is already in progress
+   */
+  static boolean alreadyInProgress(final boolean instanceMarked, final boolean lockRefused,
+      final boolean lockOverlapped) {
+    return instanceMarked || lockRefused || lockOverlapped;
+  }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -247,6 +247,7 @@
     <string name="creating_project">Creating the project…</string>
     <string name="starting_mirror">Starting the mirror…</string>
     <string name="self_contained_conflict">The mirror cannot make a self-contained page two ways at once. Untick either \"Build a single-file MHTML archive\" (Log, index, cache) or \"Inline assets as data: URIs\" (Build).</string>
+    <string name="mirror_already_in_progress">A mirror is already in progress. Wait for it to finish, or stop it, before you start another one.</string>
     <string name="engine_faulted">The copier engine crashed and cannot be used again until HTTrack restarts. The app closes when you leave this screen; open it again to start a new mirror.</string>
     <string name="keep_screen_on">Keep the screen on while copying. Copying still stops when you leave HTTrack.</string>
     <string name="load_default">Load default options</string>

--- a/app/src/test/java/com/httrack/android/ProfileLockPolicyTest.java
+++ b/app/src/test/java/com/httrack/android/ProfileLockPolicyTest.java
@@ -1,0 +1,25 @@
+package com.httrack.android;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+/** Truth table for the profile-conflict decision. The source-text tests next door prove the
+ *  run asks here and passes all three refusals; this one proves the answers. */
+public class ProfileLockPolicyTest {
+  /** Each answer is written out rather than computed, so the table cannot agree with a change
+   *  to the expression it checks. Arguments are instanceMarked, lockRefused, lockOverlapped. */
+  @Test
+  public void anyOneRefusalMeansAMirrorIsAlreadyRunning() {
+    assertEquals("none", false, ProfileLockPolicy.alreadyInProgress(false, false, false));
+    assertEquals("overlapped", true, ProfileLockPolicy.alreadyInProgress(false, false, true));
+    assertEquals("refused", true, ProfileLockPolicy.alreadyInProgress(false, true, false));
+    assertEquals("refused+overlapped", true,
+        ProfileLockPolicy.alreadyInProgress(false, true, true));
+    assertEquals("marked", true, ProfileLockPolicy.alreadyInProgress(true, false, false));
+    assertEquals("marked+overlapped", true,
+        ProfileLockPolicy.alreadyInProgress(true, false, true));
+    assertEquals("marked+refused", true, ProfileLockPolicy.alreadyInProgress(true, true, false));
+    assertEquals("all three", true, ProfileLockPolicy.alreadyInProgress(true, true, true));
+  }
+}

--- a/app/src/test/java/com/httrack/android/ProfileLockPolicyTest.java
+++ b/app/src/test/java/com/httrack/android/ProfileLockPolicyTest.java
@@ -8,7 +8,8 @@ import org.junit.Test;
  *  run asks here and passes all three refusals; this one proves the answers. */
 public class ProfileLockPolicyTest {
   /** Each answer is written out rather than computed, so the table cannot agree with a change
-   *  to the expression it checks. Arguments are instanceMarked, lockRefused, lockOverlapped. */
+   *  to the expression it checks. Arguments are claimHeldByAnother, lockRefused and
+   *  lockOverlapped. A symmetric OR tables the same whichever way the first one is passed. */
   @Test
   public void anyOneRefusalMeansAMirrorIsAlreadyRunning() {
     assertEquals("none", false, ProfileLockPolicy.alreadyInProgress(false, false, false));

--- a/app/src/test/java/com/httrack/android/RunnerFragmentTagTest.java
+++ b/app/src/test/java/com/httrack/android/RunnerFragmentTagTest.java
@@ -106,11 +106,12 @@ public class RunnerFragmentTagTest {
     assertTrue("no version guard", guard != -1);
     assertTrue("the guard must refuse the bundle",
         TestSources.balancedBlock(restore, guard).contains("return false"));
-    final int first = restore.indexOf("savedInstanceState.get");
-    assertTrue("nothing reads the bundle", first != -1 && first < guard);
+    // The bare name, since an alias assigned from the bundle reads it just as well as a get.
+    final int first = restore.indexOf("savedInstanceState");
+    assertTrue("nothing touches the bundle", first != -1 && first < guard);
     assertEquals("the version must be the first thing read", first,
         restore.indexOf("savedInstanceState.getInt(VERSION_CODE_NAME)"));
-    final int next = restore.indexOf("savedInstanceState.get", first + 1);
+    final int next = restore.indexOf("savedInstanceState", first + 1);
     assertTrue("nothing else reads the bundle", next != -1);
     assertTrue("a read ahead of the guard would act on a bundle it refuses", next > guard);
   }

--- a/app/src/test/java/com/httrack/android/RunnerFragmentTagTest.java
+++ b/app/src/test/java/com/httrack/android/RunnerFragmentTagTest.java
@@ -1,0 +1,117 @@
+package com.httrack.android;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import org.junit.Test;
+
+/** The crawl fragment's tag once carried System.nanoTime(), and saveInstanceState() wrote it
+ *  into both the saved bundle and the abort notification's extras. A cold launch from that
+ *  notification therefore adopted a dead process's tag. These pin that the tag is a constant,
+ *  that no bundle carries it, and that removing its key left the other keys alone. */
+public class RunnerFragmentTagTest {
+  private static final String TAG = "RUNNER_FRAGMENT_TAG";
+  private static final String OLD_KEY = "com.httrack.android.sessionID";
+
+  /** HTTrackActivity with comments and string literals blanked, so a commented-out call cannot
+   *  pass for one and a brace in a literal is not counted. */
+  private static String activity() throws IOException {
+    return TestSources.withoutCommentsAndStrings(TestSources.javaSource("HTTrackActivity"));
+  }
+
+  /** Body of the method whose declaration starts with SIGNATURE, braces balanced. */
+  private static String body(final String source, final String signature) {
+    final int at = source.indexOf(signature);
+    assertTrue("no " + signature.trim(), at != -1);
+    return TestSources.balancedBlock(source, at + signature.length());
+  }
+
+  @Test
+  public void theTagIsAConstantWithNothingPerProcessInIt() throws IOException {
+    assertTrue("the tag must be a compile-time constant", TestSources.javaSource("HTTrackActivity")
+        .contains("protected static final String " + TAG + " = \"runner_task\";"));
+    for (final String source : new String[] { "nanoTime", "currentTimeMillis", "randomUUID",
+        "new Random" }) {
+      assertFalse("a per-process tag outlives its process: " + source,
+          TestSources.between(activity(), TAG, ";").contains(source));
+    }
+  }
+
+  @Test
+  public void everyUseOfTheTagIsAFragmentLookupOrAdd() throws IOException {
+    final String source = activity();
+    assertTrue("no lookup by tag",
+        source.contains("findFragmentByTag(" + TAG + ")"));
+    assertTrue("no add under the tag", source.contains("add(runner, " + TAG + ")"));
+    // A use that is not a tag would need per-run uniqueness, which a constant cannot give.
+    assertEquals("the tag has a use that is neither a lookup nor an add", 3,
+        TestSources.occurrences(source, TAG) - 1);
+  }
+
+  @Test
+  public void noBundleAndNoIntentCarriesTheTag() throws IOException {
+    for (final File file : TestSources.javaSources()) {
+      assertFalse(file.getName() + " still carries the old key",
+          TestSources.read(file).contains(OLD_KEY));
+    }
+    final String source = activity();
+    assertFalse("saved state must not carry the tag", body(source,
+        "protected void saveInstanceState(final Bundle outState)").contains(TAG));
+    // sendAbortNotification() puts this same bundle into the notification's extras.
+    assertFalse("a restore must not adopt a tag from a bundle", body(source,
+        "protected boolean restoreInstanceState(final Bundle savedInstanceState)")
+        .contains(TAG));
+  }
+
+  /** Body of SIGNATURE as written. The block is located on the blanked source, so a brace in a
+   *  literal cannot miscount, then sliced from the real one, which still holds the key names. */
+  private static String rawBody(final String signature) throws IOException {
+    final String blanked = activity();
+    final int at = blanked.indexOf(signature);
+    assertTrue("no " + signature.trim(), at != -1);
+    final int from = blanked.indexOf('{', at + signature.length());
+    assertTrue("no block for " + signature.trim(), from != -1);
+    int depth = 0;
+    for (int i = from; i < blanked.length(); i++) {
+      if (blanked.charAt(i) == '{') {
+        depth++;
+      } else if (blanked.charAt(i) == '}' && --depth == 0) {
+        return TestSources.javaSource("HTTrackActivity").substring(from + 1, i);
+      }
+    }
+    throw new IllegalStateException(signature.trim() + " never closes");
+  }
+
+  @Test
+  public void theOtherSavedKeysStillMakeTheRoundTrip() throws IOException {
+    final String save = rawBody("protected void saveInstanceState(final Bundle outState)");
+    final String restore = rawBody(
+        "protected boolean restoreInstanceState(final Bundle savedInstanceState)");
+    for (final String key : new String[] { "VERSION_CODE_NAME", "MAP_NAME", "PANE_NAME",
+        "com.httrack.android.loadedProjectName", "com.httrack.android.focus_id" }) {
+      assertTrue(key + " is no longer saved", save.contains(key));
+      assertTrue(key + " is no longer restored", restore.contains(key));
+    }
+  }
+
+  @Test
+  public void theVersionGuardStillDecidesBeforeAnythingIsRead() throws IOException {
+    final String restore = body(activity(),
+        "protected boolean restoreInstanceState(final Bundle savedInstanceState)");
+    // An older bundle still holds the removed key; the guard is what makes that harmless.
+    final int guard = restore.indexOf("if (version != versionCode)");
+    assertTrue("no version guard", guard != -1);
+    assertTrue("the guard must refuse the bundle",
+        TestSources.balancedBlock(restore, guard).contains("return false"));
+    final int first = restore.indexOf("savedInstanceState.get");
+    assertTrue("nothing reads the bundle", first != -1 && first < guard);
+    assertEquals("the version must be the first thing read", first,
+        restore.indexOf("savedInstanceState.getInt(VERSION_CODE_NAME)"));
+    final int next = restore.indexOf("savedInstanceState.get", first + 1);
+    assertTrue("nothing else reads the bundle", next != -1);
+    assertTrue("a read ahead of the guard would act on a bundle it refuses", next > guard);
+  }
+}

--- a/app/src/test/java/com/httrack/android/SecondCrawlTest.java
+++ b/app/src/test/java/com/httrack/android/SecondCrawlTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -123,6 +124,13 @@ public class SecondCrawlTest {
     // Naming the call is not enough: any of the three folded to a constant would pass that.
     assertEquals(Arrays.asList("!profileMarked", "lock == null", "lockOverlapped"),
         split(TestSources.arguments(runnerBody(RUN), POLICY)));
+    int mentions = 0;
+    for (final File file : TestSources.javaSources()) {
+      mentions += TestSources.occurrences(
+          TestSources.withoutCommentsAndStrings(TestSources.read(file)), "alreadyInProgress(");
+    }
+    // A second call site reading claimHeldByAnother backwards has only the name to warn it.
+    assertEquals("the policy has a caller no argument list pins", 2, mentions);
   }
 
   @Test

--- a/app/src/test/java/com/httrack/android/SecondCrawlTest.java
+++ b/app/src/test/java/com/httrack/android/SecondCrawlTest.java
@@ -1,0 +1,174 @@
+package com.httrack.android;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+
+/** Starting a crawl over a live one refuses three ways, and tryLock() reports a lock this JVM
+ *  already holds by throwing an IllegalStateException. Caught broadly, that reaches the user as
+ *  an engine crash. ProfileLockPolicyTest holds the truth table; these read the wiring that
+ *  feeds it, pinning whole argument lists so a dropped or swapped refusal reds. */
+public class SecondCrawlTest {
+  private static final String POLICY = "ProfileLockPolicy.alreadyInProgress";
+  private static final String RUN = "protected void runInternal()";
+
+  /** HTTrackActivity with comments and string literals blanked, so a commented-out call cannot
+   *  pass for one and a brace in a literal is not counted. */
+  private static String activity() throws IOException {
+    return TestSources.withoutCommentsAndStrings(TestSources.javaSource("HTTrackActivity"));
+  }
+
+  /** Body of the method whose declaration starts with SIGNATURE, braces balanced. */
+  private static String body(final String source, final String signature) {
+    final int at = source.indexOf(signature);
+    assertTrue("no " + signature.trim(), at != -1);
+    return TestSources.balancedBlock(source, at + signature.length());
+  }
+
+  /** Body of the runner's own METHOD; RunnerFragment declares some of the same names, and it is
+   *  the trunk rather than the thing that acts. */
+  private static String runnerBody(final String signature) throws IOException {
+    final String source = activity();
+    final int runner = source.indexOf("protected static class Runner extends AsyncTask");
+    assertTrue("no Runner class", runner != -1);
+    return body(TestSources.balancedBlock(source, runner), signature);
+  }
+
+  /** Block following the first TEXT inside BODY. An absent TEXT would otherwise read as offset
+   *  -1, and balancedBlock would return the top of the method instead. */
+  private static String blockAfter(final String body, final String text) {
+    final int at = body.indexOf(text);
+    assertTrue("no " + text, at != -1);
+    return TestSources.balancedBlock(body, at + text.length());
+  }
+
+  /** SOURCE with every run of whitespace collapsed to one space. */
+  private static String flat(final String source) {
+    return source.replaceAll("\\s+", " ").trim();
+  }
+
+  /** BODY holds FIRST then SECOND. An absent one reads as -1, which compares as ordered. */
+  private static void assertInOrder(final String message, final String body, final String first,
+      final String second) {
+    assertTrue("no " + first, body.contains(first));
+    assertTrue("no " + second, body.contains(second));
+    assertTrue(message, body.indexOf(first) < body.indexOf(second));
+  }
+
+  /** Brace depth of the first TEXT inside BODY; a statement of the try block reads as one. */
+  private static int depthOf(final String body, final String text) {
+    final int at = body.indexOf(text);
+    assertTrue("no " + text, at != -1);
+    int depth = 0;
+    for (int i = 0; i < at; i++) {
+      if (body.charAt(i) == '{') {
+        depth++;
+      } else if (body.charAt(i) == '}') {
+        depth--;
+      }
+    }
+    return depth;
+  }
+
+  /** ARGUMENTS split at top-level commas, whitespace collapsed. */
+  private static List<String> split(final String arguments) {
+    final List<String> parts = new ArrayList<String>();
+    int depth = 0;
+    int from = 0;
+    for (int i = 0; i < arguments.length(); i++) {
+      final char c = arguments.charAt(i);
+      if (c == '(') {
+        depth++;
+      } else if (c == ')') {
+        depth--;
+      } else if (c == ',' && depth == 0) {
+        parts.add(flat(arguments.substring(from, i)));
+        from = i + 1;
+      }
+    }
+    parts.add(flat(arguments.substring(from)));
+    return parts;
+  }
+
+  @Test
+  public void theSameJvmOverlapIsCaughtByItsOwnType() throws IOException {
+    final String run = runnerBody(RUN);
+    // OverlappingFileLockException is an IllegalStateException, so only its own name keeps it
+    // out of the catch(Throwable) that reports a crash.
+    assertTrue("tryLock must run inside a try of its own",
+        flat(run).contains("try { lock = outLock.getChannel().tryLock(); }"));
+    assertTrue("no catch of OverlappingFileLockException",
+        run.contains("catch (final OverlappingFileLockException"));
+    assertTrue("a swallowed overlap would let the run start over a locked profile",
+        body(run, "catch (final OverlappingFileLockException overlap)")
+            .contains("lockOverlapped = true"));
+  }
+
+  @Test
+  public void allThreeRefusalsReachThePolicy() throws IOException {
+    // Naming the call is not enough: any of the three folded to a constant would pass that.
+    assertEquals(Arrays.asList("!profileMarked", "lock == null", "lockOverlapped"),
+        split(TestSources.arguments(runnerBody(RUN), POLICY)));
+  }
+
+  @Test
+  public void theRefusalStopsTheRunBeforeTheEngine() throws IOException {
+    final String run = runnerBody(RUN);
+    assertEquals("the check must be a statement of the run, not a branch of something else", 1,
+        depthOf(run, POLICY));
+    assertInOrder("the overlap has to be known before the verdict", run,
+        "catch (final OverlappingFileLockException", POLICY);
+    assertInOrder("a refusal after the engine starts is two crawls, not a message", run, POLICY,
+        "engine.main(cargs)");
+    assertTrue("the refusal must throw, or the run carries on unlocked",
+        flat(blockAfter(run, POLICY)).startsWith("throw new IOException("));
+  }
+
+  @Test
+  public void theUserIsToldInTheirOwnLanguage() throws IOException {
+    assertTrue("the message must be the cached resource", runnerBody(RUN)
+        .contains("throw new IOException(string_already_in_progress)"));
+    assertEquals("the string is read once, from the parent, like every other message",
+        Arrays.asList("R.string.mirror_already_in_progress"),
+        split(TestSources.arguments(runnerBody("public synchronized void setParent("),
+            "string_already_in_progress = getParentString")));
+    // The raw source, since withoutCommentsAndStrings blanks the literal this looks for.
+    assertFalse("an English literal cannot be translated",
+        TestSources.javaSource("HTTrackActivity").contains("already in progress\""));
+    assertTrue("no mirror_already_in_progress string",
+        TestSources.read(TestSources.resFile("values/strings.xml"))
+            .contains("<string name=\"mirror_already_in_progress\">"));
+  }
+
+  @Test
+  public void onlyTheRunThatClaimedTheProfileReleasesIt() throws IOException {
+    // A refused second run releasing the claim is what lets a third attempt reach tryLock.
+    assertEquals("the claim is a yes or no, so nothing else may end the run here",
+        "return runningInstances.add(profile.getAbsolutePath());",
+        flat(body(activity(),
+            "protected static synchronized boolean markRunningInstance(final File profile)")));
+    final String run = runnerBody(RUN);
+    assertTrue("the claim has to be recorded",
+        run.contains("profileMarked = markRunningInstance(profile)"));
+    assertEquals("clearing on a refused run releases the live run's claim",
+        "clearRunningInstance(profile);",
+        flat(blockAfter(run, "if (profileMarked)")));
+  }
+
+  @Test
+  public void aRefusedRunLeavesNoOpenHandle() throws IOException {
+    // A refusal now reaches tryLock, so the close can no longer hang off holding the lock.
+    final String run = runnerBody(RUN);
+    assertEquals("the handle must be closed whatever the lock did",
+        "try { outLock.close(); } catch (IOException io) { }",
+        flat(blockAfter(run, "if (outLock != null)")));
+    assertFalse("a close inside the lock branch skips every refused run",
+        flat(blockAfter(run, "if (lock != null)")).contains("outLock.close()"));
+  }
+}

--- a/app/src/test/java/com/httrack/android/SecondCrawlTest.java
+++ b/app/src/test/java/com/httrack/android/SecondCrawlTest.java
@@ -48,6 +48,14 @@ public class SecondCrawlTest {
     return TestSources.balancedBlock(body, at + text.length());
   }
 
+  /** The run's finally block, the only place a release runs whether the run was refused or not.
+   *  Sliced rather than searched, since a release the try holds still reads as present. */
+  private static String releases(final String run) {
+    assertEquals("one finally, or the slice below takes the wrong block", 1,
+        TestSources.occurrences(run, "finally"));
+    return blockAfter(run, "finally");
+  }
+
   /** SOURCE with every run of whitespace collapsed to one space. */
   private static String flat(final String source) {
     return source.replaceAll("\\s+", " ").trim();
@@ -156,9 +164,11 @@ public class SecondCrawlTest {
     final String run = runnerBody(RUN);
     assertTrue("the claim has to be recorded",
         run.contains("profileMarked = markRunningInstance(profile)"));
+    assertEquals("an ungated second clear releases the live run's claim just the same", 1,
+        TestSources.occurrences(run, "clearRunningInstance("));
     assertEquals("clearing on a refused run releases the live run's claim",
         "clearRunningInstance(profile);",
-        flat(blockAfter(run, "if (profileMarked)")));
+        flat(blockAfter(releases(run), "if (profileMarked)")));
   }
 
   @Test
@@ -167,7 +177,7 @@ public class SecondCrawlTest {
     final String run = runnerBody(RUN);
     assertEquals("the handle must be closed whatever the lock did",
         "try { outLock.close(); } catch (IOException io) { }",
-        flat(blockAfter(run, "if (outLock != null)")));
+        flat(blockAfter(releases(run), "if (outLock != null)")));
     assertFalse("a close inside the lock branch skips every refused run",
         flat(blockAfter(run, "if (lock != null)")).contains("outLock.close()"));
   }


### PR DESCRIPTION
Starting a crawl while another holds the project's `winprofile.ini` reports an engine crash. Three mechanisms refuse a second run and disagree about how. `markRunningInstance` threw an untranslated English sentence. `tryLock` returns null when another process holds the lock, and THROWS `OverlappingFileLockException` when this JVM does. That throw is an `IllegalStateException`, so the runner's broad `catch (Throwable)` reported it as a crash.

All three now meet in `ProfileLockPolicy` and produce one localized message.

Two more bugs sat there. A refused run released the live run's claim, which made the crash reachable on a third attempt. Now only the claiming run clears it, and the handle closes whatever the lock did.

`sessionID` becomes a constant. It was per-process, went into instance state, and travelled in the abort notification, so a cold relaunch could hold a dead handle. All six uses are a fragment tag.

378 tests pass, up from 366, and sixteen mutations each turned a test red.

Part of #74, phase 3 stage 1 of 5.
