### PR TITLE
The crawl lives inside the activity, so no job can drive it

### DIFF
--- a/app/src/main/java/com/httrack/android/CrawlArgv.java
+++ b/app/src/main/java/com/httrack/android/CrawlArgv.java
@@ -1,0 +1,37 @@
+package com.httrack.android;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The command line the engine is started with. The prelude is positional: the engine counts URLs
+ * from the first argument that is not an option, so nothing may be appended after the options.
+ */
+final class CrawlArgv {
+  private CrawlArgv() {
+  }
+
+  /**
+   * Build the whole engine argv.
+   *
+   * @param ipv6Enabled
+   *          whether this device has an IPv6 address; without one the engine is pinned to IPv4
+   * @param targetPath
+   *          the mirror directory, the engine's -O argument
+   * @param options
+   *          the options the mapper emitted, appended in order
+   * @return the argv, program name first
+   */
+  static String[] build(final boolean ipv6Enabled, final String targetPath,
+      final List<String> options) {
+    final List<String> args = new ArrayList<String>();
+    args.add("httrack");
+    if (!ipv6Enabled) {
+      args.add("-@i4");
+    }
+    args.add("-O");
+    args.add(targetPath);
+    args.addAll(options);
+    return args.toArray(new String[] {});
+  }
+}

--- a/app/src/main/java/com/httrack/android/CrawlRun.java
+++ b/app/src/main/java/com/httrack/android/CrawlRun.java
@@ -1,0 +1,363 @@
+package com.httrack.android;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.channels.OverlappingFileLockException;
+import java.util.List;
+
+import android.content.Context;
+import android.text.TextUtils;
+import android.util.Log;
+
+import com.httrack.android.jni.HTTrackCallbacks;
+import com.httrack.android.jni.HTTrackLib;
+import com.httrack.android.jni.HTTrackStats;
+
+/**
+ * One mirror, from the profile lock to the resume marker. It holds no view and no activity, so
+ * whichever owner started it may go away while it runs; everything it shows the user goes through
+ * its {@link Owner}.
+ */
+final class CrawlRun implements HTTrackCallbacks {
+  /**
+   * What the crawl needs from whoever started it. Every method may be called from the crawl
+   * thread, and none of them may assume a window is on screen.
+   */
+  interface Owner {
+    /** Refuse the run when the owner cannot supply the project, as a detached activity cannot. */
+    void checkAttached() throws IOException;
+
+    /** The mirror directory, or null when no project is named. */
+    File target();
+
+    /** The directory holding every project. */
+    File projectRoot();
+
+    /** The unpacked help and template resources, for the top index. */
+    File resources();
+
+    /** Create the project and its hts-cache/, and return the winprofile.ini to lock. */
+    File createProfileDirectory() throws IOException;
+
+    /** The engine options the option map emits. */
+    List<String> options() throws IOException;
+
+    /** Write the profile through the locked channel, which stays open. */
+    void serializeProfile(FileChannel channel, File profile) throws IOException;
+
+    /** A one-line status, shown while the crawl has no statistics yet. */
+    void onProgress(String[] lines);
+
+    /** A refresh to render; never called once a hard stop was asked for. */
+    void onStats(HTTrackStats stats);
+
+    /** The crawl is over, and this is what to show. */
+    void onFinished(String message, long errorsCount, File mirrorFolder);
+  }
+
+  /** The messages the crawl itself produces, in the user's language. */
+  static final class Messages {
+    final String creatingProject;
+    final String startingMirror;
+    final String selfContainedConflict;
+    final String alreadyInProgress;
+    final String engineFaulted;
+    final String mirrorFinished;
+
+    Messages(final String creatingProject, final String startingMirror,
+        final String selfContainedConflict, final String alreadyInProgress,
+        final String engineFaulted, final String mirrorFinished) {
+      this.creatingProject = creatingProject;
+      this.startingMirror = startingMirror;
+      this.selfContainedConflict = selfContainedConflict;
+      this.alreadyInProgress = alreadyInProgress;
+      this.engineFaulted = engineFaulted;
+      this.mirrorFinished = mirrorFinished;
+    }
+  }
+
+  private final HTTrackLib engine = new HTTrackLib(this);
+  private final Owner owner;
+  // Application context, captured once and never detached, so a crash after detach() still dumps.
+  private final Context appContext;
+  private volatile Messages messages;
+  // Captured when the run starts, so its finish path needs no activity.
+  private volatile File runTarget;
+  private volatile File runProjectRoot;
+  private volatile File runResources;
+  private boolean mirrorRefresh;
+  private HTTrackStats lastStats;
+  // Set as soon as the run knows what it left behind, so a late stop cannot overwrite it.
+  private volatile boolean verdictRecorded;
+  private volatile MirrorSession.State state = MirrorSession.State.NONE;
+  private volatile boolean interrupted;
+  private volatile boolean interruptedHard;
+
+  CrawlRun(final Context appContext, final Owner owner, final Messages messages) {
+    this.appContext = appContext;
+    this.owner = owner;
+    this.messages = messages;
+  }
+
+  /** Re-read the messages, so a run started in one language answers in the current one. */
+  void setMessages(final Messages messages) {
+    this.messages = messages;
+  }
+
+  /** Advance the state, and keep the session slot in step. */
+  private void advance(final MirrorSession.Event event) {
+    state = MirrorSession.next(state, event);
+  }
+
+  MirrorSession.State state() {
+    return state;
+  }
+
+  /** Has the mirror stopped? */
+  boolean isEnded() {
+    return state == MirrorSession.State.ENDED;
+  }
+
+  /** Has the mirror been interrupted? */
+  boolean isInterrupted() {
+    return interrupted;
+  }
+
+  /**
+   * Run the mirror to its end. Absorbs its own failures, reporting each one as the message the
+   * finished pane shows.
+   */
+  void runMirror() {
+    // Rock'in!
+    String message = null;
+    // Null unless the mirror completed, leaving the finish message unlinked.
+    File mirrorFolder = null;
+    RandomAccessFile outLock = null;
+    FileLock lock = null;
+    File profile = null;
+    // Only the run that registered the profile may deregister it, or a refused second run
+    // would release the live one's claim.
+    boolean profileMarked = false;
+    // Did the engine get as far as running, and if so did it leave anything to resume?
+    boolean engineRan = false;
+    boolean pendingWork = true;
+    final MirrorSession session = MirrorSession.get();
+    session.begin(this);
+    advance(MirrorSession.Event.START);
+    try {
+      // Sanity checks
+      owner.checkAttached();
+      // A recovered fault left the engine mid-operation; only a new process clears it.
+      if (HTTrackLib.hasFaulted()) {
+        throw new IOException(messages.engineFaulted);
+      }
+      final File target = owner.target();
+      if (target == null) {
+        throw new IOException("no project name defined!");
+      }
+      runTarget = target;
+      runProjectRoot = owner.projectRoot();
+      runResources = owner.resources();
+
+      // Progress info for slow phones
+      owner.onProgress(new String[] { messages.creatingProject });
+
+      // Validate path
+      if (!HTTrackActivity.mkdirs(target)) {
+        throw new IOException("Unable to create " + target.getAbsolutePath());
+      }
+      HTTrackActivity.setFileReadWrite(target);
+
+      // Inter-thread locking
+      profile = owner.createProfileDirectory();
+      profileMarked = session.claim(profile);
+
+      // "rw" creates winprofile.ini without emptying it, so a refused lock
+      // still leaves the settings behind.
+      outLock = new RandomAccessFile(profile, "rw");
+      boolean lockOverlapped = false;
+      try {
+        lock = outLock.getChannel().tryLock();
+      } catch (final OverlappingFileLockException overlap) {
+        // A lock this JVM already holds is thrown, not returned as null.
+        lockOverlapped = true;
+      }
+      if (ProfileLockPolicy.alreadyInProgress(!profileMarked, lock == null,
+          lockOverlapped)) {
+        throw new IOException(messages.alreadyInProgress);
+      }
+
+      // Get args from mapper
+      final List<String> options = owner.options();
+      if (CommandlineTokens.hasSelfContainedConflict(options)) {
+        throw new IOException(messages.selfContainedConflict);
+      }
+
+      // Final args array
+      final String[] cargs = CrawlArgv.build(HTTrackActivity.isIPv6Enabled(),
+          target.getAbsolutePath(), options);
+      Log.v(getClass().getSimpleName(),
+          "starting engine: " + HTTrackActivity.printArray(cargs));
+
+      // Serialize settings
+      owner.serializeProfile(outLock.getChannel(), profile);
+
+      // Progress info for slow phones
+      owner.onProgress(new String[] { messages.startingMirror });
+
+      // Run engine
+      engineRan = true;
+      advance(MirrorSession.Event.ENGINE_STARTED);
+      final int code = engine.main(cargs);
+      // One reading of the engine's verdict, so the pane and the resume offer cannot disagree.
+      final MirrorOutcome.Stop stop = interrupted ? MirrorOutcome.Stop.USER
+          : engine.wasStopped() ? MirrorOutcome.Stop.ENGINE : MirrorOutcome.Stop.NONE;
+      pendingWork = HTTrackActivity.leavesPendingWork(stop != MirrorOutcome.Stop.NONE, code);
+      verdictRecorded = true;
+
+      final MirrorOutcome.Verdict verdict = MirrorOutcome.decide(code, stop,
+          engine.abortCode(), lastStats);
+      message = verdict.text();
+      if (verdict.showsFolderLink()) {
+        mirrorFolder = target;
+        message += "<br /><br />Mirror copied in <i><a href=\""
+            + HTTrackActivity.MIRROR_FOLDER_HREF + "\">"
+            + TextUtils.htmlEncode(target.getAbsolutePath()) + "</a></i>";
+      }
+
+      // Build top index
+      buildTopIndex();
+    } catch (final IOException io) {
+      // Carries user-supplied paths, and the panel renders it as HTML.
+      final String detail = io.getMessage();
+      message = TextUtils.htmlEncode(
+          detail != null ? detail : HTTrackActivity.describeCrash(io));
+    } catch (final Throwable t) {
+      // A native fault recovered by coffeecatch lands here as java.lang.Error.
+      Log.e(getClass().getSimpleName(), "crawl aborted", t);
+      HTTrackActivity.emergencyDump(appContext, t);
+      message = "<b>Error</b>: "
+          + TextUtils.htmlEncode(HTTrackActivity.describeCrash(t));
+      // Anything else here is an ordinary Java failure, which leaves the engine usable.
+      if (HTTrackLib.hasFaulted()) {
+        message += "<br /><br />" + TextUtils.htmlEncode(messages.engineFaulted);
+      }
+    } finally {
+      // Release inter-thread lock
+      if (profileMarked) {
+        session.release(profile);
+      }
+      // Release lock
+      if (lock != null) {
+        try {
+          lock.release();
+        } catch (IOException io) {
+        }
+      }
+      // Closed whatever the lock did, or a refused run leaks the handle it opened.
+      if (outLock != null) {
+        try {
+          outLock.close();
+        } catch (IOException io) {
+        }
+      }
+      // Stamp what the run actually was; a project the engine never touched keeps its marker.
+      if (engineRan) {
+        try {
+          setInterruptedProfile(pendingWork);
+        } catch (final IOException io) {
+          Log.w(getClass().getSimpleName(), "could not update the resume marker", io);
+        }
+      }
+      // Before the finished pane, whose own stopMirror() must not read as an interruption.
+      end();
+    }
+
+    // Ensure we switch to the final pane
+    final String displayMessage = messages.mirrorFinished + ": " + message;
+    final long errorsCount = lastStats != null ? lastStats.errorsCount : 0;
+    owner.onFinished(displayMessage, errorsCount, mirrorFolder);
+  }
+
+  /* Built rather than queued, since a queue leaves the mirror indexless until one attaches. */
+  private void buildTopIndex() {
+    HTTrackActivity.buildTopIndex(appContext, runProjectRoot, runResources);
+  }
+
+  /** Mark the crawl over and free the session slot; called again from the owner's own guard. */
+  void end() {
+    advance(MirrorSession.Event.END);
+    MirrorSession.get().end(this);
+  }
+
+  /* Stamped against the run's own directory, so a detached end still records its verdict. */
+  private void setInterruptedProfile(final boolean interrupted) throws IOException {
+    final File target = runTarget != null ? runTarget : owner.target();
+    if (target == null) {
+      throw new IOException("no project directory for the resume marker");
+    }
+    HTTrackActivity.setInterruptedProfile(target, interrupted);
+  }
+
+  /**
+   * Stop the mirror.
+   *
+   * @param force
+   *          true to cut the transfers short rather than let them finish
+   * @return true when the stop reached the engine
+   */
+  boolean stopMirror(final boolean force) {
+    // Set interrupted flags
+    interrupted = true;
+    if (force) {
+      interruptedHard = true;
+    }
+    advance(MirrorSession.Event.STOP);
+    // Stop engine
+    final boolean stopSent = engine.stop(force);
+    // The finished pane asks for a stop too, long after the run decided the real outcome.
+    if (ResumePolicy.stopWritesMarker(isEnded(), verdictRecorded)) {
+      try {
+        setInterruptedProfile(true);
+      } catch (final IOException io) {
+        Log.w(getClass().getSimpleName(), "could not write the resume marker", io);
+      }
+    }
+    return stopSent;
+  }
+
+  @Override
+  public void onRefresh(HTTrackStats stats) {
+    // fake first refresh for cosmetic reasons.
+    if (stats == null) {
+      if (mirrorRefresh) {
+        return;
+      }
+      mirrorRefresh = true;
+      stats = new HTTrackStats();
+    } else {
+      synchronized (this) {
+        lastStats = stats;
+      }
+    }
+
+    // Do not refresh GUI if stopped
+    if (interruptedHard) {
+      return;
+    }
+
+    owner.onStats(stats);
+  }
+
+  /**
+   * Get last statistics.
+   *
+   * @return last statistics (or @c null if none)
+   */
+  synchronized HTTrackStats getLastStats() {
+    return lastStats;
+  }
+}

--- a/app/src/main/java/com/httrack/android/CrawlRun.java
+++ b/app/src/main/java/com/httrack/android/CrawlRun.java
@@ -107,7 +107,7 @@ final class CrawlRun implements HTTrackCallbacks {
     this.messages = messages;
   }
 
-  /** Advance the state, and keep the session slot in step. */
+  /* The one place the state moves, so next() is what decides it. */
   private void advance(final MirrorSession.Event event) {
     state = MirrorSession.next(state, event);
   }
@@ -119,11 +119,6 @@ final class CrawlRun implements HTTrackCallbacks {
   /** Has the mirror stopped? */
   boolean isEnded() {
     return state == MirrorSession.State.ENDED;
-  }
-
-  /** Has the mirror been interrupted? */
-  boolean isInterrupted() {
-    return interrupted;
   }
 
   /**
@@ -145,8 +140,8 @@ final class CrawlRun implements HTTrackCallbacks {
     boolean engineRan = false;
     boolean pendingWork = true;
     final MirrorSession session = MirrorSession.get();
-    session.begin(this);
     advance(MirrorSession.Event.START);
+    session.begin(this);
     try {
       // Sanity checks
       owner.checkAttached();

--- a/app/src/main/java/com/httrack/android/CrawlRun.java
+++ b/app/src/main/java/com/httrack/android/CrawlRun.java
@@ -21,7 +21,7 @@ import com.httrack.android.jni.HTTrackStats;
  * whichever owner started it may go away while it runs; everything it shows the user goes through
  * its {@link Owner}.
  */
-final class CrawlRun implements HTTrackCallbacks {
+final class CrawlRun implements HTTrackCallbacks, MirrorSession.Crawl {
   /**
    * What the crawl needs from whoever started it. Every method may be called from the crawl
    * thread, and none of them may assume a window is on screen.
@@ -112,7 +112,8 @@ final class CrawlRun implements HTTrackCallbacks {
     state = MirrorSession.next(state, event);
   }
 
-  MirrorSession.State state() {
+  @Override
+  public MirrorSession.State state() {
     return state;
   }
 
@@ -289,7 +290,8 @@ final class CrawlRun implements HTTrackCallbacks {
   }
 
   /* Stamped against the run's own directory, so a detached end still records its verdict. */
-  private void setInterruptedProfile(final boolean interrupted) throws IOException {
+  private synchronized void setInterruptedProfile(final boolean interrupted)
+      throws IOException {
     final File target = runTarget != null ? runTarget : owner.target();
     if (target == null) {
       throw new IOException("no project directory for the resume marker");

--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -1447,10 +1447,8 @@ public class HTTrackActivity extends FragmentActivity {
     }
 
     @Override
-    public synchronized void onProgress(final String[] lines) {
-      if (parent != null) {
-        parent.setProgressLines(lines);
-      }
+    public void onProgress(final String[] lines) {
+      postProgressLines(lines);
     }
 
     @Override
@@ -1459,9 +1457,17 @@ public class HTTrackActivity extends FragmentActivity {
       synchronized (this) {
         attached = parent;
       }
-      // Rendered on the crawl thread, as it always was; only the posting hops to the main one.
-      if (attached != null) {
-        attached.renderProgress(stats);
+      if (attached == null) {
+        return;
+      }
+      // Formatted on the crawl thread, as it always was; only the posting hops to the main one.
+      postProgressLines(attached.formatProgress(stats));
+    }
+
+    /* The one way to the pane, so a detach while a refresh was being laid out drops it. */
+    private synchronized void postProgressLines(final String[] lines) {
+      if (parent != null) {
+        parent.setProgressLines(lines);
       }
     }
 
@@ -1539,12 +1545,13 @@ public class HTTrackActivity extends FragmentActivity {
   }
 
   /**
-   * Draw one engine refresh on the progress pane.
+   * Lay one engine refresh out as the progress pane's lines.
    *
    * @param stats
    *          the statistics to render, never null
+   * @return the lines to post
    */
-  void renderProgress(final HTTrackStats stats) {
+  String[] formatProgress(final HTTrackStats stats) {
     // build stats infos
     final String sep = " • ";
     final StringBuilder str = new StringBuilder();
@@ -1660,10 +1667,7 @@ public class HTTrackActivity extends FragmentActivity {
 
     // Final string
     final String message = str.toString();
-    final String[] lines = brHtmlPattern.split(message);
-
-    // Post refresh.
-    setProgressLines(lines);
+    return brHtmlPattern.split(message);
   }
 
   /**

--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -1334,7 +1334,7 @@ public class HTTrackActivity extends FragmentActivity {
 
   /**
    * Drives one CrawlRun from the retained fragment, and is the crawl's way back to a window.
-   * Every decision the crawl makes now lives in CrawlRun; what is left here is the attach.
+   * Every decision belongs to CrawlRun, so what is left here is the attach.
    */
   protected static class Runner extends AsyncTask<Void, Integer, Void>
       implements CrawlRun.Owner {
@@ -1514,7 +1514,7 @@ public class HTTrackActivity extends FragmentActivity {
     return s;
   }
 
-  /** The messages a crawl of its own produces, re-read on every attach. */
+  /** The messages the crawl produces itself, re-read on every attach. */
   CrawlRun.Messages crawlMessages() {
     return new CrawlRun.Messages(requireString(R.string.creating_project),
         requireString(R.string.starting_mirror),

--- a/app/src/main/java/com/httrack/android/HTTrackActivity.java
+++ b/app/src/main/java/com/httrack/android/HTTrackActivity.java
@@ -30,17 +30,13 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintWriter;
-import java.io.RandomAccessFile;
 import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
 import java.net.SocketException;
 import java.nio.channels.FileChannel;
-import java.nio.channels.FileLock;
-import java.nio.channels.OverlappingFileLockException;
 import java.util.ArrayList;
 import java.util.Enumeration;
-import java.util.HashSet;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Pattern;
@@ -114,7 +110,6 @@ import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentManager;
 
-import com.httrack.android.jni.HTTrackCallbacks;
 import com.httrack.android.jni.HTTrackLib;
 import com.httrack.android.jni.HTTrackStats;
 import com.httrack.android.jni.HTTrackStats.Element;
@@ -165,14 +160,11 @@ public class HTTrackActivity extends FragmentActivity {
 
   // Marks the mirror path in the finish message; the panel swaps it for a span, so it never
   // resolves as a URL.
-  private static final String MIRROR_FOLDER_HREF = "httrack:mirror-folder";
+  static final String MIRROR_FOLDER_HREF = "httrack:mirror-folder";
 
   // Channel carrying every notification we post. Never rename: the user's sound/importance
   // choices are keyed on it, and a new id silently resets them.
   protected static final String NOTIFICATION_CHANNEL_ID = "mirror";
-
-  // Running instances of HTTrack (based on winprofile.ini path)
-  protected static final HashSet<String> runningInstances = new HashSet<String>();
 
   /*
    * Build identifiers. See
@@ -253,27 +245,23 @@ public class HTTrackActivity extends FragmentActivity {
   private final WidgetDataExchange widgetDataExchange = new WidgetDataExchange(
       this);
 
+  // Progress-pane strings, cached per attach: the engine refreshes faster than getString().
+  private String string_bytes_saved;
+  private String string_links_scanned;
+  private String string_time;
+  private String string_files_written;
+  private String string_transfer_rate;
+  private String string_files_updated;
+  private String string_active_connections;
+  private String string_errors;
+  private String string_connect;
+  private String string_ready;
+
   // Project settings
   protected String version;
   protected String versionFeatures;
   protected int versionCode;
   protected String versionName;
-
-  /*
-   * Mark this profile as in use; false when another run holds it already.
-   */
-  protected static synchronized boolean markRunningInstance(final File profile) {
-    return runningInstances.add(profile.getAbsolutePath());
-  }
-
-  /*
-   * Mark this profile as not in use.
-   */
-  protected static synchronized void clearRunningInstance(final File profile) {
-    synchronized (runningInstances) {
-      runningInstances.remove(profile.getAbsolutePath());
-    }
-  }
 
   /* The public storage root when it is ours to write, else null: StoragePaths' shared root. */
   private File sharedStorageRoot() {
@@ -1141,7 +1129,7 @@ public class HTTrackActivity extends FragmentActivity {
    *          The string array
    * @return The pretty-printed value
    */
-  private static String printArray(final String[] array) {
+  static String printArray(final String[] array) {
     final StringBuilder builder = new StringBuilder();
     for (final String s : array) {
       if (builder.length() != 0) {
@@ -1345,97 +1333,39 @@ public class HTTrackActivity extends FragmentActivity {
   }
 
   /**
-   * Engine thread runner.
+   * Drives one CrawlRun from the retained fragment, and is the crawl's way back to a window.
+   * Every decision the crawl makes now lives in CrawlRun; what is left here is the attach.
    */
   protected static class Runner extends AsyncTask<Void, Integer, Void>
-      implements HTTrackCallbacks {
-    private final HTTrackLib engine = new HTTrackLib(this);
-    final private StringBuilder str = new StringBuilder();
-    private HTTrackActivity parent;
+      implements CrawlRun.Owner {
     // Application context, captured once and never detached, so a crash after detach() still dumps.
     private final Context appContext;
+    private final CrawlRun crawl;
     private final List<Runnable> pendingParentActions = new ArrayList<Runnable>();
-    // Captured when the run starts, so its finish path needs no activity.
-    private volatile File runTarget;
-    private volatile File runProjectRoot;
-    private volatile File runResources;
-    private boolean mirrorRefresh;
-    protected HTTrackStats lastStats;
-    // Set as soon as the run knows what it left behind, so a late stop cannot overwrite it.
-    private volatile boolean verdictRecorded;
-    private volatile boolean ended;
-    private volatile boolean interrupted;
-    private volatile boolean interruptedHard;
-
-    // Copy of parent strings.
-    private String string_bytes_saved;
-    private String string_links_scanned;
-    private String string_time;
-    private String string_files_written;
-    private String string_transfer_rate;
-    private String string_files_updated;
-    private String string_active_connections;
-    private String string_errors;
-    private String string_connect;
-    private String string_ready;
-    private String string_creating_project;
-    private String string_starting_mirror;
-    private String string_self_contained_conflict;
-    private String string_already_in_progress;
-    private String string_engine_faulted;
-    private String string_mirror_finished;
+    private HTTrackActivity parent;
 
     /**
      * Constructor.
-     * 
+     *
      * @param parent
      *          the parent activity.
      */
     public Runner(final HTTrackActivity parent) {
       appContext = parent.getApplicationContext();
+      crawl = new CrawlRun(appContext, this, parent.crawlMessages());
       setParent(parent);
-    }
-
-    /* Get a string from parent. */
-    private String getParentString(final int id) {
-      if (parent == null) {
-        throw new NullPointerException("parent is null");
-      }
-      final String s = parent.getString(id);
-      if (s == null) {
-        throw new NullPointerException("null string #" + id);
-      }
-      return s;
     }
 
     /**
      * Set the parent activity.
-     * 
+     *
      * @param parent
      *          the parent activity
      */
     public synchronized void setParent(final HTTrackActivity parent) {
       this.parent = parent;
-
-      // Cache localized strings
-      string_bytes_saved = getParentString(R.string.bytes_saved);
-      string_links_scanned = getParentString(R.string.links_scanned);
-      string_time = getParentString(R.string.time);
-      string_files_written = getParentString(R.string.files_written);
-      string_transfer_rate = getParentString(R.string.transfer_rate);
-      string_files_updated = getParentString(R.string.files_updated);
-      string_active_connections = getParentString(R.string.active_connections);
-      string_errors = getParentString(R.string.errors);
-      string_connect = getParentString(R.string.connect);
-      string_ready = getParentString(R.string.ready);
-      string_creating_project = getParentString(R.string.creating_project);
-      string_starting_mirror = getParentString(R.string.starting_mirror);
-      string_self_contained_conflict = getParentString(
-          R.string.self_contained_conflict);
-      string_already_in_progress = getParentString(
-          R.string.mirror_already_in_progress);
-      string_engine_faulted = getParentString(R.string.engine_faulted);
-      string_mirror_finished = getParentString(R.string.mirror_finished);
+      parent.cacheProgressStrings();
+      crawl.setMessages(parent.crawlMessages());
 
       // Execute pending actions now we are attached
       if (pendingParentActions.size() != 0) {
@@ -1464,190 +1394,81 @@ public class HTTrackActivity extends FragmentActivity {
     @Override
     protected Void doInBackground(final Void... arg0) {
       try {
-        runInternal();
+        crawl.runMirror();
       } catch (final Throwable e) {
-        // Last resort: runInternal absorbs its own failures, this only covers what comes after.
+        // Last resort: CrawlRun absorbs its own failures, this only covers what comes after.
         HTTrackActivity.emergencyDump(appContext, e);
         throw e;
       } finally {
-        ended = true;
+        crawl.end();
       }
       return null;
     }
 
-    protected void runInternal() {
-      // Rock'in!
-      String message = null;
-      // Null unless the mirror completed, leaving the finish message unlinked.
-      File mirrorFolder = null;
-      RandomAccessFile outLock = null;
-      FileLock lock = null;
-      File profile = null;
-      // Only the run that registered the profile may deregister it, or a refused second run
-      // would release the live one's claim.
-      boolean profileMarked = false;
-      // Did the engine get as far as running, and if so did it leave anything to resume?
-      boolean engineRan = false;
-      boolean pendingWork = true;
-      try {
-        // Sanity checks
-        if (parent == null) {
-          throw new IOException("no parent!");
-        }
-        // A recovered fault left the engine mid-operation; only a new process clears it.
-        if (HTTrackLib.hasFaulted()) {
-          throw new IOException(string_engine_faulted);
-        }
-        final File target = parent.getTargetFile();
-        if (target == null) {
-          throw new IOException("no project name defined!");
-        }
-        runTarget = target;
-        runProjectRoot = parent.getProjectRootFile();
-        runResources = parent.getResourceFile();
-
-        // Progress info for slow phones
-        setProgressLines(new String[] { string_creating_project });
-
-        // Validate path
-        if (!HTTrackActivity.mkdirs(target)) {
-          throw new IOException("Unable to create " + target.getAbsolutePath());
-        }
-        HTTrackActivity.setFileReadWrite(target);
-
-        // Inter-thread locking
-        profile = parent.createProfileDirectory();
-        profileMarked = markRunningInstance(profile);
-
-        // "rw" creates winprofile.ini without emptying it, so a refused lock
-        // still leaves the settings behind.
-        outLock = new RandomAccessFile(profile, "rw");
-        boolean lockOverlapped = false;
-        try {
-          lock = outLock.getChannel().tryLock();
-        } catch (final OverlappingFileLockException overlap) {
-          // A lock this JVM already holds is thrown, not returned as null.
-          lockOverlapped = true;
-        }
-        if (ProfileLockPolicy.alreadyInProgress(!profileMarked, lock == null,
-            lockOverlapped)) {
-          throw new IOException(string_already_in_progress);
-        }
-
-        // Args list
-        final List<String> args = new ArrayList<String>();
-
-        // Program name
-        args.add("httrack");
-
-        // If IPv6 is not available, do not use it.
-        if (!isIPv6Enabled()) {
-          args.add("-@i4");
-        }
-
-        // Target
-        args.add("-O");
-        args.add(target.getAbsolutePath());
-
-        // Get args from mapper
-        final List<String> options = parent.buildCommandline();
-        if (CommandlineTokens.hasSelfContainedConflict(options)) {
-          throw new IOException(string_self_contained_conflict);
-        }
-        args.addAll(options);
-
-        // Final args array
-        final String[] cargs = args.toArray(new String[] {});
-        Log.v(getClass().getSimpleName(),
-            "starting engine: " + HTTrackActivity.printArray(cargs));
-
-        // Serialize settings
-        parent.serialize(outLock.getChannel(), profile);
-
-        // Progress info for slow phones
-        setProgressLines(new String[] { string_starting_mirror });
-
-        // Run engine
-        engineRan = true;
-        final int code = engine.main(cargs);
-        // One reading of the engine's verdict, so the pane and the resume offer cannot disagree.
-        final MirrorOutcome.Stop stop = interrupted ? MirrorOutcome.Stop.USER
-            : engine.wasStopped() ? MirrorOutcome.Stop.ENGINE : MirrorOutcome.Stop.NONE;
-        pendingWork = leavesPendingWork(stop != MirrorOutcome.Stop.NONE, code);
-        verdictRecorded = true;
-
-        final MirrorOutcome.Verdict verdict = MirrorOutcome.decide(code, stop,
-            engine.abortCode(), lastStats);
-        message = verdict.text();
-        if (verdict.showsFolderLink()) {
-          mirrorFolder = target;
-          message += "<br /><br />Mirror copied in <i><a href=\""
-              + MIRROR_FOLDER_HREF + "\">"
-              + TextUtils.htmlEncode(target.getAbsolutePath()) + "</a></i>";
-        }
-
-        // Build top index
-        buildTopIndex();
-      } catch (final IOException io) {
-        // Carries user-supplied paths, and the panel renders it as HTML.
-        final String detail = io.getMessage();
-        message = TextUtils.htmlEncode(
-            detail != null ? detail : HTTrackActivity.describeCrash(io));
-      } catch (final Throwable t) {
-        // A native fault recovered by coffeecatch lands here as java.lang.Error.
-        Log.e(getClass().getSimpleName(), "crawl aborted", t);
-        HTTrackActivity.emergencyDump(appContext, t);
-        message = "<b>Error</b>: "
-            + TextUtils.htmlEncode(HTTrackActivity.describeCrash(t));
-        // Anything else here is an ordinary Java failure, which leaves the engine usable.
-        if (HTTrackLib.hasFaulted()) {
-          message += "<br /><br />" + TextUtils.htmlEncode(string_engine_faulted);
-        }
-      } finally {
-        // Release inter-thread lock
-        if (profileMarked) {
-          clearRunningInstance(profile);
-        }
-        // Release lock
-        if (lock != null) {
-          try {
-            lock.release();
-          } catch (IOException io) {
-          }
-        }
-        // Closed whatever the lock did, or a refused run leaks the handle it opened.
-        if (outLock != null) {
-          try {
-            outLock.close();
-          } catch (IOException io) {
-          }
-        }
-        // Stamp what the run actually was; a project the engine never touched keeps its marker.
-        if (engineRan) {
-          try {
-            setInterruptedProfile(pendingWork);
-          } catch (final IOException io) {
-            Log.w(getClass().getSimpleName(), "could not update the resume marker", io);
-          }
-        }
-        // Before the finished pane, whose own stopMirror() must not read as an interruption.
-        ended = true;
+    @Override
+    public synchronized void checkAttached() throws IOException {
+      if (parent == null) {
+        throw new IOException("no parent!");
       }
-
-      // Ensure we switch to the final pane
-      final String displayMessage = string_mirror_finished + ": " + message;
-      final long errorsCount = lastStats != null ? lastStats.errorsCount : 0;
-      displayFinishedPanel(displayMessage, errorsCount, mirrorFolder);
     }
 
-    /* Built rather than queued, since a queue leaves the mirror indexless until one attaches. */
-    private void buildTopIndex() {
-      HTTrackActivity.buildTopIndex(appContext, runProjectRoot, runResources);
+    @Override
+    public synchronized File target() {
+      return parent != null ? parent.getTargetFile() : null;
     }
 
-    /* Trunk to parent.displayFinishedPanel(), still queued because only a pane can show it. */
-    private synchronized void displayFinishedPanel(final String displayMessage,
-        final long errorsCount, final File mirrorFolder) {
+    @Override
+    public synchronized File projectRoot() {
+      return parent != null ? parent.getProjectRootFile() : null;
+    }
+
+    @Override
+    public synchronized File resources() {
+      return parent != null ? parent.getResourceFile() : null;
+    }
+
+    @Override
+    public synchronized File createProfileDirectory() throws IOException {
+      checkAttached();
+      return parent.createProfileDirectory();
+    }
+
+    @Override
+    public synchronized List<String> options() throws IOException {
+      checkAttached();
+      return parent.buildCommandline();
+    }
+
+    @Override
+    public synchronized void serializeProfile(final FileChannel channel, final File profile)
+        throws IOException {
+      checkAttached();
+      parent.serialize(channel, profile);
+    }
+
+    @Override
+    public synchronized void onProgress(final String[] lines) {
+      if (parent != null) {
+        parent.setProgressLines(lines);
+      }
+    }
+
+    @Override
+    public void onStats(final HTTrackStats stats) {
+      final HTTrackActivity attached;
+      synchronized (this) {
+        attached = parent;
+      }
+      // Rendered on the crawl thread, as it always was; only the posting hops to the main one.
+      if (attached != null) {
+        attached.renderProgress(stats);
+      }
+    }
+
+    /* Queued when detached, since only a pane can show the finished message. */
+    @Override
+    public synchronized void onFinished(final String displayMessage, final long errorsCount,
+        final File mirrorFolder) {
       if (parent != null) {
         parent.displayFinishedPanel(displayMessage, errorsCount, mirrorFolder);
       } else {
@@ -1660,217 +1481,189 @@ public class HTTrackActivity extends FragmentActivity {
       }
     }
 
-    /* Stamped against the run's own directory, so a detached end still records its verdict. */
-    private synchronized void setInterruptedProfile(final boolean interrupted)
-        throws IOException {
-      final File target = runTarget != null ? runTarget
-          : parent != null ? parent.getTargetFile() : null;
-      if (target == null) {
-        throw new IOException("no project directory for the resume marker");
-      }
-      HTTrackActivity.setInterruptedProfile(target, interrupted);
-    }
-
-    /*
-     * Trunk to parent.setProgressLines().
-     */
-    private synchronized void setProgressLines(final String[] lines) {
-      if (parent != null) {
-        parent.setProgressLines(lines);
-      }
-    }
-
     /**
      * Stop the mirror.
      */
     public boolean stopMirror(final boolean force) {
-      // Set interrupted flags
-      interrupted = true;
-      if (force) {
-        interruptedHard = true;
-      }
-      // Stop engine
-      final boolean stopSent = engine.stop(force);
-      // The finished pane asks for a stop too, long after the run decided the real outcome.
-      if (ResumePolicy.stopWritesMarker(ended, verdictRecorded)) {
-        try {
-          setInterruptedProfile(true);
-        } catch (final IOException io) {
-          Log.w(getClass().getSimpleName(), "could not write the resume marker", io);
-        }
-      }
-      return stopSent;
-    }
-
-    /**
-     * Has the mirror been interrupted ?
-     */
-    public boolean isInterrupted() {
-      return interrupted;
+      return crawl.stopMirror(force);
     }
 
     /**
      * Has the mirror stopped ?
      */
     public boolean isEnded() {
-      return ended;
-    }
-
-    @Override
-    public void onRefresh(HTTrackStats stats) {
-      // fake first refresh for cosmetic reasons.
-      if (stats == null) {
-        if (mirrorRefresh) {
-          return;
-        }
-        mirrorRefresh = true;
-        stats = new HTTrackStats();
-      } else {
-        synchronized (this) {
-          lastStats = stats;
-        }
-      }
-
-      // Do not refresh GUI if stopped
-      if (interruptedHard) {
-        return;
-      }
-
-      synchronized (this) {
-        if (parent == null) {
-          return;
-        }
-      }
-
-      // build stats infos
-      final String sep = " • ";
-      str.setLength(0);
-      str.append("<b>");
-      str.append(string_bytes_saved);
-      str.append("</b>: ");
-      str.append(stats.bytesWritten);
-      str.append(sep);
-      str.append("<b>");
-      str.append(string_links_scanned);
-      str.append("</b>: ");
-      str.append(stats.linksScanned);
-      str.append("/");
-      str.append(stats.linksTotal);
-      str.append(" (+");
-      str.append(stats.linksBackground);
-      str.append(")<br />");
-      /* */
-      str.append("<b>");
-      str.append(string_time);
-      str.append("</b>: ");
-      str.append(stats.elapsedTime);
-      str.append(sep);
-      str.append("<b>");
-      str.append(string_files_written);
-      str.append("</b>: ");
-      str.append(stats.filesWritten);
-      str.append(" (+");
-      str.append(stats.filesWrittenBackground);
-      str.append(")<br />");
-      /* */
-      str.append("<b>");
-      str.append(string_transfer_rate);
-      str.append("</b>: ");
-      str.append(stats.transferRate);
-      str.append(" (");
-      str.append(stats.totalTransferRate);
-      str.append(")");
-      str.append(sep);
-      str.append("<b>");
-      str.append(string_files_updated);
-      str.append("</b>: ");
-      str.append(stats.filesUpdated);
-      str.append("<br />");
-      /* */
-      str.append("<b>");
-      str.append(string_active_connections);
-      str.append("</b>: ");
-      str.append(stats.socketsCount);
-      str.append(sep);
-      str.append("<b>");
-      str.append(string_errors);
-      str.append("</b>:");
-      str.append(stats.errorsCount);
-      /* */
-      if (stats.elements != null && stats.elements.length != 0) {
-        str.append("<br />");
-        str.append("<br />");
-
-        int maxElts = 32; // limit the number of displayed items
-        for (final Element element : stats.elements) {
-          if (element == null || element.address == null
-              || element.filename == null) {
-            continue;
-          }
-          if (--maxElts == 0) {
-            break;
-          }
-
-          // URL (server-controlled: escape so markup/entities stay literal)
-          str.append("<i>");
-          str.append(TextUtils.htmlEncode(element.address));
-          str.append(TextUtils.htmlEncode(element.path));
-          str.append("</i>");
-          str.append(" → ");
-
-          // state
-          switch (element.state) {
-          case Element.STATE_CONNECTING:
-            str.append(string_connect);
-            break;
-          case Element.STATE_DNS:
-            str.append("dns");
-            break;
-          case Element.STATE_FTP:
-            str.append("ftp");
-            break;
-          case Element.STATE_READY:
-            str.append("<b>");
-            str.append(string_ready);
-            str.append("</b>");
-            break;
-          case Element.STATE_RECEIVE:
-            if (element.totalSize > 0) {
-              final long completion = (100 * element.size + element.totalSize / 2)
-                  / element.totalSize;
-              str.append(completion);
-              str.append("%");
-            } else {
-              str.append(element.size);
-              str.append("B");
-            }
-            break;
-          default:
-            str.append("???");
-            break;
-          }
-
-          // Next line
-          str.append("<br />");
-        }
-      }
-
-      // Final string
-      final String message = str.toString();
-      final String[] lines = brHtmlPattern.split(message);
-
-      // Post refresh.
-      setProgressLines(lines);
+      return crawl.isEnded();
     }
 
     /**
      * Get last statistics
-     * 
+     *
      * @return last statistics (or @c null if none)
      */
-    public synchronized HTTrackStats getLastStats() {
-      return lastStats;
+    public HTTrackStats getLastStats() {
+      return crawl.getLastStats();
     }
+  }
+
+  /* A string resource that must exist, since a null one would reach the user as "null". */
+  private String requireString(final int id) {
+    final String s = getString(id);
+    if (s == null) {
+      throw new NullPointerException("null string #" + id);
+    }
+    return s;
+  }
+
+  /** The messages a crawl of its own produces, re-read on every attach. */
+  CrawlRun.Messages crawlMessages() {
+    return new CrawlRun.Messages(requireString(R.string.creating_project),
+        requireString(R.string.starting_mirror),
+        requireString(R.string.self_contained_conflict),
+        requireString(R.string.mirror_already_in_progress),
+        requireString(R.string.engine_faulted),
+        requireString(R.string.mirror_finished));
+  }
+
+  /* Read once per attach rather than per refresh, which the engine drives faster than the UI. */
+  void cacheProgressStrings() {
+    string_bytes_saved = requireString(R.string.bytes_saved);
+    string_links_scanned = requireString(R.string.links_scanned);
+    string_time = requireString(R.string.time);
+    string_files_written = requireString(R.string.files_written);
+    string_transfer_rate = requireString(R.string.transfer_rate);
+    string_files_updated = requireString(R.string.files_updated);
+    string_active_connections = requireString(R.string.active_connections);
+    string_errors = requireString(R.string.errors);
+    string_connect = requireString(R.string.connect);
+    string_ready = requireString(R.string.ready);
+  }
+
+  /**
+   * Draw one engine refresh on the progress pane.
+   *
+   * @param stats
+   *          the statistics to render, never null
+   */
+  void renderProgress(final HTTrackStats stats) {
+    // build stats infos
+    final String sep = " • ";
+    final StringBuilder str = new StringBuilder();
+    str.append("<b>");
+    str.append(string_bytes_saved);
+    str.append("</b>: ");
+    str.append(stats.bytesWritten);
+    str.append(sep);
+    str.append("<b>");
+    str.append(string_links_scanned);
+    str.append("</b>: ");
+    str.append(stats.linksScanned);
+    str.append("/");
+    str.append(stats.linksTotal);
+    str.append(" (+");
+    str.append(stats.linksBackground);
+    str.append(")<br />");
+    /* */
+    str.append("<b>");
+    str.append(string_time);
+    str.append("</b>: ");
+    str.append(stats.elapsedTime);
+    str.append(sep);
+    str.append("<b>");
+    str.append(string_files_written);
+    str.append("</b>: ");
+    str.append(stats.filesWritten);
+    str.append(" (+");
+    str.append(stats.filesWrittenBackground);
+    str.append(")<br />");
+    /* */
+    str.append("<b>");
+    str.append(string_transfer_rate);
+    str.append("</b>: ");
+    str.append(stats.transferRate);
+    str.append(" (");
+    str.append(stats.totalTransferRate);
+    str.append(")");
+    str.append(sep);
+    str.append("<b>");
+    str.append(string_files_updated);
+    str.append("</b>: ");
+    str.append(stats.filesUpdated);
+    str.append("<br />");
+    /* */
+    str.append("<b>");
+    str.append(string_active_connections);
+    str.append("</b>: ");
+    str.append(stats.socketsCount);
+    str.append(sep);
+    str.append("<b>");
+    str.append(string_errors);
+    str.append("</b>:");
+    str.append(stats.errorsCount);
+    /* */
+    if (stats.elements != null && stats.elements.length != 0) {
+      str.append("<br />");
+      str.append("<br />");
+
+      int maxElts = 32; // limit the number of displayed items
+      for (final Element element : stats.elements) {
+        if (element == null || element.address == null
+            || element.filename == null) {
+          continue;
+        }
+        if (--maxElts == 0) {
+          break;
+        }
+
+        // URL (server-controlled: escape so markup/entities stay literal)
+        str.append("<i>");
+        str.append(TextUtils.htmlEncode(element.address));
+        str.append(TextUtils.htmlEncode(element.path));
+        str.append("</i>");
+        str.append(" → ");
+
+        // state
+        switch (element.state) {
+        case Element.STATE_CONNECTING:
+          str.append(string_connect);
+          break;
+        case Element.STATE_DNS:
+          str.append("dns");
+          break;
+        case Element.STATE_FTP:
+          str.append("ftp");
+          break;
+        case Element.STATE_READY:
+          str.append("<b>");
+          str.append(string_ready);
+          str.append("</b>");
+          break;
+        case Element.STATE_RECEIVE:
+          if (element.totalSize > 0) {
+            final long completion = (100 * element.size + element.totalSize / 2)
+                / element.totalSize;
+            str.append(completion);
+            str.append("%");
+          } else {
+            str.append(element.size);
+            str.append("B");
+          }
+          break;
+        default:
+          str.append("???");
+          break;
+        }
+
+        // Next line
+        str.append("<br />");
+      }
+    }
+
+    // Final string
+    final String message = str.toString();
+    final String[] lines = brHtmlPattern.split(message);
+
+    // Post refresh.
+    setProgressLines(lines);
   }
 
   /**
@@ -2025,7 +1818,7 @@ public class HTTrackActivity extends FragmentActivity {
   }
 
   /** Make directorie(s) if necessary. **/
-  private static boolean mkdirs(final File target) {
+  static boolean mkdirs(final File target) {
     return target.mkdirs() || target.isDirectory();
   }
 
@@ -2053,7 +1846,7 @@ public class HTTrackActivity extends FragmentActivity {
   }
 
   /** make the given file readable/writabe. **/
-  private static boolean setFileReadWrite(final File target) {
+  static boolean setFileReadWrite(final File target) {
     // return target.setReadable(true) && target.setWritable(true);
     return true;
   }

--- a/app/src/main/java/com/httrack/android/MirrorSession.java
+++ b/app/src/main/java/com/httrack/android/MirrorSession.java
@@ -1,0 +1,122 @@
+package com.httrack.android;
+
+import java.io.File;
+import java.util.HashSet;
+
+/**
+ * The one crawl this process runs, and the profiles a run holds. Whoever starts a crawl puts it
+ * in the slot, so a second starter finds it rather than taking the same project twice.
+ */
+final class MirrorSession {
+  /** How far the crawl has got. */
+  enum State {
+    NONE, STARTING, RUNNING, STOPPING, ENDED
+  }
+
+  /** What just happened to the crawl. */
+  enum Event {
+    START, ENGINE_STARTED, STOP, END
+  }
+
+  /**
+   * Where a crawl in STATE stands once EVENT has happened.
+   *
+   * @param state
+   *          the state before the event
+   * @param event
+   *          what happened
+   * @return the state after it
+   */
+  static State next(final State state, final Event event) {
+    if (state == State.ENDED) {
+      return State.ENDED;
+    }
+    switch (event) {
+    case START:
+      return state == State.NONE ? State.STARTING : state;
+    case ENGINE_STARTED:
+      return state == State.STARTING ? State.RUNNING : state;
+    case STOP:
+      return State.STOPPING;
+    default:
+      return State.ENDED;
+    }
+  }
+
+  private static final MirrorSession INSTANCE = new MirrorSession();
+
+  static MirrorSession get() {
+    return INSTANCE;
+  }
+
+  /** Profiles a run holds, keyed on the winprofile.ini path. */
+  private final HashSet<String> claims = new HashSet<String>();
+
+  /** The last crawl started, live or not; only the crawl itself clears it. */
+  private CrawlRun run;
+
+  private MirrorSession() {
+  }
+
+  /**
+   * Take the profile for this run.
+   *
+   * @param profile
+   *          the winprofile.ini of the project
+   * @return false when another run holds it already
+   */
+  synchronized boolean claim(final File profile) {
+    return claims.add(profile.getAbsolutePath());
+  }
+
+  /**
+   * Give the profile back. Only the run that claimed it may, or a refused second run releases
+   * the live one's claim.
+   *
+   * @param profile
+   *          the winprofile.ini of the project
+   */
+  synchronized void release(final File profile) {
+    claims.remove(profile.getAbsolutePath());
+  }
+
+  /**
+   * Put this crawl in the slot.
+   *
+   * @param crawl
+   *          the crawl that is starting
+   */
+  synchronized void begin(final CrawlRun crawl) {
+    run = crawl;
+  }
+
+  /**
+   * Empty the slot, unless a later crawl already took it.
+   *
+   * @param crawl
+   *          the crawl that has ended
+   */
+  synchronized void end(final CrawlRun crawl) {
+    if (run == crawl) {
+      run = null;
+    }
+  }
+
+  /**
+   * The crawl an owner may attach to.
+   *
+   * @return the crawl in the slot while it has not ended, else null
+   */
+  synchronized CrawlRun live() {
+    return run != null && run.state() != State.ENDED ? run : null;
+  }
+
+  /**
+   * How far the crawl in the slot has got.
+   *
+   * @return its state, or NONE when the slot is empty
+   */
+  synchronized State state() {
+    return run != null ? run.state() : State.NONE;
+  }
+}

--- a/app/src/main/java/com/httrack/android/MirrorSession.java
+++ b/app/src/main/java/com/httrack/android/MirrorSession.java
@@ -18,6 +18,12 @@ final class MirrorSession {
     START, ENGINE_STARTED, STOP, END
   }
 
+  /** What the session needs of the crawl in its slot. */
+  interface Crawl {
+    /** How far this crawl has got. */
+    State state();
+  }
+
   /**
    * Where a crawl in STATE stands once EVENT has happened.
    *
@@ -53,7 +59,7 @@ final class MirrorSession {
   private final HashSet<String> claims = new HashSet<String>();
 
   /** The last crawl started, live or not; only the crawl itself clears it. */
-  private CrawlRun run;
+  private Crawl run;
 
   private MirrorSession() {
   }
@@ -86,7 +92,7 @@ final class MirrorSession {
    * @param crawl
    *          the crawl that is starting
    */
-  synchronized void begin(final CrawlRun crawl) {
+  synchronized void begin(final Crawl crawl) {
     run = crawl;
   }
 
@@ -96,7 +102,7 @@ final class MirrorSession {
    * @param crawl
    *          the crawl that has ended
    */
-  synchronized void end(final CrawlRun crawl) {
+  synchronized void end(final Crawl crawl) {
     if (run == crawl) {
       run = null;
     }
@@ -107,16 +113,7 @@ final class MirrorSession {
    *
    * @return the crawl in the slot while it has not ended, else null
    */
-  synchronized CrawlRun live() {
+  synchronized Crawl live() {
     return run != null && run.state() != State.ENDED ? run : null;
-  }
-
-  /**
-   * How far the crawl in the slot has got.
-   *
-   * @return its state, or NONE when the slot is empty
-   */
-  synchronized State state() {
-    return run != null ? run.state() : State.NONE;
   }
 }

--- a/app/src/main/java/com/httrack/android/MirrorSession.java
+++ b/app/src/main/java/com/httrack/android/MirrorSession.java
@@ -109,7 +109,8 @@ final class MirrorSession {
   }
 
   /**
-   * The crawl an owner may attach to.
+   * The crawl an owner may attach to. Its production caller arrives with stage 3's job owner,
+   * so meanwhile the Crawl seam above is what puts a test double in the slot.
    *
    * @return the crawl in the slot while it has not ended, else null
    */

--- a/app/src/test/java/com/httrack/android/CrawlArgvGoldenTest.java
+++ b/app/src/test/java/com/httrack/android/CrawlArgvGoldenTest.java
@@ -1,0 +1,107 @@
+package com.httrack.android;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+
+/** The argv the app hands the engine, recorded literally before the crawl core moved out of
+ *  HTTrackActivity.Runner, so the move can be proved to have changed nothing. The literals were
+ *  produced by the run at e62ccdb; masterArgv() is Runner.runInternal()'s own assembly from that
+ *  commit. Once a production assembler exists, it answers the same bytes or this reds. */
+public class CrawlArgvGoldenTest {
+  private static final String ASSEMBLER = "com.httrack.android.CrawlArgv";
+  private static final String TARGET = "/storage/emulated/0/HTTrack/demo";
+
+  /** Every option the golden map sets, and its value. */
+  private static final int IDS[] = { R.id.fieldProjectName, R.id.fieldWebsiteURLs,
+      R.id.radioAction, R.id.editMaxDepth, R.id.editMaxExtDepth, R.id.editNumberOfConnections,
+      R.id.checkPersistentConnections, R.id.checkUseCacheForUpdates, R.id.editRules,
+      R.id.checkDosNames, R.id.editBrowserIdentity, R.id.editAcceptLanguage };
+  private static final String VALUES[] = { "demo", "http://example.com/ http://example.org/", "1",
+      "3", "1", "4", "0", "0", "+*.png -*.zip", "1", "Mozilla/5.0 (probe)", "fr,en,*" };
+
+  /** What buildCommandline() returned for that map on master. */
+  private static final String OPTIONS[] = { "-iC2", "http://example.com/", "http://example.org/",
+      "+*.png", "-*.zip", "-r3", "-%e1", "-A25000", "-c4", "-%k0", "-%P", "-F",
+      "Mozilla/5.0 (probe)", "-%F",
+      "<!-- Mirrored from {url} by HTTrack Website Copier/3.x [XR&CO], {date} -->", "-%l",
+      "fr,en,*", "-u1", "-s2", "-%s", "-%u", "-%f", "-C0", "-D", "-a", "-K0", "-H0", "-N0", "-L0",
+      "-p3" };
+
+  /** The whole argv with IPv6 available, so no family is forced. */
+  private static final String ARGV_IPV6[] = full("httrack", "-O", TARGET);
+
+  /** The whole argv without IPv6, where -@i4 precedes the target. */
+  private static final String ARGV_IPV4[] = full("httrack", "-@i4", "-O", TARGET);
+
+  private static String[] full(final String... prelude) {
+    final List<String> argv = new ArrayList<String>(Arrays.asList(prelude));
+    argv.addAll(Arrays.asList(OPTIONS));
+    return argv.toArray(new String[] {});
+  }
+
+  /** The shipped mapper, driven through the shipped assembly path. */
+  private static List<String> options() {
+    final OptionsMapper mapper = new OptionsMapper();
+    for (int i = 0; i < IDS.length; i++) {
+      mapper.setMap(IDS[i], VALUES[i]);
+    }
+    return mapper.buildCommandline();
+  }
+
+  /** Runner.runInternal()'s assembly as master wrote it, kept here as the thing to match. */
+  private static String[] masterArgv(final boolean ipv6Enabled, final String target,
+      final List<String> options) {
+    final List<String> args = new ArrayList<String>();
+    args.add("httrack");
+    if (!ipv6Enabled) {
+      args.add("-@i4");
+    }
+    args.add("-O");
+    args.add(target);
+    args.addAll(options);
+    return args.toArray(new String[] {});
+  }
+
+  @Test
+  public void theOptionsAreStillTheOnesMasterEmitted() {
+    assertEquals(Arrays.asList(OPTIONS), options());
+  }
+
+  @Test
+  public void masterAssembledTheseTwoArgvs() {
+    assertArrayEquals("with IPv6", ARGV_IPV6, masterArgv(true, TARGET, options()));
+    assertArrayEquals("without IPv6", ARGV_IPV4, masterArgv(false, TARGET, options()));
+  }
+
+  /** Absent on master, where the assembly is inline in Runner.runInternal(); present after the
+   *  extraction, where it must answer the same two arrays. */
+  @Test
+  public void theExtractedAssemblerAnswersTheSame() throws Exception {
+    final Class<?> assembler;
+    try {
+      assembler = Class.forName(ASSEMBLER);
+    } catch (final ClassNotFoundException notYet) {
+      System.out.println(ASSEMBLER + " does not exist yet; the assembly is still inline");
+      return;
+    }
+    final Method build;
+    try {
+      build = assembler.getDeclaredMethod("build", boolean.class, String.class, List.class);
+    } catch (final NoSuchMethodException missing) {
+      fail(ASSEMBLER + " has no build(boolean, String, List)");
+      return;
+    }
+    build.setAccessible(true);
+    assertArrayEquals("with IPv6", ARGV_IPV6, (String[]) build.invoke(null, true, TARGET,
+        options()));
+    assertArrayEquals("without IPv6", ARGV_IPV4, (String[]) build.invoke(null, false, TARGET,
+        options()));
+  }
+}

--- a/app/src/test/java/com/httrack/android/CrawlArgvTest.java
+++ b/app/src/test/java/com/httrack/android/CrawlArgvTest.java
@@ -1,0 +1,49 @@
+package com.httrack.android;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.Test;
+
+/** The engine reads the argv positionally: it counts URLs from the first argument that is not an
+ *  option, and -iC* only selects a resume while it precedes them. CrawlArgvGoldenTest holds the
+ *  whole line for a real option map; these pin the prelude on its own. */
+public class CrawlArgvTest {
+  private static final String TARGET = "/storage/emulated/0/HTTrack/demo";
+
+  @Test
+  public void theProgramNameComesFirstAndTheOptionsLast() {
+    assertArrayEquals(new String[] { "httrack", "-O", TARGET, "-iC1", "http://example.com/" },
+        CrawlArgv.build(true, TARGET, Arrays.asList("-iC1", "http://example.com/")));
+  }
+
+  /** -@i4 pins the engine to IPv4, so it must appear exactly when the device has no IPv6. */
+  @Test
+  public void theFamilyIsForcedOnlyWithoutIPv6() {
+    assertArrayEquals(new String[] { "httrack", "-@i4", "-O", TARGET },
+        CrawlArgv.build(false, TARGET, Collections.<String> emptyList()));
+    assertArrayEquals(new String[] { "httrack", "-O", TARGET },
+        CrawlArgv.build(true, TARGET, Collections.<String> emptyList()));
+  }
+
+  /** An option landing between -O and its path would be taken for the mirror directory. */
+  @Test
+  public void theTargetFollowsItsOwnOption() {
+    final String[] argv = CrawlArgv.build(false, TARGET, Arrays.asList("http://example.com/"));
+    assertArrayEquals(new String[] { "httrack", "-@i4", "-O", TARGET, "http://example.com/" },
+        argv);
+  }
+
+  /** The device answer has to reach the build, or every phone gets one family's argv. */
+  @Test
+  public void theRunAsksTheDeviceForItsAnswer() throws IOException {
+    final String source = TestSources.withoutCommentsAndStrings(
+        TestSources.javaSource("CrawlRun"));
+    assertTrue("the argv must be built from the device's own IPv6 answer and the run's target",
+        source.replaceAll("\\s+", " ").contains("CrawlArgv.build(HTTrackActivity.isIPv6Enabled(), "
+            + "target.getAbsolutePath(), options)"));
+  }
+}

--- a/app/src/test/java/com/httrack/android/CrawlMessagesTest.java
+++ b/app/src/test/java/com/httrack/android/CrawlMessagesTest.java
@@ -1,0 +1,81 @@
+package com.httrack.android;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+
+/** CrawlRun.Messages carries six strings of one type, so a swapped pair compiles and only shows
+ *  up as the wrong sentence on a phone. Each field is pinned to the resource that fills it and to
+ *  the parameter that assigns it. */
+public class CrawlMessagesTest {
+  /** Field, then the string resource the activity reads for it, in constructor order. */
+  private static final String PAIRS[][] = { { "creatingProject", "R.string.creating_project" },
+      { "startingMirror", "R.string.starting_mirror" },
+      { "selfContainedConflict", "R.string.self_contained_conflict" },
+      { "alreadyInProgress", "R.string.mirror_already_in_progress" },
+      { "engineFaulted", "R.string.engine_faulted" },
+      { "mirrorFinished", "R.string.mirror_finished" } };
+
+  private static String source(final String name) throws IOException {
+    return TestSources.withoutCommentsAndStrings(TestSources.javaSource(name));
+  }
+
+  /** Body of the method whose declaration starts with SIGNATURE, braces balanced. */
+  private static String body(final String source, final String signature) {
+    final int at = source.indexOf(signature);
+    assertTrue("no " + signature.trim(), at != -1);
+    return TestSources.balancedBlock(source, at + signature.length());
+  }
+
+  /** ARGUMENTS split at top-level commas, whitespace collapsed. */
+  private static List<String> split(final String arguments) {
+    final List<String> parts = new ArrayList<String>();
+    int depth = 0;
+    int from = 0;
+    for (int i = 0; i < arguments.length(); i++) {
+      final char c = arguments.charAt(i);
+      if (c == '(') {
+        depth++;
+      } else if (c == ')') {
+        depth--;
+      } else if (c == ',' && depth == 0) {
+        parts.add(arguments.substring(from, i).replaceAll("\\s+", " ").trim());
+        from = i + 1;
+      }
+    }
+    parts.add(arguments.substring(from).replaceAll("\\s+", " ").trim());
+    return parts;
+  }
+
+  @Test
+  public void theActivityFillsEachFieldFromItsOwnString() throws IOException {
+    final List<String> read = split(TestSources.arguments(
+        body(source("HTTrackActivity"), "CrawlRun.Messages crawlMessages()"),
+        "new CrawlRun.Messages"));
+    assertEquals("the message count changed", PAIRS.length, read.size());
+    for (int i = 0; i < PAIRS.length; i++) {
+      assertEquals(PAIRS[i][0] + " is filled from the wrong string",
+          "requireString(" + PAIRS[i][1] + ")", read.get(i));
+    }
+  }
+
+  @Test
+  public void theConstructorAssignsEachParameterToItsOwnField() throws IOException {
+    // Sliced first, or setMessages() elsewhere in the file could pass for the constructor.
+    final String declared = body(source("CrawlRun"), "static final class Messages");
+    final List<String> parameters = split(TestSources.arguments(declared, "Messages"));
+    assertEquals("the constructor takes a different number of messages", PAIRS.length,
+        parameters.size());
+    final String assignments = body(declared, "Messages(final String creatingProject");
+    for (int i = 0; i < PAIRS.length; i++) {
+      assertEquals("parameter " + i + " is not the one the activity fills there",
+          "final String " + PAIRS[i][0], parameters.get(i));
+      assertTrue(PAIRS[i][0] + " is assigned from another parameter", assignments
+          .contains("this." + PAIRS[i][0] + " = " + PAIRS[i][0] + ";"));
+    }
+  }
+}

--- a/app/src/test/java/com/httrack/android/CrawlOwnershipTest.java
+++ b/app/src/test/java/com/httrack/android/CrawlOwnershipTest.java
@@ -61,7 +61,7 @@ public class CrawlOwnershipTest {
         "advance(MirrorSession.Event.END); MirrorSession.get().end(this);",
         body(crawl, "void end()").replaceAll("\\s+", " ").trim());
     assertTrue("a slot freed by name would free another owner's crawl",
-        body(source("MirrorSession"), "synchronized void end(final CrawlRun crawl)")
+        body(source("MirrorSession"), "synchronized void end(final Crawl crawl)")
             .contains("if (run == crawl)"));
   }
 

--- a/app/src/test/java/com/httrack/android/CrawlOwnershipTest.java
+++ b/app/src/test/java/com/httrack/android/CrawlOwnershipTest.java
@@ -1,0 +1,83 @@
+package com.httrack.android;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import org.junit.Test;
+
+/** The crawl has to survive the window that started it, so nothing of the activity may creep back
+ *  into it. A job owner reaches the same run through the same seams. */
+public class CrawlOwnershipTest {
+  private static String source(final String name) throws IOException {
+    return TestSources.withoutCommentsAndStrings(TestSources.javaSource(name));
+  }
+
+  /** Body of the method whose declaration starts with SIGNATURE, braces balanced. */
+  private static String body(final String source, final String signature) {
+    final int at = source.indexOf(signature);
+    assertTrue("no " + signature.trim(), at != -1);
+    return TestSources.balancedBlock(source, at + signature.length());
+  }
+
+  /** An activity held here is one the crawl outlives, and a fragment one it cannot reach. */
+  @Test
+  public void theCrawlKnowsNoWindow() throws IOException {
+    final String crawl = source("CrawlRun");
+    for (final String android : new String[] { "HTTrackActivity parent", "Fragment", "AsyncTask",
+        "Activity ", "findViewById", "runOnUiThread" }) {
+      assertFalse("the crawl core still names " + android, crawl.contains(android));
+    }
+    // Statics only: an instance call would need the activity the core refuses to hold.
+    assertFalse("the crawl core holds an activity instance",
+        crawl.matches("(?s).*\\bHTTrackActivity\\s+\\w+\\s*[;=)].*"));
+  }
+
+  /** The claim set was a static on the activity, which a headless owner can neither see nor
+   *  serve; one holder is what makes the two owners refuse each other. */
+  @Test
+  public void oneSetHoldsEveryClaim() throws IOException {
+    assertTrue("the claims must live with the session",
+        source("MirrorSession").contains("HashSet<String> claims"));
+    for (final File file : TestSources.javaSources()) {
+      if (file.getName().equals("MirrorSession.java")) {
+        continue;
+      }
+      final String other = TestSources.withoutCommentsAndStrings(TestSources.read(file));
+      assertFalse(file.getName() + " keeps a claim set of its own",
+          other.contains("runningInstances") || other.contains("markRunningInstance"));
+    }
+  }
+
+  /** A crawl that never reaches the slot is one a second owner starts over. */
+  @Test
+  public void theRunTakesTheSlotAndGivesItBack() throws IOException {
+    final String crawl = source("CrawlRun");
+    assertTrue("the run must put itself in the slot",
+        body(crawl, "void runMirror()").contains("session.begin(this)"));
+    assertEquals("the slot must be freed by the run that took it",
+        "advance(MirrorSession.Event.END); MirrorSession.get().end(this);",
+        body(crawl, "void end()").replaceAll("\\s+", " ").trim());
+    assertTrue("a slot freed by name would free another owner's crawl",
+        body(source("MirrorSession"), "synchronized void end(final CrawlRun crawl)")
+            .contains("if (run == crawl)"));
+  }
+
+  /** Every decision the run makes has to be in the core, or one owner behaves unlike the other. */
+  @Test
+  public void theFragmentAdapterDecidesNothing() throws IOException {
+    final String activity = source("HTTrackActivity");
+    final int at = activity.indexOf("protected static class Runner extends AsyncTask");
+    assertTrue("no Runner class", at != -1);
+    final String runner = TestSources.balancedBlock(activity, at);
+    for (final String engineWork : new String[] { "engine.", "tryLock", "ProfileLockPolicy",
+        "MirrorOutcome", "CrawlArgv", "setInterruptedProfile" }) {
+      assertFalse("the adapter still does the crawl's own work: " + engineWork,
+          runner.contains(engineWork));
+    }
+    assertTrue("the adapter must drive the core rather than a copy of it",
+        runner.contains("crawl.runMirror()"));
+  }
+}

--- a/app/src/test/java/com/httrack/android/DetachedRunTest.java
+++ b/app/src/test/java/com/httrack/android/DetachedRunTest.java
@@ -29,37 +29,29 @@ public class DetachedRunTest {
     return TestSources.balancedBlock(source, at);
   }
 
+  /** Body of the Runner adapter, which is where the crawl reaches a window. */
+  private static String runnerBody() throws IOException {
+    final String source = source();
+    return TestSources.balancedBlock(source,
+        TestSources.indexOf(source, "protected static class Runner extends AsyncTask"));
+  }
+
   /** Arguments of the call to NAME, whitespace collapsed. */
   private static String callArguments(final String source, final String name) {
     return TestSources.arguments(source, name).trim().replaceAll("\\s+", " ");
   }
 
-  /** Brace depth of TEXT within BODY; zero means a statement of the method itself. */
-  private static int depthOf(final String body, final String text) {
-    final int at = body.indexOf(text);
-    assertTrue(text + " is gone", at != -1);
-    int depth = 0;
-    for (int i = 0; i < at; i++) {
-      if (body.charAt(i) == '{') {
-        depth++;
-      } else if (body.charAt(i) == '}') {
-        depth--;
-      }
-    }
-    return depth;
-  }
-
   @Test
   public void aDetachedRunStillStampsItsVerdict() throws Exception {
     final String body = crawlBody(
-        "private void setInterruptedProfile(final boolean interrupted)");
+        "private synchronized void setInterruptedProfile(final boolean interrupted)");
     assertTrue("a stop before the capture stamps the owner's directory rather than nothing",
         body.replaceAll("\\s+", " ")
             .contains("final File target = runTarget != null ? runTarget : owner.target();"));
     assertEquals("the stamp may reach the owner for the fallback target and nothing else", 1,
         TestSources.occurrences(body, "owner."));
     assertEquals("gated on a parent, a detached run stamps nothing", 0,
-        depthOf(body, "HTTrackActivity.setInterruptedProfile(target, interrupted)"));
+        TestSources.depthOf(body, "HTTrackActivity.setInterruptedProfile(target, interrupted)"));
   }
 
   @Test
@@ -96,6 +88,32 @@ public class DetachedRunTest {
     }
   }
 
+  /** Formatting a refresh takes long enough for the window to go; the post has to look again. */
+  @Test
+  public void aDetachWhileARefreshIsLaidOutDropsIt() throws Exception {
+    final String runner = runnerBody();
+    final String post = TestSources.balancedBlock(runner,
+        TestSources.indexOf(runner,
+            "private synchronized void postProgressLines(final String[] lines)"));
+    assertEquals("the parent read once at the top is the one that may have gone",
+        "if (parent != null) { parent.setProgressLines(lines); }",
+        post.replaceAll("\\s+", " ").trim());
+
+    final String stats = TestSources.balancedBlock(runner,
+        TestSources.indexOf(runner, "public void onStats(final HTTrackStats stats)"));
+    assertEquals("a refresh may only reach the pane through the re-checking post", 0,
+        TestSources.occurrences(stats, "setProgressLines("));
+    assertEquals("a second post would be one the check does not cover", 1,
+        TestSources.occurrences(stats, "postProgressLines("));
+    assertEquals("what was laid out is what gets posted", "attached.formatProgress(stats)",
+        callArguments(stats, "postProgressLines"));
+
+    assertEquals("laying out and posting must stay apart, or there is nothing to drop", 0,
+        TestSources.occurrences(TestSources.balancedBlock(source(),
+            TestSources.indexOf(source(), "String[] formatProgress(final HTTrackStats stats)")),
+            "setProgressLines("));
+  }
+
   @Test
   public void aNotificationTapReachesTheLiveActivity() throws Exception {
     final String source = source();
@@ -106,7 +124,7 @@ public class DetachedRunTest {
         "extras != null, hasLiveRunner()",
         callArguments(body, "ResumePolicy.restoresIntentState"));
     assertTrue("a refused bundle must not become the intent restartActivity() reopens",
-        depthOf(body, "setIntent(intent)") > 0);
+        TestSources.depthOf(body, "setIntent(intent)") > 0);
     assertTrue("without singleTop the tap builds a second activity",
         TestSources.read(TestSources.mainFile("AndroidManifest.xml"))
             .contains("android:launchMode=\"singleTop\""));

--- a/app/src/test/java/com/httrack/android/DetachedRunTest.java
+++ b/app/src/test/java/com/httrack/android/DetachedRunTest.java
@@ -17,17 +17,16 @@ public class DetachedRunTest {
         .withoutCommentsAndStrings(TestSources.javaSource("HTTrackActivity"));
   }
 
-  /** Body of the runner's own METHOD declaration; RunnerFragment declares some of the same
-   *  names, and it is the trunk rather than the thing that acts. */
-  private static String runnerBody(final String declaration) throws IOException {
-    final String source = source();
-    final int runner = source
-        .indexOf("protected static class Runner extends AsyncTask");
-    assertTrue("no Runner class", runner != -1);
-    final String body = TestSources.balancedBlock(source, runner);
-    final int at = body.indexOf(declaration);
+  private static String crawlSource() throws IOException {
+    return TestSources.withoutCommentsAndStrings(TestSources.javaSource("CrawlRun"));
+  }
+
+  /** Body of the crawl core's METHOD declaration. */
+  private static String crawlBody(final String declaration) throws IOException {
+    final String source = crawlSource();
+    final int at = source.indexOf(declaration);
     assertTrue(declaration + " is gone", at != -1);
-    return TestSources.balancedBlock(body, at);
+    return TestSources.balancedBlock(source, at);
   }
 
   /** Arguments of the call to NAME, whitespace collapsed. */
@@ -52,31 +51,31 @@ public class DetachedRunTest {
 
   @Test
   public void aDetachedRunStillStampsItsVerdict() throws Exception {
-    final String body = runnerBody(
-        "private synchronized void setInterruptedProfile(final boolean interrupted)");
-    assertTrue("a stop before the capture stamps the activity's directory rather than nothing",
-        body.replaceAll("\\s+", " ").contains("final File target = runTarget != null "
-            + "? runTarget : parent != null ? parent.getTargetFile() : null;"));
-    assertFalse("a marker write through the activity cannot happen once detached",
-        body.contains("parent.setInterruptedProfile"));
+    final String body = crawlBody(
+        "private void setInterruptedProfile(final boolean interrupted)");
+    assertTrue("a stop before the capture stamps the owner's directory rather than nothing",
+        body.replaceAll("\\s+", " ")
+            .contains("final File target = runTarget != null ? runTarget : owner.target();"));
+    assertEquals("the stamp may reach the owner for the fallback target and nothing else", 1,
+        TestSources.occurrences(body, "owner."));
     assertEquals("gated on a parent, a detached run stamps nothing", 0,
         depthOf(body, "HTTrackActivity.setInterruptedProfile(target, interrupted)"));
   }
 
   @Test
   public void aLateStopDoesNotOverwriteTheVerdict() throws Exception {
-    final String body = runnerBody("public boolean stopMirror(final boolean force)");
+    final String body = crawlBody("boolean stopMirror(final boolean force)");
     assertEquals("ended alone is set after the top index, leaving a window",
-        "ended, verdictRecorded",
+        "isEnded(), verdictRecorded",
         callArguments(body, "ResumePolicy.stopWritesMarker"));
     assertTrue("the verdict has to be latched where it is computed",
-        TestSources.between(source(), "pendingWork = leavesPendingWork",
+        TestSources.between(crawlSource(), "pendingWork = HTTrackActivity.leavesPendingWork",
             "MirrorOutcome.Verdict verdict").contains("verdictRecorded = true"));
   }
 
   @Test
   public void theTopIndexIsBuiltRatherThanQueued() throws Exception {
-    final String body = runnerBody("private void buildTopIndex()");
+    final String body = crawlBody("private void buildTopIndex()");
     assertFalse("a queued build waits for an activity that adds nothing to it",
         body.contains("pendingParentActions"));
     assertEquals("the two paths are same-typed, so a swap compiles",
@@ -89,7 +88,7 @@ public class DetachedRunTest {
   /** Everything above reads what the run captured, so the capture has to precede the engine. */
   @Test
   public void theRunCapturesWhatItsFinishPathNeeds() throws Exception {
-    final String body = TestSources.between(source(), "protected void runInternal()",
+    final String body = TestSources.between(crawlSource(), "void runMirror()",
         "engine.main(cargs)");
     for (final String field : new String[] { "runTarget =", "runProjectRoot =",
         "runResources =" }) {

--- a/app/src/test/java/com/httrack/android/EngineAbortReportedTest.java
+++ b/app/src/test/java/com/httrack/android/EngineAbortReportedTest.java
@@ -29,7 +29,7 @@ public class EngineAbortReportedTest {
   /** Both inputs must reach the choice; the return code alone cannot see either. */
   @Test
   public void theFinishedPaneWeighsBothTheStopAndTheEnginesVerdict() throws Exception {
-    final String call = TestSources.arguments(TestSources.javaSource("HTTrackActivity"),
+    final String call = TestSources.arguments(TestSources.javaSource("CrawlRun"),
         "MirrorOutcome.decide");
     assertEquals("the exit code must reach the choice", "code", call.split(",")[0].trim());
     assertEquals("the pane must weigh the same stop the resume offer does", "stop",
@@ -55,12 +55,12 @@ public class EngineAbortReportedTest {
   /** MirrorOutcomeTest owns the text and the link; only the folder the link points at is here. */
   @Test
   public void theFolderIsOfferedExactlyWhenTheVerdictSaysSo() throws Exception {
-    final String body = TestSources.between(TestSources.javaSource("HTTrackActivity"),
-        "protected void runInternal()", "// Build top index");
+    final String body = TestSources.between(TestSources.javaSource("CrawlRun"),
+        "void runMirror()", "// Build top index");
     assertEquals("the mirror folder must be offered once, and only under the verdict", 1,
         body.split("mirrorFolder = target", -1).length - 1);
     assertTrue("the folder must hang off the verdict's own answer",
-        body.contains("if (verdict.showsFolderLink()) {\n          mirrorFolder = target;"));
+        body.contains("if (verdict.showsFolderLink()) {\n        mirrorFolder = target;"));
     // A second verdict, or a second assignment, would answer over the one decide() handed back.
     assertTrue("the verdict must not be replaceable",
         body.contains("final MirrorOutcome.Verdict verdict = MirrorOutcome.decide("));
@@ -73,7 +73,7 @@ public class EngineAbortReportedTest {
   /** Transposing the two branches is invisible to the enum, so each is pinned to its source. */
   @Test
   public void theStopSourceNamesWhoAskedForIt() throws Exception {
-    final String assigned = TestSources.between(TestSources.javaSource("HTTrackActivity"),
+    final String assigned = TestSources.between(TestSources.javaSource("CrawlRun"),
         "final MirrorOutcome.Stop stop", ";");
     assertTrue("the user's own tap must be the USER stop",
         assigned.matches("(?s).*interrupted\\s*\\?\\s*MirrorOutcome\\.Stop\\.USER.*"));

--- a/app/src/test/java/com/httrack/android/FinishedMessageTest.java
+++ b/app/src/test/java/com/httrack/android/FinishedMessageTest.java
@@ -22,6 +22,11 @@ public class FinishedMessageTest {
     return TestSources.javaSource("HTTrackActivity");
   }
 
+  /** The crawl core, which is where the finish message is concatenated. */
+  private static String crawlSource() throws IOException {
+    return TestSources.javaSource("CrawlRun");
+  }
+
   /** Source with every whitespace run flattened, so a match ignores wrapping. */
   private static String flattened(final String source) {
     return source.replaceAll("\\s+", " ");
@@ -30,10 +35,9 @@ public class FinishedMessageTest {
   /** Each statement writing the finish message, up to its semicolon. Scoped to the crawl runner:
    *  another local named message elsewhere goes to a Toast, which renders no HTML. */
   private static List<String> messageStatements(final String source) {
-    final int from = source.indexOf("protected void runInternal()");
-    final int to = source.indexOf("displayFinishedPanel(displayMessage, errorsCount, mirrorFolder)");
-    assertTrue("runInternal no longer bounded by its displayFinishedPanel call",
-        from != -1 && to > from);
+    final int from = source.indexOf("void runMirror()");
+    final int to = source.indexOf("owner.onFinished(displayMessage, errorsCount, mirrorFolder)");
+    assertTrue("runMirror no longer bounded by its onFinished call", from != -1 && to > from);
     final List<String> statements = new ArrayList<String>();
     final Matcher m = Pattern.compile("(?m)^\\s*message\\s*\\+?=")
         .matcher(source.substring(from, to));
@@ -53,7 +57,7 @@ public class FinishedMessageTest {
   @Test
   public void everyPathReachingTheMessageIsEscaped() throws Exception {
     boolean anyPath = false;
-    for (final String statement : messageStatements(source())) {
+    for (final String statement : messageStatements(crawlSource())) {
       final Matcher m = PATH_ACCESSOR.matcher(statement);
       while (m.find()) {
         anyPath = true;
@@ -67,7 +71,7 @@ public class FinishedMessageTest {
   /** An unclosed anchor makes Html.fromHtml run the link to the end of the message. */
   @Test
   public void theMirrorPathIsWrappedInAClosedHref() throws Exception {
-    final String statement = mirrorPathStatement(source());
+    final String statement = mirrorPathStatement(crawlSource());
     assertTrue(statement, statement.contains("<a href="));
     assertTrue(statement, statement.contains("MIRROR_FOLDER_HREF"));
     assertTrue(statement, statement.contains("</a>"));

--- a/app/src/test/java/com/httrack/android/InterruptedLockTest.java
+++ b/app/src/test/java/com/httrack/android/InterruptedLockTest.java
@@ -89,15 +89,12 @@ public class InterruptedLockTest {
     assertFalse("a stale marker survived a clean run", reopensOnContinue(false, 0));
   }
 
-  /** Runner.stopMirror needs a live AsyncTask, so the guard is pinned in the source instead. */
+  /** CrawlRun.stopMirror needs a live engine, so the guard is pinned in the source instead. */
   private static String stopMirrorBody() throws IOException {
-    final String source = TestSources.javaSource("HTTrackActivity");
-    // The last declaration is the runner's; the first is RunnerFragment's trunk to it.
-    final int from = source.lastIndexOf("public boolean stopMirror(final boolean force) {");
-    assertTrue("Runner.stopMirror is gone", from != -1);
-    final int to = source.indexOf("\n    }\n", from);
-    assertTrue("Runner.stopMirror is not closed where expected", to > from);
-    return source.substring(from, to);
+    final String source = TestSources.javaSource("CrawlRun");
+    final int from = source.indexOf("boolean stopMirror(final boolean force) {");
+    assertTrue("CrawlRun.stopMirror is gone", from != -1);
+    return TestSources.balancedBlock(source, from);
   }
 
   @Test
@@ -116,17 +113,16 @@ public class InterruptedLockTest {
   @Test
   public void aStopAfterTheCrawlEndedIsIgnored() throws Exception {
     assertTrue("the finished pane's own stopMirror() would mark every project resumable",
-        stopMirrorBody().contains("ResumePolicy.stopWritesMarker(ended,"));
+        stopMirrorBody().contains("ResumePolicy.stopWritesMarker(isEnded(),"));
   }
 
   /** The verdict belongs to the run, so it is written where the run ends. */
   @Test
   public void theCrawlStampsItsOwnOutcome() throws Exception {
-    final String source = TestSources.javaSource("HTTrackActivity");
-    final int from = source.indexOf("protected void runInternal()");
-    final int to = source.indexOf("displayFinishedPanel(displayMessage, errorsCount,");
-    assertTrue("runInternal no longer bounded by its displayFinishedPanel call",
-        from != -1 && to > from);
+    final String source = TestSources.javaSource("CrawlRun");
+    final int from = source.indexOf("void runMirror()");
+    final int to = source.indexOf("owner.onFinished(displayMessage, errorsCount,");
+    assertTrue("runMirror no longer bounded by its onFinished call", from != -1 && to > from);
     final String body = source.substring(from, to);
     final String resumeOffer = TestSources.arguments(body, "leavesPendingWork");
     assertTrue("the resume offer must read the run's own stop verdict",
@@ -135,10 +131,13 @@ public class InterruptedLockTest {
         resumeOffer.contains("interrupted"));
     assertFalse("the resume offer must not narrow to one kind of stop",
         resumeOffer.contains("=="));
-    assertTrue("runInternal must write the verdict before the finished pane opens",
+    assertTrue("runMirror must write the verdict before the finished pane opens",
         body.contains("setInterruptedProfile(pendingWork)"));
-    assertTrue("ended must be set before the finished pane asks for a stop",
-        body.contains("ended = true"));
+    assertTrue("the crawl must read as ended before the finished pane asks for a stop",
+        body.contains("\n      end();"));
+    assertTrue("end() is what makes isEnded() true", TestSources
+        .balancedBlock(source, source.indexOf("void end() {"))
+        .contains("advance(MirrorSession.Event.END)"));
   }
 
   /* The predicate below only ever sees what wasStopped() reports, so the engine's

--- a/app/src/test/java/com/httrack/android/MirrorSessionTest.java
+++ b/app/src/test/java/com/httrack/android/MirrorSessionTest.java
@@ -1,0 +1,111 @@
+package com.httrack.android;
+
+import static com.httrack.android.MirrorSession.Event.END;
+import static com.httrack.android.MirrorSession.Event.ENGINE_STARTED;
+import static com.httrack.android.MirrorSession.Event.START;
+import static com.httrack.android.MirrorSession.Event.STOP;
+import static com.httrack.android.MirrorSession.State.ENDED;
+import static com.httrack.android.MirrorSession.State.NONE;
+import static com.httrack.android.MirrorSession.State.RUNNING;
+import static com.httrack.android.MirrorSession.State.STARTING;
+import static com.httrack.android.MirrorSession.State.STOPPING;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import org.junit.Test;
+
+/** The crawl state the owners read, and the profile claims that used to be a static set on the
+ *  activity. Every answer below is written out rather than computed, so the table cannot agree
+ *  with a change to the expression it checks. */
+public class MirrorSessionTest {
+  /** Every cell of next(), state by event. */
+  @Test
+  public void theWholeTableIsWrittenOut() {
+    assertEquals("NONE/START", STARTING, MirrorSession.next(NONE, START));
+    assertEquals("NONE/ENGINE_STARTED", NONE, MirrorSession.next(NONE, ENGINE_STARTED));
+    assertEquals("NONE/STOP", STOPPING, MirrorSession.next(NONE, STOP));
+    assertEquals("NONE/END", ENDED, MirrorSession.next(NONE, END));
+
+    assertEquals("STARTING/START", STARTING, MirrorSession.next(STARTING, START));
+    assertEquals("STARTING/ENGINE_STARTED", RUNNING, MirrorSession.next(STARTING, ENGINE_STARTED));
+    assertEquals("STARTING/STOP", STOPPING, MirrorSession.next(STARTING, STOP));
+    assertEquals("STARTING/END", ENDED, MirrorSession.next(STARTING, END));
+
+    assertEquals("RUNNING/START", RUNNING, MirrorSession.next(RUNNING, START));
+    assertEquals("RUNNING/ENGINE_STARTED", RUNNING, MirrorSession.next(RUNNING, ENGINE_STARTED));
+    assertEquals("RUNNING/STOP", STOPPING, MirrorSession.next(RUNNING, STOP));
+    assertEquals("RUNNING/END", ENDED, MirrorSession.next(RUNNING, END));
+
+    assertEquals("STOPPING/START", STOPPING, MirrorSession.next(STOPPING, START));
+    assertEquals("STOPPING/ENGINE_STARTED", STOPPING,
+        MirrorSession.next(STOPPING, ENGINE_STARTED));
+    assertEquals("STOPPING/STOP", STOPPING, MirrorSession.next(STOPPING, STOP));
+    assertEquals("STOPPING/END", ENDED, MirrorSession.next(STOPPING, END));
+
+    assertEquals("ENDED/START", ENDED, MirrorSession.next(ENDED, START));
+    assertEquals("ENDED/ENGINE_STARTED", ENDED, MirrorSession.next(ENDED, ENGINE_STARTED));
+    assertEquals("ENDED/STOP", ENDED, MirrorSession.next(ENDED, STOP));
+    assertEquals("ENDED/END", ENDED, MirrorSession.next(ENDED, END));
+  }
+
+  /** A run that ends and then restarts would report a live crawl no owner is driving. */
+  @Test
+  public void nothingLeavesTheEndedState() {
+    for (final MirrorSession.Event event : MirrorSession.Event.values()) {
+      assertEquals(event.name(), ENDED, MirrorSession.next(ENDED, event));
+    }
+  }
+
+  /** The whole point of the claim: a second run on one project is refused, a first is not. */
+  @Test
+  public void oneProfileIsClaimedOnce() {
+    final MirrorSession session = MirrorSession.get();
+    final File profile = new File("/tmp/httrack-test/one/hts-cache/winprofile.ini");
+    final File other = new File("/tmp/httrack-test/two/hts-cache/winprofile.ini");
+    assertTrue("a free profile must be claimable", session.claim(profile));
+    assertFalse("a claimed profile must refuse the second run", session.claim(profile));
+    assertTrue("another project is not the same claim", session.claim(other));
+    session.release(profile);
+    assertTrue("a released profile is claimable again", session.claim(profile));
+    session.release(profile);
+    session.release(other);
+  }
+
+  /** Releasing must name one profile: a release that emptied the set would free the live run. */
+  @Test
+  public void aReleaseLeavesEveryOtherClaimAlone() {
+    final MirrorSession session = MirrorSession.get();
+    final File mine = new File("/tmp/httrack-test/mine/hts-cache/winprofile.ini");
+    final File theirs = new File("/tmp/httrack-test/theirs/hts-cache/winprofile.ini");
+    assertTrue(session.claim(mine));
+    assertTrue(session.claim(theirs));
+    session.release(mine);
+    assertFalse("the other run's claim went with it", session.claim(theirs));
+    session.release(theirs);
+  }
+
+  /** CrawlRun builds an HTTrackLib, whose constructor is native, so the slot is read in the
+   *  source instead. An ended crawl left in the slot is one a second owner would attach to. */
+  @Test
+  public void theSlotOnlyOffersALiveCrawl() throws IOException {
+    final String source = TestSources.withoutCommentsAndStrings(
+        TestSources.javaSource("MirrorSession"));
+    assertEquals("an ended crawl must not read as one to attach to",
+        "return run != null && run.state() != State.ENDED ? run : null;",
+        block(source, "synchronized CrawlRun live()"));
+    assertEquals("an empty slot must have no state of its own",
+        "return run != null ? run.state() : State.NONE;",
+        block(source, "synchronized State state()"));
+  }
+
+  /** Body of the method whose declaration starts with SIGNATURE, whitespace collapsed. */
+  private static String block(final String source, final String signature) {
+    final int at = source.indexOf(signature);
+    assertTrue("no " + signature, at != -1);
+    return TestSources.balancedBlock(source, at + signature.length())
+        .replaceAll("\\s+", " ").trim();
+  }
+}

--- a/app/src/test/java/com/httrack/android/MirrorSessionTest.java
+++ b/app/src/test/java/com/httrack/android/MirrorSessionTest.java
@@ -11,6 +11,8 @@ import static com.httrack.android.MirrorSession.State.STARTING;
 import static com.httrack.android.MirrorSession.State.STOPPING;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
@@ -21,6 +23,16 @@ import org.junit.Test;
  *  activity. Every answer below is written out rather than computed, so the table cannot agree
  *  with a change to the expression it checks. */
 public class MirrorSessionTest {
+  /** A crawl the session can hold, so the slot is exercised rather than read as source. */
+  private static final class FakeCrawl implements MirrorSession.Crawl {
+    private MirrorSession.State state = STARTING;
+
+    @Override
+    public MirrorSession.State state() {
+      return state;
+    }
+  }
+
   /** Every cell of next(), state by event. */
   @Test
   public void theWholeTableIsWrittenOut() {
@@ -59,19 +71,62 @@ public class MirrorSessionTest {
     }
   }
 
+  /** The table above is a pure function, so only these calls tie it to a crawl that runs. */
+  @Test
+  public void everyStateChangeSitsInTheRun() throws IOException {
+    final String crawl = TestSources
+        .withoutCommentsAndStrings(TestSources.javaSource("CrawlRun"));
+
+    final String run = body(crawl, "void runMirror()");
+    assertEquals("the run moves the state twice and nowhere else", 2,
+        TestSources.occurrences(run, "advance("));
+    assertTrue("a crawl reaching the slot as NONE is one nothing reads as started",
+        TestSources.indexOf(run, "advance(MirrorSession.Event.START);") < TestSources
+            .indexOf(run, "session.begin(this);"));
+    assertEquals("a START inside a branch leaves the other branch at NONE", 0,
+        TestSources.depthOf(run, "advance(MirrorSession.Event.START);"));
+    assertTrue("the state has to say RUNNING while the engine is in fact running",
+        TestSources.indexOf(run, "advance(MirrorSession.Event.ENGINE_STARTED);") < TestSources
+            .indexOf(run, "engine.main(cargs)"));
+    assertEquals("the engine call lives in the try, so its event belongs at that depth", 1,
+        TestSources.depthOf(run, "advance(MirrorSession.Event.ENGINE_STARTED);"));
+
+    final String stop = body(crawl, "boolean stopMirror(final boolean force)");
+    assertEquals("one STOP, and the state is what a second owner would read", 1,
+        TestSources.occurrences(stop, "advance("));
+    assertTrue("a STOP recorded after the engine returns races the run's own end",
+        TestSources.indexOf(stop, "advance(MirrorSession.Event.STOP);") < TestSources
+            .indexOf(stop, "engine.stop(force)"));
+    assertEquals("gated on force, a soft stop would leave the state saying RUNNING", 0,
+        TestSources.depthOf(stop, "advance(MirrorSession.Event.STOP);"));
+
+    final String end = body(crawl, "void end()");
+    assertEquals("one END, or the slot is freed by a crawl that never reached ENDED", 1,
+        TestSources.occurrences(end, "advance("));
+    assertTrue("a crawl freed before it says ENDED is one live() still offers",
+        TestSources.indexOf(end, "advance(MirrorSession.Event.END);") < TestSources
+            .indexOf(end, "MirrorSession.get().end(this);"));
+    assertEquals("an END inside a branch leaves the crawl reading as live", 0,
+        TestSources.depthOf(end, "advance(MirrorSession.Event.END);"));
+  }
+
   /** The whole point of the claim: a second run on one project is refused, a first is not. */
   @Test
   public void oneProfileIsClaimedOnce() {
     final MirrorSession session = MirrorSession.get();
     final File profile = new File("/tmp/httrack-test/one/hts-cache/winprofile.ini");
     final File other = new File("/tmp/httrack-test/two/hts-cache/winprofile.ini");
-    assertTrue("a free profile must be claimable", session.claim(profile));
-    assertFalse("a claimed profile must refuse the second run", session.claim(profile));
-    assertTrue("another project is not the same claim", session.claim(other));
-    session.release(profile);
-    assertTrue("a released profile is claimable again", session.claim(profile));
-    session.release(profile);
-    session.release(other);
+    try {
+      assertTrue("a free profile must be claimable", session.claim(profile));
+      assertFalse("a claimed profile must refuse the second run", session.claim(profile));
+      assertTrue("another project is not the same claim", session.claim(other));
+      session.release(profile);
+      assertTrue("a released profile is claimable again", session.claim(profile));
+    } finally {
+      // The session is process-wide, so a failing assertion must not leave a claim behind.
+      session.release(profile);
+      session.release(other);
+    }
   }
 
   /** Releasing must name one profile: a release that emptied the set would free the live run. */
@@ -80,32 +135,55 @@ public class MirrorSessionTest {
     final MirrorSession session = MirrorSession.get();
     final File mine = new File("/tmp/httrack-test/mine/hts-cache/winprofile.ini");
     final File theirs = new File("/tmp/httrack-test/theirs/hts-cache/winprofile.ini");
-    assertTrue(session.claim(mine));
-    assertTrue(session.claim(theirs));
-    session.release(mine);
-    assertFalse("the other run's claim went with it", session.claim(theirs));
-    session.release(theirs);
+    try {
+      assertTrue(session.claim(mine));
+      assertTrue(session.claim(theirs));
+      session.release(mine);
+      assertFalse("the other run's claim went with it", session.claim(theirs));
+    } finally {
+      session.release(mine);
+      session.release(theirs);
+    }
   }
 
-  /** CrawlRun builds an HTTrackLib, whose constructor is native, so the slot is read in the
-   *  source instead. An ended crawl left in the slot is one a second owner would attach to. */
+  /** An ended crawl left in the slot is one a second owner would attach to. */
   @Test
-  public void theSlotOnlyOffersALiveCrawl() throws IOException {
-    final String source = TestSources.withoutCommentsAndStrings(
-        TestSources.javaSource("MirrorSession"));
-    assertEquals("an ended crawl must not read as one to attach to",
-        "return run != null && run.state() != State.ENDED ? run : null;",
-        block(source, "synchronized CrawlRun live()"));
-    assertEquals("an empty slot must have no state of its own",
-        "return run != null ? run.state() : State.NONE;",
-        block(source, "synchronized State state()"));
+  public void theSlotOnlyOffersALiveCrawl() {
+    final MirrorSession session = MirrorSession.get();
+    final FakeCrawl crawl = new FakeCrawl();
+    try {
+      assertNull("the slot starts empty", session.live());
+      session.begin(crawl);
+      assertSame("a started crawl is what an owner attaches to", crawl, session.live());
+      crawl.state = ENDED;
+      assertNull("an ended crawl is no longer one to attach to", session.live());
+    } finally {
+      session.end(crawl);
+    }
+    assertNull("the slot must come back empty", session.live());
   }
 
-  /** Body of the method whose declaration starts with SIGNATURE, whitespace collapsed. */
-  private static String block(final String source, final String signature) {
-    final int at = source.indexOf(signature);
-    assertTrue("no " + signature, at != -1);
-    return TestSources.balancedBlock(source, at + signature.length())
-        .replaceAll("\\s+", " ").trim();
+  /** A slot freed by whoever ends first would drop the crawl that holds it. */
+  @Test
+  public void onlyTheCrawlInTheSlotMayEmptyIt() {
+    final MirrorSession session = MirrorSession.get();
+    final FakeCrawl first = new FakeCrawl();
+    final FakeCrawl second = new FakeCrawl();
+    try {
+      session.begin(first);
+      session.begin(second);
+      session.end(first);
+      assertSame("the earlier crawl's end took the later one's slot", second, session.live());
+    } finally {
+      session.end(first);
+      session.end(second);
+    }
+    assertNull("both ends leave the slot empty", session.live());
+  }
+
+  /** Body of the method whose declaration starts with SIGNATURE. */
+  private static String body(final String source, final String signature) {
+    return TestSources.balancedBlock(source,
+        TestSources.indexOf(source, signature) + signature.length());
   }
 }

--- a/app/src/test/java/com/httrack/android/NativeFaultLatchTest.java
+++ b/app/src/test/java/com/httrack/android/NativeFaultLatchTest.java
@@ -153,10 +153,9 @@ public class NativeFaultLatchTest {
 
   @Test
   public void aFaultedEngineIsNeverAskedForAnotherMirror() throws IOException {
-    final String source = TestSources.javaSource("HTTrackActivity");
-    final String run = TestSources.between(source, "protected void runInternal()",
-        "final int code = engine.main(cargs)");
-    assertTrue("runInternal must refuse before it starts the engine",
+    final String run = TestSources.between(TestSources.javaSource("CrawlRun"),
+        "void runMirror()", "final int code = engine.main(cargs)");
+    assertTrue("runMirror must refuse before it starts the engine",
         run.contains("HTTrackLib.hasFaulted()"));
   }
 

--- a/app/src/test/java/com/httrack/android/SecondCrawlTest.java
+++ b/app/src/test/java/com/httrack/android/SecondCrawlTest.java
@@ -17,7 +17,7 @@ import org.junit.Test;
  *  feeds it, pinning whole argument lists so a dropped or swapped refusal reds. */
 public class SecondCrawlTest {
   private static final String POLICY = "ProfileLockPolicy.alreadyInProgress";
-  private static final String RUN = "protected void runInternal()";
+  private static final String RUN = "void runMirror()";
 
   /** HTTrackActivity with comments and string literals blanked, so a commented-out call cannot
    *  pass for one and a brace in a literal is not counted. */
@@ -32,13 +32,19 @@ public class SecondCrawlTest {
     return TestSources.balancedBlock(source, at + signature.length());
   }
 
-  /** Body of the runner's own METHOD; RunnerFragment declares some of the same names, and it is
-   *  the trunk rather than the thing that acts. */
-  private static String runnerBody(final String signature) throws IOException {
-    final String source = activity();
-    final int runner = source.indexOf("protected static class Runner extends AsyncTask");
-    assertTrue("no Runner class", runner != -1);
-    return body(TestSources.balancedBlock(source, runner), signature);
+  /** The crawl core, blanked the same way. */
+  private static String crawl() throws IOException {
+    return TestSources.withoutCommentsAndStrings(TestSources.javaSource("CrawlRun"));
+  }
+
+  /** The session holding the profile claims, blanked the same way. */
+  private static String session() throws IOException {
+    return TestSources.withoutCommentsAndStrings(TestSources.javaSource("MirrorSession"));
+  }
+
+  /** Body of the crawl core's METHOD. */
+  private static String crawlBody(final String signature) throws IOException {
+    return body(crawl(), signature);
   }
 
   /** Block following the first TEXT inside BODY. An absent TEXT would otherwise read as offset
@@ -107,7 +113,7 @@ public class SecondCrawlTest {
 
   @Test
   public void theSameJvmOverlapIsCaughtByItsOwnType() throws IOException {
-    final String run = runnerBody(RUN);
+    final String run = crawlBody(RUN);
     // OverlappingFileLockException is an IllegalStateException, so only its own name keeps it
     // out of the catch(Throwable) that reports a crash.
     assertTrue("tryLock must run inside a try of its own",
@@ -123,7 +129,7 @@ public class SecondCrawlTest {
   public void allThreeRefusalsReachThePolicy() throws IOException {
     // Naming the call is not enough: any of the three folded to a constant would pass that.
     assertEquals(Arrays.asList("!profileMarked", "lock == null", "lockOverlapped"),
-        split(TestSources.arguments(runnerBody(RUN), POLICY)));
+        split(TestSources.arguments(crawlBody(RUN), POLICY)));
     int mentions = 0;
     for (final File file : TestSources.javaSources()) {
       mentions += TestSources.occurrences(
@@ -135,7 +141,7 @@ public class SecondCrawlTest {
 
   @Test
   public void theRefusalStopsTheRunBeforeTheEngine() throws IOException {
-    final String run = runnerBody(RUN);
+    final String run = crawlBody(RUN);
     assertEquals("the check must be a statement of the run, not a branch of something else", 1,
         depthOf(run, POLICY));
     assertInOrder("the overlap has to be known before the verdict", run,
@@ -148,12 +154,12 @@ public class SecondCrawlTest {
 
   @Test
   public void theUserIsToldInTheirOwnLanguage() throws IOException {
-    assertTrue("the message must be the cached resource", runnerBody(RUN)
-        .contains("throw new IOException(string_already_in_progress)"));
-    assertEquals("the string is read once, from the parent, like every other message",
-        Arrays.asList("R.string.mirror_already_in_progress"),
-        split(TestSources.arguments(runnerBody("public synchronized void setParent("),
-            "string_already_in_progress = getParentString")));
+    assertTrue("the message must be the one the owner handed the crawl", crawlBody(RUN)
+        .contains("throw new IOException(messages.alreadyInProgress)"));
+    // CrawlMessagesTest pins which resource fills that field; only its presence is read here.
+    assertTrue("no crawl message is built from mirror_already_in_progress",
+        body(activity(), "CrawlRun.Messages crawlMessages()")
+            .contains("requireString(R.string.mirror_already_in_progress)"));
     // The raw source, since withoutCommentsAndStrings blanks the literal this looks for.
     assertFalse("an English literal cannot be translated",
         TestSources.javaSource("HTTrackActivity").contains("already in progress\""));
@@ -166,23 +172,25 @@ public class SecondCrawlTest {
   public void onlyTheRunThatClaimedTheProfileReleasesIt() throws IOException {
     // A refused second run releasing the claim is what lets a third attempt reach tryLock.
     assertEquals("the claim is a yes or no, so nothing else may end the run here",
-        "return runningInstances.add(profile.getAbsolutePath());",
-        flat(body(activity(),
-            "protected static synchronized boolean markRunningInstance(final File profile)")));
-    final String run = runnerBody(RUN);
+        "return claims.add(profile.getAbsolutePath());",
+        flat(body(session(), "synchronized boolean claim(final File profile)")));
+    assertEquals("a release that took the path apart could give back another project's claim",
+        "claims.remove(profile.getAbsolutePath());",
+        flat(body(session(), "synchronized void release(final File profile)")));
+    final String run = crawlBody(RUN);
     assertTrue("the claim has to be recorded",
-        run.contains("profileMarked = markRunningInstance(profile)"));
-    assertEquals("an ungated second clear releases the live run's claim just the same", 1,
-        TestSources.occurrences(run, "clearRunningInstance("));
-    assertEquals("clearing on a refused run releases the live run's claim",
-        "clearRunningInstance(profile);",
+        run.contains("profileMarked = session.claim(profile)"));
+    assertEquals("an ungated second release gives back the live run's claim just the same", 1,
+        TestSources.occurrences(run, "session.release("));
+    assertEquals("releasing on a refused run gives back the live run's claim",
+        "session.release(profile);",
         flat(blockAfter(releases(run), "if (profileMarked)")));
   }
 
   @Test
   public void aRefusedRunLeavesNoOpenHandle() throws IOException {
     // A refusal now reaches tryLock, so the close can no longer hang off holding the lock.
-    final String run = runnerBody(RUN);
+    final String run = crawlBody(RUN);
     assertEquals("the handle must be closed whatever the lock did",
         "try { outLock.close(); } catch (IOException io) { }",
         flat(blockAfter(releases(run), "if (outLock != null)")));

--- a/app/src/test/java/com/httrack/android/TestSources.java
+++ b/app/src/test/java/com/httrack/android/TestSources.java
@@ -179,6 +179,29 @@ final class TestSources {
     return new String(out);
   }
 
+  /** Offset of TEXT in SOURCE; a missing pin throws rather than reading as -1. */
+  static int indexOf(final String source, final String text) {
+    final int at = source.indexOf(text);
+    if (at == -1) {
+      throw new IllegalStateException("no " + text);
+    }
+    return at;
+  }
+
+  /** Brace depth of TEXT within BODY; zero means a statement of the block itself. */
+  static int depthOf(final String body, final String text) {
+    final int at = indexOf(body, text);
+    int depth = 0;
+    for (int i = 0; i < at; i++) {
+      if (body.charAt(i) == '{') {
+        depth++;
+      } else if (body.charAt(i) == '}') {
+        depth--;
+      }
+    }
+    return depth;
+  }
+
   static int occurrences(final String source, final String text) {
     int count = 0;
     for (int at = source.indexOf(text); at != -1; at = source.indexOf(text,


### PR DESCRIPTION
`Runner` owned everything. The argv build, the lock, the engine call, the verdict, the stats HTML and the resume marker all sat in one `AsyncTask` inside the activity. A job cannot drive that, so phase 3 had nowhere to start.

The run moves into `CrawlRun`, which any owner drives through a small interface. `MirrorSession` holds the process-wide slot and the profile claims, with a pure `next(state, event)`. `CrawlArgv` builds the command line. `Runner` keeps only attach and trunk duties, and the stats HTML moves to the activity.

Nothing user-visible changes, which is why the proof matters. `CrawlArgvGoldenTest` landed in the first commit. It froze the whole argv for twelve options and both IPv6 polarities, and it passes byte-identical after the move, unedited. A differential probe shows eleven of its twelve entries change that output, so it discriminates.

Stage 1's source guards moved to the code's new home, and fourteen mutants each turned a test red.

411 tests pass, up from 390.

Part of #74, phase 3 stage 2 of 5.